### PR TITLE
Script to download all member images from Firebase Storage

### DIFF
--- a/backend/data/download-images.ts
+++ b/backend/data/download-images.ts
@@ -1,0 +1,23 @@
+import { bucket } from './firebase';
+
+const fs = require('fs-extra');
+
+const dirPath = 'backend/data/members/images/'
+if(!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath); 
+}
+else {
+    fs.emptyDirSync(dirPath);
+}
+
+bucket.getFiles().then(results => {
+    const files = results[0];
+    files.forEach(async file => {
+        const fileName = file.name.slice(file.name.indexOf('/') + 1)
+        if (fileName.length > 0) {
+            const filePath = dirPath + fileName;
+            if(fs.existsSync(filePath) === false) fs.ensureFile(filePath); 
+            bucket.file(file.name).download({destination:filePath});
+        }
+    });
+}).catch((err) => console.log("Error in getting files: ", err));

--- a/backend/data/download-images.ts
+++ b/backend/data/download-images.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
 import fetch from 'node-fetch';
-import { ProfileImage } from '../src/DataTypes';
-
 import fs from 'fs-extra';
+import { ProfileImage } from '../src/DataTypes';
 
 const dirPath = './data/members/images/';
 

--- a/backend/data/download-images.ts
+++ b/backend/data/download-images.ts
@@ -3,7 +3,7 @@
 import fetch from 'node-fetch';
 import { ProfileImage } from '../src/DataTypes';
 
-const fs = require('fs-extra');
+import fs from 'fs-extra';
 
 const dirPath = './data/members/images/';
 

--- a/backend/data/download-images.ts
+++ b/backend/data/download-images.ts
@@ -5,17 +5,17 @@ import { ProfileImage } from '../src/DataTypes';
 
 const fs = require('fs-extra');
 
-const dirPath = './data/members/images/'; 
+const dirPath = './data/members/images/';
 
 async function getMemberImages(): Promise<readonly ProfileImage[]> {
-  const { images } : { images: readonly ProfileImage[] } = await fetch(
+  const { images }: { images: readonly ProfileImage[] } = await fetch(
     'https://idol.cornelldti.org/.netlify/functions/api/allMemberImages'
   ).then((response) => response.json());
   return images;
 }
 
 async function downloadFile(image: ProfileImage) {
-  const {fileName} = image;
+  const { fileName } = image;
   const filePath = dirPath + fileName;
   const response = await fetch(image.url);
   const buffer = await response.buffer();
@@ -25,7 +25,9 @@ async function downloadFile(image: ProfileImage) {
 async function main(): Promise<void> {
   fs.emptyDirSync(dirPath);
   const memberImages = await getMemberImages();
-  memberImages.forEach((image) => {downloadFile(image)});
+  memberImages.forEach((image) => {
+    downloadFile(image);
+  });
 }
 
 main();

--- a/backend/data/download-images.ts
+++ b/backend/data/download-images.ts
@@ -2,22 +2,24 @@ import { bucket } from './firebase';
 
 const fs = require('fs-extra');
 
-const dirPath = 'backend/data/members/images/'
-if(!fs.existsSync(dirPath)) {
-    fs.mkdirSync(dirPath); 
-}
-else {
-    fs.emptyDirSync(dirPath);
+const dirPath = 'backend/data/members/images/';
+if (!fs.existsSync(dirPath)) {
+  fs.mkdirSync(dirPath);
+} else {
+  fs.emptyDirSync(dirPath);
 }
 
-bucket.getFiles().then(results => {
+bucket
+  .getFiles()
+  .then((results) => {
     const files = results[0];
-    files.forEach(async file => {
-        const fileName = file.name.slice(file.name.indexOf('/') + 1)
-        if (fileName.length > 0) {
-            const filePath = dirPath + fileName;
-            if(fs.existsSync(filePath) === false) fs.ensureFile(filePath); 
-            bucket.file(file.name).download({destination:filePath});
-        }
+    files.forEach(async (file) => {
+      const fileName = file.name.slice(file.name.indexOf('/') + 1);
+      if (fileName.length > 0) {
+        const filePath = dirPath + fileName;
+        if (fs.existsSync(filePath) === false) fs.ensureFile(filePath);
+        bucket.file(file.name).download({ destination: filePath });
+      }
     });
-}).catch((err) => console.log("Error in getting files: ", err));
+  })
+  .catch((err) => console.log('Error in getting files: ', err));

--- a/backend/data/firebase.ts
+++ b/backend/data/firebase.ts
@@ -19,9 +19,11 @@ const configureAccount = (sa) => {
 
 admin.initializeApp({
   credential: admin.credential.cert(configureAccount(serviceAccount)),
-  databaseURL: 'https://idol-b6c68.firebaseio.com'
+  databaseURL: 'https://idol-b6c68.firebaseio.com',
+  storageBucket: 'gs://idol-b6c68.appspot.com'
 });
 
 const db = admin.firestore();
+export const bucket = admin.storage().bucket();
 
 export default db;

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "start": "./node_modules/.bin/netlify-lambda serve build",
     "dev": "ts-node --transpile-only src/api.ts",
     "tsc": "tsc",
-    "build": "tsc"
+    "build": "tsc",
+    "download-images": "ts-node-script data/download-images.ts"
   },
   "license": "AGPL-3.0",
   "dependencies": {
@@ -18,6 +19,7 @@
     "@types/cors": "^2.8.7",
     "@types/express": "4.17.8",
     "@types/express-session": "1.17.0",
+    "@types/node-fetch": "^2.5.8",
     "@types/uuid": "^8.3.0",
     "body-parser": "^1.19.0",
     "common-types": "1.0.0",
@@ -27,6 +29,7 @@
     "express-session": "^1.17.1",
     "firebase-admin": "^9.2.0",
     "netlify-lambda": "^2.0.1",
+    "node-fetch": "^2.6.1",
     "serverless-http": "^2.5.0",
     "ts-node": "^9.0.0",
     "tsc": "^1.20150623.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.1",
     "firebase-admin": "^9.2.0",
+    "fs-extra": "^9.1.0",
     "netlify-lambda": "^2.0.1",
     "node-fetch": "^2.6.1",
     "serverless-http": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6962,7 +6962,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements a script `download_images.ts` to download all member images from the `images` bucket in IDOL's Firebase Storage and saves them with the same name (i.e. _netid.jpg_). It does not affect any existing functionality.


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
- [x] Run the script to ensure all images are downloaded.
![image](https://user-images.githubusercontent.com/55467524/112779351-8d578180-9014-11eb-9d7b-eb072690de0e.png)

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
<!-- Keep items that apply: -->
None
