### PR TITLE
Allow approving a subset of member information change

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "body-parser": "^1.19.0",
     "common-types": "1.0.0",
     "cors": "^2.8.5",
+    "diff": "^5.0.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.17.1",
@@ -35,5 +36,8 @@
     "tsc": "^1.20150623.0",
     "typescript": "^4.0.2",
     "uuid": "^8.3.0"
+  },
+  "devDependencies": {
+    "@types/diff": "^5.0.0"
   }
 }

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -7,10 +7,13 @@ import admin from 'firebase-admin';
 import { db as database, app as adminApp } from './firebase';
 import {
   allMembers,
+  allApprovedMembers,
   getMember,
   setMember,
   deleteMember,
-  updateMember
+  updateMember,
+  getUserInformationDifference,
+  approveUserInformationChange
 } from './memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './imageAPI';
 import { allTeams, setTeam, deleteTeam } from './teamAPI';
@@ -158,6 +161,10 @@ router.get('/allMembers', async (_, res) => {
   const members = await allMembers();
   res.status(200).json({ members });
 });
+router.get('/allApprovedMembers', async (_, res) => {
+  const members = await allApprovedMembers();
+  res.status(200).json({ members });
+});
 loginCheckedGet('/getMember/:email', async (req, user) => ({
   member: await getMember(req.params.email, user)
 }));
@@ -170,6 +177,12 @@ loginCheckedDelete('/deleteMember/:email', async (req, user) => {
 });
 loginCheckedPost('/updateMember', async (req, user) => ({
   member: await updateMember(req.body, user)
+}));
+loginCheckedGet('/memberDiffs', async (_, user) => ({
+  diffs: await getUserInformationDifference(user)
+}));
+loginCheckedPost('/approveMemberDiffs', async (req, user) => ({
+  member: await approveUserInformationChange(req.body.approved, user)
 }));
 
 // Teams

--- a/backend/src/dao/MembersDao.ts
+++ b/backend/src/dao/MembersDao.ts
@@ -1,8 +1,8 @@
-import { memberCollection } from '../firebase';
+import { db, approvedMemberCollection, memberCollection } from '../firebase';
 
 export default class MembersDao {
-  static async getAllMembers(): Promise<IdolMember[]> {
-    return memberCollection
+  static async getAllMembers(fromApproved: boolean): Promise<IdolMember[]> {
+    return (fromApproved ? approvedMemberCollection : memberCollection)
       .get()
       .then((vals) => vals.docs.map((it) => it.data()));
   }
@@ -29,5 +29,30 @@ export default class MembersDao {
   ): Promise<IdolMember> {
     await memberCollection.doc(email).update(member);
     return member;
+  }
+
+  /**
+   * @param emails a list of emails to update.
+   * It can refer to either an email that needs to be updated or the one that needs to be deleted.
+   * This function will automatically decide whether to update or delete the documents in the approved
+   * collection based on whether they exist in the original collection.
+   */
+  static async approveMemberInformationChanges(
+    emails: readonly string[]
+  ): Promise<void> {
+    const batch = db.batch();
+    const approvedMemberInfoList = await Promise.all(
+      emails.map(async (email) => {
+        const data = (await memberCollection.doc(email).get()).data();
+        if (data == null) batch.delete(approvedMemberCollection.doc(email));
+        return data;
+      })
+    );
+    approvedMemberInfoList.forEach((member) => {
+      if (member != null) {
+        batch.set(approvedMemberCollection.doc(member.email), member);
+      }
+    });
+    await batch.commit();
   }
 }

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -51,6 +51,17 @@ export const memberCollection: admin.firestore.CollectionReference<IdolMember> =
     }
   });
 
