### PR TITLE
Update pull-from-idol.yml

### DIFF
--- a/.github/workflows/pull-from-idol.yml
+++ b/.github/workflows/pull-from-idol.yml
@@ -1,5 +1,7 @@
 name: Pull from IDOL
 on:
+  repository_dispatch:
+    types: pull-idol-changes
   schedule:
     # Run the script at 0AM in UTC every day, which is 7PM or 8PM in ET.
     - cron: '0 0 * * *'


### PR DESCRIPTION
### Summary <!-- Required -->

Made the pull from idol workflow triggered by a repo dispatch event, which idol will hook into in order to create the new PR. Then potentially another endpoint on idol could be used to approve/reject the PR, essentially choosing whether or not to publish the changes (since approving the PR immediately redeploys master).

### Test Plan <!-- Required -->

I have to put the workflow into action to test it, so I will test to see if the workflow is triggered once it is live.

### Breaking Changes

None
