### PR TITLE
Derive NetID and role description from email and role

### DIFF
--- a/frontend/src/API/MembersAPI.ts
+++ b/frontend/src/API/MembersAPI.ts
@@ -9,6 +9,24 @@ type MemberResponseObj = {
   error?: string;
 };
 
+export type Role =
+  | 'lead'
+  | 'admin'
+  | 'tpm'
+  | 'pm'
+  | 'developer'
+  | 'designer'
+  | 'business';
+
+export type RoleDescription =
+  | 'Lead'
+  | 'Admin'
+  | 'Technical PM'
+  | 'Product Manager'
+  | 'Developer'
+  | 'Designer'
+  | 'Business Analyst';
+
 export type Member = {
   email: string;
   netid: string;
@@ -25,8 +43,8 @@ export type Member = {
   about: string;
   subteam: string;
   otherSubteams: string[] | null;
-  role: string;
-  roleDescription: string;
+  role: Role;
+  roleDescription: RoleDescription;
 };
 
 export class MembersAPI {
@@ -76,8 +94,8 @@ export class MembersAPI {
     }).then((res) => res.data);
   }
 
-  public static deleteMember(member: Member): Promise<MemberResponseObj> {
-    return APIWrapper.delete(`${backendURL}/deleteMember/${member.email}`, {
+  public static deleteMember(memberEmail: string): Promise<MemberResponseObj> {
+    return APIWrapper.delete(`${backendURL}/deleteMember/${memberEmail}`, {
       withCredentials: true
     }).then((res) => res.data);
   }

--- a/frontend/src/API/RolesAPI.ts
+++ b/frontend/src/API/RolesAPI.ts
@@ -2,9 +2,10 @@ import APICache from '../Cache/Cache';
 import { backendURL } from '../environment';
 import APIWrapper from './APIWrapper';
 import Emitters from '../EventEmitter/constant-emitters';
+import { Role } from './MembersAPI';
 
 export default class RolesAPI {
-  public static getAllRoles(): Promise<string[]> {
+  public static getAllRoles(): Promise<Role[]> {
     const funcName = 'getAllRoles';
     if (APICache.has(funcName)) {
       return Promise.resolve(APICache.retrieve(funcName));
@@ -21,7 +22,7 @@ export default class RolesAPI {
         });
         return [];
       }
-      let roles = val.roles as string[];
+      let roles = val.roles as Role[];
       roles = roles.sort((a, b) => (a < b ? -1 : 1));
       APICache.cache(funcName, roles);
       return roles;

--- a/frontend/src/User/UserProfile/UserProfile.tsx
+++ b/frontend/src/User/UserProfile/UserProfile.tsx
@@ -1,8 +1,14 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { Form, TextArea } from 'semantic-ui-react';
 import { UserContext } from '../../UserProvider/UserProvider';
-import { Member, MembersAPI } from '../../API/MembersAPI';
+import {
+  Member,
+  MembersAPI,
+  Role,
+  RoleDescription
+} from '../../API/MembersAPI';
 import Emitters from '../../EventEmitter/constant-emitters';
+import { getNetIDFromEmail, getRoleDescriptionFromRoleID } from '../../utils';
 
 const UserProfile: React.FC = () => {
   const userEmail = useContext(UserContext).user?.email;
@@ -15,7 +21,7 @@ const UserProfile: React.FC = () => {
   const [email, setEmail] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-  const [role, setRole] = useState('');
+  const [role, setRole] = useState('' as Role);
   const [graduation, setGraduation] = useState('');
   const [major, setMajor] = useState('');
   const [doubleMajor, setDoubleMajor] = useState('');
@@ -86,12 +92,12 @@ const UserProfile: React.FC = () => {
 
     if (isValid) {
       const updatedUser: Member = {
-        netid: '',
+        netid: getNetIDFromEmail(email),
         email,
         firstName,
         lastName,
         role,
-        roleDescription: '',
+        roleDescription: getRoleDescriptionFromRoleID(role),
         graduation,
         major,
         doubleMajor: isFilledOut(doubleMajor) ? doubleMajor : null,

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,24 @@
+import { Role, RoleDescription } from './API/MembersAPI';
+
+export const getNetIDFromEmail = (email: string): string => email.split('@')[0];
+
+export const getRoleDescriptionFromRoleID = (role: Role): RoleDescription => {
+  switch (role) {
+    case 'lead':
+      return 'Lead';
+    case 'admin':
+      return 'Admin';
+    case 'tpm':
+      return 'Technical PM';
+    case 'pm':
+      return 'Product Manager';
+    case 'developer':
+      return 'Developer';
+    case 'designer':
+      return 'Designer';
+    case 'business':
+      return 'Business Analyst';
+    default:
+      throw new Error();
+  }
+};


### PR DESCRIPTION
### Summary <!-- Required -->

Unbreak saving user on the frontend by deriving netid and role description from existing fields. In the future, we probably shouldn't store them at all, since we can always easily derive them.

### Test Plan <!-- Required -->

A screenshot showing that a setMember request sent by frontend. Here, the role description and netid is correct.
<img width="1680" alt="Screen Shot 2021-03-08 at 13 41 05" src="https://user-images.githubusercontent.com/4290500/110366471-52b18900-8014-11eb-9b7b-496d640e0ea6.png">