+export const approvedMemberCollection: admin.firestore.CollectionReference<IdolMember> = db
+  .collection('approved-members')
+  .withConverter({
+    fromFirestore(snapshot): IdolMember {
+      return snapshot.data() as IdolMember;
+    },
+    toFirestore(userData: IdolMember) {
+      return userData;
+    }
+  });
+
 export const teamCollection: admin.firestore.CollectionReference<DBTeam> = db
   .collection('teams')
   .withConverter({

--- a/backend/src/permissions.ts
+++ b/backend/src/permissions.ts
@@ -21,6 +21,10 @@ export class PermissionsManager {
     return mem.role === 'lead' || this.isAdmin(mem);
   }
 
+  static async canReviewChanges(mem: IdolMember): Promise<boolean> {
+    return mem.role === 'lead' || this.isAdmin(mem);
+  }
+
   public static async isAdmin(mem: IdolMember): Promise<boolean> {
     const member = (await adminCollection.doc(mem.email).get()).data();
     return member !== undefined;

--- a/backend/src/util.ts
+++ b/backend/src/util.ts
@@ -1,4 +1,5 @@
 // This file contains common operations that will need to be performed often.
+import { createPatch } from 'diff';
 
 export const getNetIDFromEmail = (email: string): string => email.split('@')[0];
 
@@ -11,3 +12,67 @@ export const filterImagesResponse = (
       ...image,
       fileName: image.fileName.slice(image.fileName.indexOf('/') + 1)
     }));
+
+type SimplifiedMember = { readonly email: string };
+
+export const computeMembersDiff = <M extends SimplifiedMember>(
+  allApprovedMembersList: readonly M[],
+  allLatestMembersList: readonly M[]
+): readonly IdolMemberDiff[] => {
+  const approvedMemberMap = new Map(
+    allApprovedMembersList.map((it) => [it.email, it])
+  );
+
+  const diffs: IdolMemberDiff[] = [];
+
+  const jsonToString = (json: unknown): string => {
+    if (typeof json !== 'object' || json == null) return '';
+    return Object.entries(json)
+      .sort(([n1], [n2]) => n1.localeCompare(n2))
+      .map(([name, value]) => {
+        if (Array.isArray(value)) {
+          value.sort((a, b) => a.localeCompare(b));
+          return ` ${name}: [${value.join(', ')}]`;
+        }
+        return ` ${name}: ${value}`;
+      })
+      .join('\n');
+  };
+  const diff = (oldString: string, newString: string) => {
+    const rawDiff = createPatch(
+      '',
+      `${oldString}\n`,
+      `${newString}\n`,
+      undefined,
+      undefined,
+      // Show full context for member json
+      { context: 20 }
+    );
+    // Remove some irrelevant junk
+    return rawDiff.substr(rawDiff.indexOf('@@')).trim();
+  };
+
+  // First pass: check difference between new data and old data (i.e. changed/added since last approve)
+  allLatestMembersList.forEach((latestData) => {
+    const approvedData = approvedMemberMap.get(latestData.email);
+    const oldString = jsonToString(approvedData);
+    const newString = jsonToString(latestData);
+    if (oldString !== newString) {
+      diffs.push({
+        email: latestData.email,
+        diffString: diff(oldString, newString)
+      });
+    }
+    // Delete the matched data from map. Therefore, after this pass ends, we know what's unmatched.
+    approvedMemberMap.delete(latestData.email);
+  });
+  // Second pass: report missing members from the new data (i.e. deleted since last approve)
+  approvedMemberMap.forEach((leftOverApprovedMember) => {
+    diffs.push({
+      email: leftOverApprovedMember.email,
+      diffString: diff(jsonToString(leftOverApprovedMember), '')
+    });
+  });
+
+  return diffs.sort((a, b) => a.email.localeCompare(b.email));
+};

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -5,9 +5,8 @@
     "noImplicitAny": false,
     "outDir": "build",
     "strict": true,
-    "target": "ES5"
+    "target": "ES5",
+    "lib": ["ESNext", "DOM"]
   },
-  "include": [
-    "src/*"
-  ]
+  "include": ["src/*"]
 }

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -33,6 +33,12 @@ interface IdolMember {
   readonly roleDescription: RoleDescription;
 }
 
