### PR TITLE
Use firestore data converter for statically typed DB operations

### DIFF
--- a/backend/src/dao/MembersDao.ts
+++ b/backend/src/dao/MembersDao.ts
@@ -1,28 +1,25 @@
-import { db } from '../firebase';
+import { memberCollection } from '../firebase';
 
 export default class MembersDao {
   static async getAllMembers(): Promise<IdolMember[]> {
-    return db
-      .collection('members')
+    return memberCollection
       .get()
-      .then((vals) => vals.docs.map((doc) => doc.data()) as IdolMember[]);
+      .then((vals) => vals.docs.map((it) => it.data()));
   }
 
   static async getMember(email: string): Promise<IdolMember | undefined> {
-    return (await db.doc(`members/${email}`).get()).data() as
-      | IdolMember
-      | undefined;
+    return (await memberCollection.doc(email).get()).data();
   }
 
   static async deleteMember(email: string): Promise<void> {
-    await db.doc(`members/${email}`).delete();
+    await memberCollection.doc(email).delete();
   }
 
   static async setMember(
     email: string,
     member: IdolMember
   ): Promise<IdolMember> {
-    await db.doc(`members/${email}`).set(member);
+    await memberCollection.doc(email).set(member);
     return member;
   }
 
@@ -30,7 +27,7 @@ export default class MembersDao {
     email: string,
     member: IdolMember
   ): Promise<IdolMember> {
-    await db.doc(`members/${email}`).update(member);
+    await memberCollection.doc(email).update(member);
     return member;
   }
 }

--- a/backend/src/dao/TeamsDao.ts
+++ b/backend/src/dao/TeamsDao.ts
@@ -1,12 +1,12 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Team, DBTeam } from '../DataTypes';
 import { NotFoundError } from '../errors';
-import { db } from '../firebase';
+import { db, teamCollection } from '../firebase';
 import { materialize } from '../util';
 
 export default class TeamsDao {
   static async getAllTeams(): Promise<Team[]> {
-    const teamRefs = await db.collection('teams').get();
+    const teamRefs = await teamCollection.get();
     return Promise.all(
       teamRefs.docs.map((teamRef) => materialize(teamRef.data()))
     );
@@ -29,7 +29,7 @@ export default class TeamsDao {
         "Couldn't create team from members that don't exist!"
       );
     }
-    await db.doc(`teams/${teamRef.uuid}`).set(teamRef);
+    await teamCollection.doc(teamRef.uuid).set(teamRef);
     return { ...team, uuid: teamRef.uuid };
   }
 

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -1,4 +1,5 @@
 import admin from 'firebase-admin';
+import { DBTeam } from './DataTypes';
 
 require('dotenv').config();
 
