### PR TITLE
Update permissions and error messages for updateMember

### DIFF
--- a/backend/src/memberAPI.ts
+++ b/backend/src/memberAPI.ts
@@ -79,9 +79,20 @@ export const updateMember = async (
         error: "Couldn't edit member with undefined email!"
       };
     }
+    const member = await (
+      await db.doc(`members/${req.body!.email}`).get()
+    ).data();
+    if (!member) {
+      return {
+        status: 404,
+        error: `No member with email: ${req.body!.email}`
+      };
+    }
     if (
-      (req.body.role || req.body.first_name || req.body.last_name) &&
-      !canEdit
+      !canEdit &&
+      (req.body.role !== member.role ||
+        req.body.first_name !== member.first_name ||
+        req.body.last_name !== member.last_name)
     ) {
       return {
         status: 403,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request updates the backend function to fix the check for user permissions for updating member documents. Previously, there was an error where the user could not update their own information if their role was not `'admin'` or `'lead'`. 

The changes in this PR fixes that and also displays the appropriate error message in case the member's document is not in the Firebase.


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
- [x] Run to check if the users can change their own information if they are not admin or lead (checked locally)
- [x] Run to check if the users cannot change their first name, last name or the role if they are not admin or lead (checked locally)

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->