+interface IdolMemberDiff {
+  /** Email of the member. */
+  readonly email: string;
+  readonly diffString: string;
+}
+
 /** The data type used by Nova site to represent a DTI member. */
 interface NovaMember {
   readonly netid: string;

--- a/frontend/src/Admin/AdminBase/AdminBase.tsx
+++ b/frontend/src/Admin/AdminBase/AdminBase.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router-dom';
 import { Card, Button } from 'semantic-ui-react';
 import SiteDeployer from '../DTI-Site-Deployer/SiteDeployer';
+import MemberReview from '../MemberReview/MemberReview';
 import styles from './AdminBase.module.css';
 
 const AdminBase: React.FC = () => {
@@ -17,6 +18,23 @@ const AdminBase: React.FC = () => {
       <div className={styles.AdminBase} data-testid="AdminBase">
         <div className={styles.content}>
           <Card.Group>
+            <Card>
+              <Card.Content>
+                <Card.Header>Member Information Review</Card.Header>
+                <Card.Description>
+                  Approve the new info from IDOL.
+                </Card.Description>
+              </Card.Content>
+              <Card.Content extra>
+                <div className="ui one buttons">
+                  <Link to="admin/member-review">
+                    <Button basic color="blue">
+                      Go To
+                    </Button>
+                  </Link>
+                </div>
+              </Card.Content>
+            </Card>
             <Card>
               <Card.Content>
                 <Card.Header>Site Deployer</Card.Header>
@@ -43,6 +61,9 @@ const AdminBase: React.FC = () => {
     <div className={styles.AdminBase} data-testid="AdminBase">
       <Router>
         <Switch>
+          <Route path="/admin/member-review">
+            <MemberReview />
+          </Route>
           <Route path="/admin/site-deployer">
             <SiteDeployer />
           </Route>

--- a/frontend/src/Admin/MemberReview/MemberReview.module.css
+++ b/frontend/src/Admin/MemberReview/MemberReview.module.css
@@ -1,0 +1,21 @@
+.Wrapper {
+  margin-left: 2rem;
+  margin-right: 2rem;
+  padding-top: 2rem;
+}
+
+.ApprovingContainer {
+  display: flex;
+  flex-direction: row;
+}
+
+.ApprovingContainerCards {
+  width: 70%;
+  height: calc(100vh - 90px);
+  overflow: scroll;
+}
+
+.ApprovingContainerSideBar {
+  flex: 1 1 auto;
+  padding: 1em;
+}

--- a/frontend/src/Admin/MemberReview/MemberReview.tsx
+++ b/frontend/src/Admin/MemberReview/MemberReview.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Card, Loader } from 'semantic-ui-react';
+import APIWrapper from '../../API/APIWrapper';
+import { backendURL } from '../../environment';
+
+import styles from './MemberReview.module.css';
+
+const DiffRenderer = ({ children }: { readonly children: string }) => (
+  <pre className="language-diff-json diff-highlight">
+    <code className="language-diff-json diff-highlight">
+      {children.split('\n').map((l, lineNo) => {
+        const line = `${l}\n`;
+        let backgroundColor: string | undefined;
+        if (line.startsWith('@@')) {
+          backgroundColor = 'rgba(0,0,255,0.2)';
+        }
+        if (line.startsWith('+')) {
+          backgroundColor = 'rgba(0,255,0,0.2)';
+        }
+        if (line.startsWith('-')) {
+          backgroundColor = 'rgba(255,0,0,0.2)';
+        }
+        return (
+          <span key={lineNo} style={{ backgroundColor }}>
+            {line}
+          </span>
+        );
+      })}
+    </code>
+  </pre>
+);
+
+const getDiffs = async (): Promise<readonly IdolMemberDiff[]> => {
+  const resp = await APIWrapper.get(`${backendURL}/memberDiffs`);
+  return resp.data.diffs;
+};
+
+const MemberReview: React.FC = () => {
+  const [diffs, setDiffs] = useState<readonly IdolMemberDiff[] | null>(null);
+  const [approved, setApproved] = useState<readonly string[]>([]);
+
+  useEffect(() => {
+    getDiffs().then((fetchedDiffs) => {
+      setDiffs(fetchedDiffs);
+      setApproved([]);
+    });
+  }, []);
+
+  if (diffs == null) return <Loader active={true} size="massive" />;
+
+  const toggleApprove = (email: string) =>
+    setApproved((currentApproved) =>
+      currentApproved.includes(email)
+        ? currentApproved.filter((it) => it !== email)
+        : [...currentApproved, email]
+    );
+
+  const sendApproveRequest = async () => {
+    await APIWrapper.post(`${backendURL}/approveMemberDiffs`, { approved });
+    const fetchedDiffs = await getDiffs();
+    setDiffs(fetchedDiffs);
+    setApproved([]);
+  };
+
+  return (
+    <div className={styles.Wrapper}>
+      {diffs.length === 0 && (
+        <Card style={{ width: '100%', whiteSpace: 'pre-wrap' }}>
+          <Card.Content>No changes need to approve.</Card.Content>
+        </Card>
+      )}
+      {diffs.length > 0 && (
+        <div className={styles.ApprovingContainer}>
+          <div className={styles.ApprovingContainerCards}>
+            {diffs.map(({ email, diffString }) => (
+              <Card
+                key={email}
+                style={{ width: '100%', whiteSpace: 'pre-wrap' }}
+              >
+                <Card.Content>
+                  <h2>{email}</h2>
+                  <DiffRenderer>{diffString}</DiffRenderer>
+                </Card.Content>
+                <Card.Content extra>
+                  <div className="ui one buttons" style={{ width: '100%' }}>
+                    <Button
+                      basic
+                      color={approved.includes(email) ? 'red' : 'green'}
+                      onClick={() => toggleApprove(email)}
+                    >
+                      {approved.includes(email) ? 'Unapprove' : 'Approve'}
+                    </Button>
+                  </div>
+                </Card.Content>
+              </Card>
+            ))}
+          </div>
+          <div className={styles.ApprovingContainerSideBar}>
+            <Card style={{ width: '100%', whiteSpace: 'pre-wrap' }}>
+              <Card.Content>
+                <h2>Current Approved Member Change List</h2>
+              </Card.Content>
+              <Card.Content>
+                <ul>
+                  {approved.map((email) => (
+                    <li key={email}>Email: {email}</li>
+                  ))}
+                </ul>
+              </Card.Content>
+              <Card.Content extra>
+                <div className="ui one buttons" style={{ width: '100%' }}>
+                  <Button
+                    basic
+                    disabled={approved.length === 0}
+                    color="green"
+                    onClick={sendApproveRequest}
+                  >
+                    Submit Approvals
+                  </Button>
+                </div>
+              </Card.Content>
+            </Card>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MemberReview;

--- a/frontend/src/Common/Search/Search.tsx
+++ b/frontend/src/Common/Search/Search.tsx
@@ -87,9 +87,7 @@ function CustomSearch<T>({
 
         dispatch({
           type: 'FINISH_SEARCH',
-          results: source
-            .filter((val) => isMatch(data.value, val))
-            .map((val) => ({ ...val, title: JSON.stringify(val) })),
+          results: source.filter((val) => isMatch(data.value, val)),
           selection: '',
           query: data.value
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2650,6 +2650,11 @@
     "@types/d3-voronoi" "*"
     "@types/d3-zoom" "*"
 
+"@types/diff@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-5.0.0.tgz#eb71e94feae62548282c4889308a3dfb57e36020"
+  integrity sha512-jrm2K65CokCCX4NmowtA+MfXyuprZC13jbRuwprs6/04z/EcFg/MCwYdsHn+zgV4CQBiATiI7AEq7y1sZCtWKA==
+
 "@types/eslint@^7.2.6":
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.6.tgz#5e9aff555a975596c03a98b59ecd103decc70c3c"
@@ -6401,6 +6406,11 @@ diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"


### PR DESCRIPTION
### Summary <!-- Required -->

The current flow of member information change approval has a big issue: if one member's information change has something we don't want, we cannot approve others' information without leaving the bad one out.

This PR aims to fix the issue by building a per-person information change approval flow. I build an IDOL page that loads in diffs **on each member**, and allows the admin to selectively approve a subset of them. This allows the good ones to go through, without making the bad change taking hostage of the entire flow.

This PR only implements the review part. It does not alter the rest of the system yet. It currently only stores the approved members' information into a separate collection. I exposed an endpoint that fetches from that collection instead of the old collection. In the next PR, we can make the `pull-from-idol` script pull from that collection instead.

#### Future Work

- Integrate the new endpoint into `pull-from-idol` script.
- Implement similar feature for profile pictures
- Have some mechanism to notify the admin that there is something to review (could be a slackbot).

### Test Plan <!-- Required -->

Example:
<img width="1481" alt="Screen Shot 2021-04-15 at 22 01 40" src="https://user-images.githubusercontent.com/4290500/114961213-975fe980-9e36-11eb-997a-10f532427d47.png">

### Notes <!-- Optional -->

@meganyin13 what you want has now been built.