### PR TITLE
[easy] Fix simple accessibility warning on website button

### DIFF
--- a/dti-website/src/components/DtiFooter.tsx
+++ b/dti-website/src/components/DtiFooter.tsx
@@ -46,14 +46,14 @@ export default function DtiFooter({
                   <div className="subfooter-text subfooter-text-red">
                     Sign up for our newsletter!
                   </div>
-                  <a className="button-wrapper">
+                  <div className="button-wrapper">
                     <button
                       onClick={() => setIsSubscribing(true)}
-                      className="subfooter-button subfooter-button-red"
+                      className=" subfooter-button subfooter-button-red"
                     >
                       Subscribe
                     </button>
-                  </a>
+                  </div>
                 </Col>
               </Row>
             </Col>


### PR DESCRIPTION
### Summary <!-- Required -->

According to accessibility standards, `a` tag must have `href`. In the existing code, we are mostly using `a` tag to achieve some styling effect, which is bad. This PR replaces it with `div` and everything still looks the same.

### Test Plan <!-- Required -->

No change in appearance

<img width="2386" alt="Screen Shot 2021-03-26 at 23 42 20" src="https://user-images.githubusercontent.com/4290500/112709136-0330e100-8e8d-11eb-8857-0a43450d53e5.png">