### PR TITLE
Refactor frontend API calls to reduce boilerplate

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,13 +8,11 @@
   },
   "rules": {
     "camelcase": "off",
+    "no-alert": "off",
     "no-console": "warn",
     "no-shadow": "off",
-    "no-restricted-syntax": "warn",
     "no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "@typescript-eslint/camel-case": "off",
-    "import/prefer-default-export": "warn",
     "import/extensions": [
       "error",
       "ignorePackages",

--- a/frontend/src/API/APIWrapper.ts
+++ b/frontend/src/API/APIWrapper.ts
@@ -1,69 +1,50 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 import { auth } from '../firebase';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type APIProcessedResponse = { data: any };
 
 export default class APIWrapper {
   public static post(
     url: string,
-    body: unknown,
-    config?: AxiosRequestConfig | undefined
-  ): Promise<any> {
-    const responseProm = axios
-      .post(url, body, {
-        ...config,
-        withCredentials: true
-      })
-      .catch((err) => err)
+    body: unknown
+  ): Promise<APIProcessedResponse> {
+    return axios
+      .post(url, body, { withCredentials: true })
+      .catch((err: AxiosError) => err)
       .then((resOrErr) => this.responseMiddleware(resOrErr));
-    return responseProm;
   }
 
-  public static get(
-    url: string,
-    config?: AxiosRequestConfig | undefined
-  ): Promise<any> {
-    const responseProm = axios
-      .get(url, {
-        ...config,
-        withCredentials: true
-      })
-      .catch((err) => err)
+  public static get(url: string): Promise<APIProcessedResponse> {
+    return axios
+      .get(url, { withCredentials: true })
+      .catch((err: AxiosError) => err)
       .then((resOrErr) => this.responseMiddleware(resOrErr));
-    return responseProm;
   }
 
-  public static delete(
-    url: string,
-    config?: AxiosRequestConfig | undefined
-  ): Promise<any> {
-    const responseProm = axios
-      .delete(url, {
-        ...config,
-        withCredentials: true
-      })
-      .catch((err) => err)
+  public static delete(url: string): Promise<APIProcessedResponse> {
+    return axios
+      .delete(url, { withCredentials: true })
+      .catch((err: AxiosError) => err)
       .then((resOrErr) => this.responseMiddleware(resOrErr));
-    return responseProm;
   }
 
-  public static put(
-    url: string,
-    body: unknown,
-    config?: AxiosRequestConfig | undefined
-  ): Promise<any> {
-    const responseProm = axios
-      .put(url, body, { ...config })
-      .catch((err) => err)
+  public static put(url: string, body: unknown): Promise<APIProcessedResponse> {
+    return axios
+      .put(url, body, {})
+      .catch((err: AxiosError) => err)
       .then((resOrErr) => this.responseMiddleware(resOrErr));
-    return responseProm;
   }
 
-  private static responseMiddleware(resOrErr: any) {
-    if (resOrErr.name === 'Error' && resOrErr.response.status === 440) {
+  private static responseMiddleware(
+    resOrErr: AxiosResponse | AxiosError
+  ): APIProcessedResponse {
+    if (resOrErr instanceof Error && resOrErr.response?.status === 440) {
       auth.signOut();
       return { data: { error: 'Session expired! Log in again!' } };
     }
     // No default, return the response
-    if (resOrErr.name === 'Error') return resOrErr.response;
+    if (resOrErr instanceof Error) return resOrErr.response ?? { data: null };
     return resOrErr;
   }
 }

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -4,9 +4,9 @@ import HeadshotPlaceholder from '../static/images/headshot-placeholder.png';
 
 export default class ImagesAPI {
   public static getMemberImage(): Promise<string> {
-    const responseProm = APIWrapper.get(`${backendURL}/getMemberImage`, {
-      withCredentials: true
-    }).then((res) => res.data);
+    const responseProm = APIWrapper.get(`${backendURL}/getMemberImage`).then(
+      (res) => res.data
+    );
 
     return responseProm.then((val) => {
       if (val.error) {
@@ -17,9 +17,9 @@ export default class ImagesAPI {
   }
 
   private static getSignedURL(): Promise<string> {
-    const responseProm = APIWrapper.get(`${backendURL}/getImageSignedURL`, {
-      withCredentials: true
-    }).then((res) => res.data);
+    const responseProm = APIWrapper.get(`${backendURL}/getImageSignedURL`).then(
+      (res) => res.data
+    );
     return responseProm.then((val) => val.url);
   }
 

--- a/frontend/src/API/LoginAPI.ts
+++ b/frontend/src/API/LoginAPI.ts
@@ -11,24 +11,16 @@ export type LogoutResponse = {
 
 export class LoginAPI {
   public static login(authToken: string): Promise<LoginResponse> {
-    const responseProm = APIWrapper.post(
-      `${backendURL}/login`,
-      { auth_token: authToken },
-      {
-        withCredentials: true
-      }
-    ).then((res) => res.data as LoginResponse);
+    const responseProm = APIWrapper.post(`${backendURL}/login`, {
+      auth_token: authToken
+    }).then((res) => res.data as LoginResponse);
     return responseProm;
   }
 
   public static logout(): Promise<LogoutResponse> {
-    const responseProm = APIWrapper.post(
-      `${backendURL}/logout`,
-      {},
-      {
-        withCredentials: true
-      }
-    ).then((res) => res.data as LogoutResponse);
+    const responseProm = APIWrapper.post(`${backendURL}/logout`, {}).then(
+      (res) => res.data as LogoutResponse
+    );
     return responseProm;
   }
 }

--- a/frontend/src/API/MembersAPI.ts
+++ b/frontend/src/API/MembersAPI.ts
@@ -17,9 +17,9 @@ export class MembersAPI {
       return Promise.resolve(APICache.retrieve(funcName));
     }
 
-    const responseProm = APIWrapper.get(`${backendURL}/allMembers`, {
-      withCredentials: true
-    }).then((res) => res.data);
+    const responseProm = APIWrapper.get(`${backendURL}/allMembers`).then(
+      (res) => res.data
+    );
     return responseProm.then((val) => {
       if (val.error) {
         Emitters.generalError.emit({
@@ -36,9 +36,9 @@ export class MembersAPI {
   }
 
   public static getMember(email: string): Promise<Member> {
-    const responseProm = APIWrapper.get(`${backendURL}/getMember/${email}`, {
-      withCredentials: true
-    }).then((res) => res.data);
+    const responseProm = APIWrapper.get(
+      `${backendURL}/getMember/${email}`
+    ).then((res) => res.data);
     return responseProm.then((val) => {
       if (val.error) {
         Emitters.generalError.emit({
@@ -52,22 +52,22 @@ export class MembersAPI {
   }
 
   public static setMember(member: Member): Promise<MemberResponseObj> {
-    return APIWrapper.post(`${backendURL}/setMember`, member, {
-      withCredentials: true
-    }).then((res) => res.data);
+    return APIWrapper.post(`${backendURL}/setMember`, member).then(
+      (res) => res.data
+    );
   }
 
   public static deleteMember(
     memberEmail: string
   ): Promise<{ status: number; error?: string }> {
-    return APIWrapper.delete(`${backendURL}/deleteMember/${memberEmail}`, {
-      withCredentials: true
-    }).then((res) => res.data);
+    return APIWrapper.delete(`${backendURL}/deleteMember/${memberEmail}`).then(
+      (res) => res.data
+    );
   }
 
   public static updateMember(member: Member): Promise<MemberResponseObj> {
-    return APIWrapper.post(`${backendURL}/updateMember`, member, {
-      withCredentials: true
-    }).then((res) => res.data);
+    return APIWrapper.post(`${backendURL}/updateMember`, member).then(
+      (res) => res.data
+    );
   }
 }

--- a/frontend/src/API/RolesAPI.ts
+++ b/frontend/src/API/RolesAPI.ts
@@ -10,9 +10,9 @@ export default class RolesAPI {
       return Promise.resolve(APICache.retrieve(funcName));
     }
 
-    const responseProm = APIWrapper.get(`${backendURL}/allRoles`, {
-      withCredentials: true
-    }).then((res) => res.data);
+    const responseProm = APIWrapper.get(`${backendURL}/allRoles`).then(
+      (res) => res.data
+    );
     return responseProm.then((val) => {
       if (val.error) {
         Emitters.generalError.emit({

--- a/frontend/src/API/TeamsAPI.ts
+++ b/frontend/src/API/TeamsAPI.ts
@@ -23,9 +23,9 @@ export class TeamsAPI {
       return Promise.resolve(APICache.retrieve(funcName));
     }
 
-    const responseProm = APIWrapper.get(`${backendURL}/allTeams`, {
-      withCredentials: true
-    }).then((res) => res.data);
+    const responseProm = APIWrapper.get(`${backendURL}/allTeams`).then(
+      (res) => res.data
+    );
     return responseProm.then((val) => {
       if (val.error) {
         Emitters.generalError.emit({
@@ -42,14 +42,14 @@ export class TeamsAPI {
   }
 
   public static setTeam(team: Team): Promise<TeamResponseObj> {
-    return APIWrapper.post(`${backendURL}/setTeam`, team, {
-      withCredentials: true
-    }).then((res) => res.data);
+    return APIWrapper.post(`${backendURL}/setTeam`, team).then(
+      (res) => res.data
+    );
   }
 
   public static deleteTeam(team: Team): Promise<TeamResponseObj> {
-    return APIWrapper.post(`${backendURL}/deleteTeam`, team, {
-      withCredentials: true
-    }).then((res) => res.data);
+    return APIWrapper.post(`${backendURL}/deleteTeam`, team).then(
+      (res) => res.data
+    );
   }
 }

--- a/frontend/src/Admin/DTI-Site-Deployer/SiteDeployer.tsx
+++ b/frontend/src/Admin/DTI-Site-Deployer/SiteDeployer.tsx
@@ -24,7 +24,7 @@ const SiteDeployer: React.FC = () => {
   const [pullRequests, setPullRequests] = useState<{ body: string }[]>([]);
 
   const loadPullRequests = () => {
-    APIWrapper.get(`${backendURL}/getIDOLChangesPR`, {}).then((resp) => {
+    APIWrapper.get(`${backendURL}/getIDOLChangesPR`).then((resp) => {
       if (!resp.data.pr) {
         setPullRequests([]);
         setLoading(false);

--- a/frontend/src/User/UserProfile/UserProfile.tsx
+++ b/frontend/src/User/UserProfile/UserProfile.tsx
@@ -68,7 +68,6 @@ const UserProfile: React.FC = () => {
           contentMsg: val.error
         });
       } else {
-        // eslint-disable-next-line no-alert
         alert('Member information successfully updated!');
       }
     });

--- a/frontend/src/UserProvider/UserProvider.tsx
+++ b/frontend/src/UserProvider/UserProvider.tsx
@@ -30,7 +30,6 @@ class UserProvider extends Component<Record<string, unknown>, UserContextType> {
           if (!logoutResp.isLoggedIn) {
             this.setState({ user: userAuth });
           } else {
-            // eslint-disable-next-line no-alert
             alert("Couldn't log out!");
           }
         });


### PR DESCRIPTION
### Summary <!-- Required -->

- All the APIWrapper's config parameters are all about `withCredentials: true`, which is already set in APIWrapper. Therefore, there is no need to pass it again, so I removed the parameters.
- Strictified the types of APIWrapper return a little bit

As a result of this refactoring all the linter warnings are gone!

Close #27.

### Test Plan <!-- Required -->

Go into the app to ensure that things can load, which shows that the credentials are still being correctly passed.