@@ -25,3 +26,29 @@ export const app = admin.initializeApp({
 
 export const bucket = admin.storage().bucket();
 export const db = admin.firestore();
+
+export const memberCollection: admin.firestore.CollectionReference<IdolMember> = db
+  .collection('members')
+  .withConverter({
+    fromFirestore(snapshot): IdolMember {
+      return snapshot.data() as IdolMember;
+    },
+    toFirestore(userData: IdolMember) {
+      return userData;
+    }
+  });
+
+export const teamCollection: admin.firestore.CollectionReference<DBTeam> = db
+  .collection('teams')
+  .withConverter({
+    fromFirestore(snapshot): DBTeam {
+      return snapshot.data() as DBTeam;
+    },
+    toFirestore(userData: DBTeam) {
+      return userData;
+    }
+  });
+
+export const adminCollection: admin.firestore.CollectionReference = db.collection(
+  'admins'
+);

--- a/backend/src/permissions.ts
+++ b/backend/src/permissions.ts
@@ -1,4 +1,4 @@
-import { db } from './firebase';
+import { adminCollection } from './firebase';
 
 export const allRoles: readonly Role[] = [
   'lead',
@@ -10,21 +10,15 @@ export const allRoles: readonly Role[] = [
 
 export class PermissionsManager {
   static async canEditMembers(mem: IdolMember): Promise<boolean> {
-    if (mem.role === 'lead' || (await this.isAdmin(mem))) {
-      return true;
-    }
-    return false;
+    return mem.role === 'lead' || this.isAdmin(mem);
   }
 
   static async canEditTeams(mem: IdolMember): Promise<boolean> {
-    if (mem.role === 'lead' || (await this.isAdmin(mem))) {
-      return true;
-    }
-    return false;
+    return mem.role === 'lead' || this.isAdmin(mem);
   }
 
   public static async isAdmin(mem: IdolMember): Promise<boolean> {
-    const member = await (await db.doc(`admins/${mem.email}`).get()).data();
+    const member = (await adminCollection.doc(mem.email).get()).data();
     return member !== undefined;
   }
 }

--- a/backend/src/teamAPI.ts
+++ b/backend/src/teamAPI.ts
@@ -1,18 +1,23 @@
 import { Request } from 'express';
-import { db } from './firebase';
+import { teamCollection } from './firebase';
 import { PermissionsManager } from './permissions';
 import { Team } from './DataTypes';
+import MembersDao from './dao/MembersDao';
 import TeamsDao from './dao/TeamsDao';
-import { BadRequestError, NotFoundError, PermissionError } from './errors';
+import {
+  BadRequestError,
+  UnauthorizedError,
+  NotFoundError,
+  PermissionError
+} from './errors';
 
 export const allTeams = (): Promise<readonly Team[]> => TeamsDao.getAllTeams();
 
 export const setTeam = async (req: Request): Promise<Team> => {
   const teamBody = req.body as Team;
   const userEmail: string = req.session?.email as string;
-  const member = (
-    await db.doc(`members/${userEmail}`).get()
-  ).data() as IdolMember;
+  const member = await MembersDao.getMember(userEmail);
+  if (!member) throw new UnauthorizedError(`No user with email: ${userEmail}`);
   const canEdit = await PermissionsManager.canEditTeams(member);
   if (!canEdit) {
     throw new PermissionError(
@@ -31,10 +36,9 @@ export const deleteTeam = async (req: Request): Promise<Team> => {
     throw new BadRequestError("Couldn't delete team with undefined uuid!");
   }
   const userEmail: string = req.session?.email as string;
-  const member = (
-    await db.doc(`members/${userEmail}`).get()
-  ).data() as IdolMember;
-  const teamSnap = await db.doc(`teams/${teamBody.uuid}`).get();
+  const member = await MembersDao.getMember(userEmail);
+  if (!member) throw new UnauthorizedError(`No user with email: ${userEmail}`);
+  const teamSnap = await teamCollection.doc(teamBody.uuid).get();
   if (!teamSnap.exists) {
     throw new NotFoundError(`No team with uuid: ${teamBody.uuid}`);
   }

--- a/frontend/src/User/EditTeam/EditTeam.tsx
+++ b/frontend/src/User/EditTeam/EditTeam.tsx
@@ -224,7 +224,7 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         source={this.state.allMembers}
                         resultRenderer={(mem) => (
                           <Segment>
-                            <h4>{`${mem.first_name} ${mem.last_name}`}</h4>
+                            <h4>{`${mem.firstName} ${mem.lastName}`}</h4>
                             <Label>{mem.email}</Label>
                           </Segment>
                         )}
@@ -303,7 +303,7 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         source={this.state.allMembers}
                         resultRenderer={(mem) => (
                           <Segment>
-                            <h4>{`${mem.first_name} ${mem.last_name}`}</h4>
+                            <h4>{`${mem.firstName} ${mem.lastName}`}</h4>
                             <Label>{mem.email}</Label>
                           </Segment>
                         )}


### PR DESCRIPTION
### Summary <!-- Required -->

Using typescript with [`FirestoreDataConverter`](https://firebase.google.com/docs/reference/js/firebase.firestore.FirestoreDataConverter) gives all the database operations a more specific type instead of any type. This means that we won't accidentally write data that doesn't belong to a collection.

Here is a little demo showing how it can help to type check database operations:

<img width="1085" alt="Screen Shot 2021-03-26 at 11 09 50" src="https://user-images.githubusercontent.com/4290500/112652575-ed3b0600-8e23-11eb-9943-194dcb0a555c.png">


I replaced all the existing untyped calls to the database collection methods with the typed ones. This change reveals the hidden bug where we don't check member is `null` in team API and using `first_name` instead of `firstName` in member API.

### Test Plan <!-- Required -->

Start frontend and backend to ensure that every endpoint can still work.