### PR TITLE
Change memberAPI to remove auth requirement for nova integration

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -105,9 +105,9 @@ router.post('/logout', (req, res) => {
 router.get('/allRoles', getAllRoles);
 
 // Members
-router.get('/allMembers', async (req, res) => {
-  const handled = await allMembers(req, res);
-  res.status(handled!.status).json(handled);
+router.get('/allMembers', async (_, res) => {
+  const handled = await allMembers();
+  res.status(handled.status).json(handled);
 });
 router.get('/getMember/:email', async (req, res) => {
   const handled = await getMember(req, res);

--- a/backend/src/memberAPI.ts
+++ b/backend/src/memberAPI.ts
@@ -6,18 +6,9 @@ import { PermissionsManager } from './permissions';
 import { Member } from './DataTypes';
 import { ErrorResponse, MemberResponse, AllMembersResponse } from './APITypes';
 
-export const allMembers = async (
-  req: Request,
-  res: Response
-): Promise<AllMembersResponse | ErrorResponse | undefined> => {
-  if (checkLoggedIn(req, res)) {
-    const result = await MembersDao.getAllMembers();
-    return {
-      status: 200,
-      members: result.members
-    };
-  }
-  return undefined;
+export const allMembers = async (): Promise<AllMembersResponse> => {
+  const result = await MembersDao.getAllMembers();
+  return { status: 200, members: result.members };
 };
 
 export const setMember = async (


### PR DESCRIPTION
### Summary <!-- Required -->

In our meeting, we decide to make this API public to help nova integration. This API is readonly, and the info it exposed will be on the public team website anyways, so it won't introduce any security vulnerability.

### Test Plan <!-- Required -->

Check you can visit the public API url in deploy preview. (sad the instance still hasn't secret set, so the endpoint fails)