### PR TITLE
Add documentation to READMEs for configuring dev vs prod Firebase instances 

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -45,3 +45,7 @@ Example: An endpoint to update member information.
 
 3. In the database logic layer, we perform some raw database operation. The code here is usually
    quite simple and not directly related to any business logic. [Example](https://github.com/cornell-dti/idol/blob/907a3f950cd24023b2b6cbb663f04146822a00ed/backend/src/dao/MembersDao.ts#L26-L32).
+
+## Production vs. Development Firebase Instance
+
+The IDOL backend has a Firebase instance for development and a Firebase instance for production. To use the production Firebase instance locally, set the `USE_PROD_DB` environment to `true`. Otherwise, set `USE_PROD_DB` to `false` to use the development Firebase instance.

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,4 +48,4 @@ Example: An endpoint to update member information.
 
 ## Production vs. Development Firebase Instance
 
-The IDOL backend has a Firebase instance for development and a Firebase instance for production. To use the production Firebase instance locally, set the `USE_PROD_DB` environment to `true`. Otherwise, set `USE_PROD_DB` to `false` to use the development Firebase instance.
+The IDOL backend has a Firebase instance for development and a Firebase instance for production. To use the production Firebase instance locally, set the `USE_PROD_DB` environment variable to `true`. Otherwise, set `USE_PROD_DB` to `false` to use the development Firebase instance.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,4 +5,8 @@
 The website is built with React and TypeScript. It is deployed to a netlify instance together with
 idol backend, but separate from DTI website.
 
-When running the frontend locally, the frontend must be configured to be using the same Firebase instance as the backend for Google authentication. If the backend is connected to the production Firebase instance, set `useProdDb` to `true` in `src/environment.ts`. If the backend is connectd to the development Firebase instna,ce set `useProdDb` to `false` in `src/environment.ts`
+## Local testing
+
+When running the frontend locally, the frontend must be configured to be using the same Firebase instance as the backend for Google authentication. If the backend is connected to the production Firebase instance, set `useProdDb` to `true` in `src/environment.ts`. If the backend is connectd to the development Firebase instna,ce set `useProdDb` to `false` in `src/environment.ts`.
+
+<b>Make sure that `useProdDb` is `true` before committing.</b>

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,6 +7,6 @@ idol backend, but separate from DTI website.
 
 ## Local testing
 
-When running the frontend locally, the frontend must be configured to be using the same Firebase instance as the backend for Google authentication. If the backend is connected to the production Firebase instance, set `useProdDb` to `true` in `src/environment.ts`. If the backend is connectd to the development Firebase instna,ce set `useProdDb` to `false` in `src/environment.ts`.
+When running the frontend locally, the frontend must be configured to be using the same Firebase instance as the backend for Google authentication. If the backend is connected to the production Firebase instance, set `useProdDb` to `true` in `src/environment.ts`. If the backend is connected to the development Firebase instance set `useProdDb` to `false` in `src/environment.ts`.
 
 <b>Make sure that `useProdDb` is `true` before committing.</b>

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,3 +4,5 @@
 
 The website is built with React and TypeScript. It is deployed to a netlify instance together with
 idol backend, but separate from DTI website.
+
+When running the frontend locally, the frontend must be configured to be using the same Firebase instance as the backend for Google authentication. If the backend is connected to the production Firebase instance, set `useProdDb` to `true` in `src/environment.ts`. If the backend is connectd to the development Firebase instna,ce set `useProdDb` to `false` in `src/environment.ts`

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -3,6 +3,9 @@ export const isProduction = process.env.NODE_ENV === 'production';
 /** Switch to true when using prod API for dev. Remember to change it back before commit. */
 const useProdBackendForDev = false;
 
+/** Switch to false to use development Firebase instance. Change back to true before committing. */
+export const useProdDb = false;
+
 export const backendURL =
   isProduction || !useProdBackendForDev
     ? '/.netlify/functions/api'

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = false;
+export const useProdDb = true;
 
 export const backendURL =
   isProduction || !useProdBackendForDev

--- a/frontend/src/firebase.ts
+++ b/frontend/src/firebase.ts
@@ -1,9 +1,9 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
-import { isProduction } from './environment';
+import { useProdDb } from './environment';
 
-const firebaseConfig = isProduction
+const firebaseConfig = useProdDb
   ? {
       apiKey: 'AIzaSyCCT5j588crPFvtKW5jM7Zkb_DLU_61VdY',
       authDomain: 'idol-b6c68.firebaseapp.com',


### PR DESCRIPTION
### Summary <!-- Required -->

I just added documentation for the frontend and backend READMEs for configuring the dev and prod Firebase instances when running IDOL locally. 

### Test Plan <!-- Required -->
👀

### Notes <!-- Optional -->
Added a `useProdDb` variable in `environment.ts` for the frontend so that the frontend can be configured to use dev/prod for Google authentication during login. In #88, the frontend was unable to run locally when the backend was connected to the production firebase instance. 
