### PR TITLE
only edit name if user has correct permissions

### DIFF
--- a/frontend/src/User/UserProfile/UserProfile.test.tsx
+++ b/frontend/src/User/UserProfile/UserProfile.test.tsx
@@ -6,8 +6,6 @@ import UserProfile from './UserProfile';
 describe('<UserProfile />', () => {
   test('labels', () => {
     render(<UserProfile />);
-    expect(screen.getByText('First name')).toBeInTheDocument();
-    expect(screen.getByText('Last name')).toBeInTheDocument();
     expect(screen.getByText('Graduation')).toBeInTheDocument();
     expect(screen.getByText('Major')).toBeInTheDocument();
     expect(screen.getByText('Double Major')).toBeInTheDocument();

--- a/frontend/src/User/UserProfile/UserProfile.tsx
+++ b/frontend/src/User/UserProfile/UserProfile.tsx
@@ -114,24 +114,16 @@ const UserProfile: React.FC = () => {
     }
   };
 
-  return role === 'admin' || role === 'lead' ? (
-    <Form
-      style={{
-        width: '80%',
-        alignSelf: 'center',
-        margin: 'auto',
-        marginTop: '10vh'
-      }}
-    >
+  let name;
+  if (role === 'admin' || role === 'lead') {
+    name = (
       <Form.Group widths="equal">
         <Form.Input
           fluid
           label="First name"
           value={firstName}
           onChange={(event) => {
-            if (role === 'admin') {
-              setFirstName(event.target.value);
-            }
+            setFirstName(event.target.value);
           }}
           required
         />
@@ -140,87 +132,21 @@ const UserProfile: React.FC = () => {
           label="Last name"
           value={lastName}
           onChange={(event) => {
-            if (role === 'admin') {
-              setLastName(event.target.value);
-            }
+            setLastName(event.target.value);
           }}
           required
         />
       </Form.Group>
+    );
+  } else {
+    name = (
+      <h2 style={{ fontFamily: 'var(--mainFontFamily)', marginBottom: '2vh' }}>
+        {firstName} {lastName}
+      </h2>
+    );
+  }
 
-      <Form.Group widths="equal">
-        <Form.Input
-          fluid
-          label="Graduation"
-          value={graduation}
-          onChange={(event) => setGraduation(event.target.value)}
-          required
-        />
-        <Form.Input
-          fluid
-          label="Hometown"
-          value={hometown}
-          onChange={(event) => setHometown(event.target.value)}
-          required
-        />
-      </Form.Group>
-
-      <Form.Group widths="equal">
-        <Form.Input
-          fluid
-          label="Major"
-          value={major}
-          onChange={(event) => setMajor(event.target.value)}
-          required
-        />
-        <Form.Input
-          fluid
-          label="Double Major"
-          value={doubleMajor || ''}
-          onChange={(event) => setDoubleMajor(event.target.value)}
-        />
-        <Form.Input
-          fluid
-          label="Minor"
-          value={minor}
-          onChange={(event) => setMinor(event.target.value)}
-        />
-      </Form.Group>
-
-      <Form.Input
-        label="About"
-        name="about"
-        value={about}
-        control={TextArea}
-        onChange={(event) => setAbout(event.target.value)}
-        style={{ minHeight: '25vh' }}
-        required
-      />
-
-      <Form.Group widths="equal">
-        <Form.Input
-          fluid
-          label="Website"
-          value={website}
-          onChange={(event) => setWebsite(event.target.value)}
-        />
-        <Form.Input
-          fluid
-          label="LinkedIn"
-          value={linkedin}
-          onChange={(event) => setLinkedin(event.target.value)}
-        />
-        <Form.Input
-          fluid
-          label="GitHub"
-          value={github}
-          onChange={(event) => setGithub(event.target.value)}
-        />
-      </Form.Group>
-
-      <Form.Button onClick={saveProfileInfo}>Save</Form.Button>
-    </Form>
-  ) : (
+  return (
     <Form
       style={{
         width: '80%',
@@ -229,9 +155,7 @@ const UserProfile: React.FC = () => {
         marginTop: '10vh'
       }}
     >
-      <h2 style={{ fontFamily: 'var(--mainFontFamily)', marginBottom: '2vh' }}>
-        {firstName} {lastName}
-      </h2>
+      {name}
 
       <Form.Group widths="equal">
         <Form.Input

--- a/frontend/src/User/UserProfile/UserProfile.tsx
+++ b/frontend/src/User/UserProfile/UserProfile.tsx
@@ -114,7 +114,7 @@ const UserProfile: React.FC = () => {
     }
   };
 
-  return (
+  return role === 'admin' || role === 'lead' ? (
     <Form
       style={{
         width: '80%',
@@ -147,6 +147,91 @@ const UserProfile: React.FC = () => {
           required
         />
       </Form.Group>
+
+      <Form.Group widths="equal">
+        <Form.Input
+          fluid
+          label="Graduation"
+          value={graduation}
+          onChange={(event) => setGraduation(event.target.value)}
+          required
+        />
+        <Form.Input
+          fluid
+          label="Hometown"
+          value={hometown}
+          onChange={(event) => setHometown(event.target.value)}
+          required
+        />
+      </Form.Group>
+
+      <Form.Group widths="equal">
+        <Form.Input
+          fluid
+          label="Major"
+          value={major}
+          onChange={(event) => setMajor(event.target.value)}
+          required
+        />
+        <Form.Input
+          fluid
+          label="Double Major"
+          value={doubleMajor || ''}
+          onChange={(event) => setDoubleMajor(event.target.value)}
+        />
+        <Form.Input
+          fluid
+          label="Minor"
+          value={minor}
+          onChange={(event) => setMinor(event.target.value)}
+        />
+      </Form.Group>
+
+      <Form.Input
+        label="About"
+        name="about"
+        value={about}
+        control={TextArea}
+        onChange={(event) => setAbout(event.target.value)}
+        style={{ minHeight: '25vh' }}
+        required
+      />
+
+      <Form.Group widths="equal">
+        <Form.Input
+          fluid
+          label="Website"
+          value={website}
+          onChange={(event) => setWebsite(event.target.value)}
+        />
+        <Form.Input
+          fluid
+          label="LinkedIn"
+          value={linkedin}
+          onChange={(event) => setLinkedin(event.target.value)}
+        />
+        <Form.Input
+          fluid
+          label="GitHub"
+          value={github}
+          onChange={(event) => setGithub(event.target.value)}
+        />
+      </Form.Group>
+
+      <Form.Button onClick={saveProfileInfo}>Save</Form.Button>
+    </Form>
+  ) : (
+    <Form
+      style={{
+        width: '80%',
+        alignSelf: 'center',
+        margin: 'auto',
+        marginTop: '10vh'
+      }}
+    >
+      <h2 style={{ fontFamily: 'var(--mainFontFamily)', marginBottom: '2vh' }}>
+        {firstName} {lastName}
+      </h2>
 
       <Form.Group widths="equal">
         <Form.Input


### PR DESCRIPTION
### Summary

The user can now only edit their first and last name if they have the correct permissions ('admin' or 'lead').

- [x] fixed editing on user permissions
- [ ] fix error modal for when member info can't be changed


### Test Plan

<img width="1149" alt="admin_permissions" src="https://user-images.githubusercontent.com/49768384/111216958-64aea100-85ab-11eb-9054-18f789098c0b.png">
 Form for a user with 'admin' permissions.




<img width="1165" alt="developer_permissions" src="https://user-images.githubusercontent.com/49768384/111216989-6bd5af00-85ab-11eb-90e9-b19d3334b800.png">
Form for a user with 'developer' permissions.


### Notes 

- This has a bit of duplicated code, so if anyone has any suggestions on how to reduce that I would appreciate it!
- I also noticed that the error modal isn't working when a user with the wrong permissions tries to edit their information, so that needs to be addressed
