### PR TITLE
Update pull-from-idol script to fetch approved member data list

### DIFF
--- a/dti-website/pull-from-idol.ts
+++ b/dti-website/pull-from-idol.ts
@@ -11,7 +11,7 @@ import fetch from 'node-fetch';
 
 async function getIdolMembers(): Promise<readonly IdolMember[]> {
   const { members }: { members: readonly IdolMember[] } = await fetch(
-    'https://idol.cornelldti.org/.netlify/functions/api/allMembers'
+    'https://idol.cornelldti.org/.netlify/functions/api/allApprovedMembers'
   ).then((response) => response.json());
   return members.filter((it) => it.email.endsWith('@cornell.edu'));
 }
@@ -117,15 +117,15 @@ async function main(): Promise<void> {
   \`\`\`diff
   ${diffOutput}
   \`\`\`
-  
+
   ## Summary
 
   This is a PR auto-generated from \`yarn workspace dti-website pull-from-idol\`.
-  It updates the members JSON with latest data from IDOL backend.
-  Please review it carefully to ensure nothing bad is here.
-  
+  It updates the members JSON with latest **approved** data from IDOL backend.
+  Please review it carefully again to ensure nothing bad is here.
+
   ## Test Plan
-  
+
   :eyes:`;
   const existingPR = (
     await octokit.pulls.list({


### PR DESCRIPTION
### Summary <!-- Required -->

Update the pull-from-idol script to fetch only approved member data list. This finishes the per-member approval integration.

### Test Plan <!-- Required -->

👀 