### PR TITLE
Fix UI bug on DTI website on team page

### DIFF
--- a/dti-website/src/components/CircleProgressIndicator.tsx
+++ b/dti-website/src/components/CircleProgressIndicator.tsx
@@ -15,7 +15,6 @@ export default function CircleProgressIndicator({
     const currentInterval = intervalRef.current;
     if (currentInterval !== -1) {
       clearInterval(currentInterval);
-      intervalRef.current = -1;
     }
 
     intervalRef.current = setInterval(() => {
@@ -23,7 +22,6 @@ export default function CircleProgressIndicator({
 
       if (diff <= 0.005) {
         clearInterval(currentInterval as NodeJS.Timeout);
-        intervalRef.current = -1;
 
         setCurrentPercentage(percentage);
       } else if (currentPercentage < percentage) {
@@ -32,12 +30,6 @@ export default function CircleProgressIndicator({
         setCurrentPercentage((p) => p - Math.min(0.01, diff));
       }
     }, 5);
-
-    return () => {
-      if (intervalRef.current !== -1) {
-        clearInterval(intervalRef.current);
-      }
-    };
   }, [currentPercentage, percentage]);
 
   return (


### PR DESCRIPTION
### Summary <!-- Required -->
This PR fixes a UI bug on the team page of the DTI website. 

The bug caused the gender ratio donut graph to bug out:
https://cornelldti.slack.com/files/U77S15WQL/F01T18XDR0R/idol-bug.mp4

### Test Plan <!-- Required -->
Just start the website and make sure the donut graph looks normal. 