### PR TITLE
shoutouts backend

### DIFF
--- a/backend/src/DataTypes.d.ts
+++ b/backend/src/DataTypes.d.ts
@@ -13,3 +13,15 @@ export type Team = {
   leaders: IdolMember[];
   members: IdolMember[];
 };
+
+export type DBShoutout = {
+  giver: firestore.DocumentReference;
+  receiver: firestore.DocumentReference;
+  message: string;
+};
+
+export type Shoutout = {
+  giver: IdolMember;
+  receiver: IdolMember;
+  message: string;
+};

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -14,6 +14,7 @@ import {
 } from './memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './imageAPI';
 import { allTeams, setTeam, deleteTeam } from './teamAPI';
+import { getShoutouts, giveShoutout } from './shoutoutAPI';
 import {
   acceptIDOLChanges,
   getIDOLChangesPR,
@@ -192,6 +193,14 @@ router.get('/allMemberImages', async (_, res) => {
   const images = await allMemberImages();
   res.status(200).json({ images });
 });
+
+loginCheckedGet('/getShoutouts/:email/:type', async (req, user) => ({
+  shoutouts: await getShoutouts(req.params.email, req.params.type, user)
+}));
+
+loginCheckedPost('/giveShoutout', async (req, user) => ({
+  shoutout: await giveShoutout(req.body, user)
+}));
 
 // Permissions
 loginCheckedGet('/isAdmin/:email', async (_, user) => ({

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -208,7 +208,11 @@ router.get('/allMemberImages', async (_, res) => {
 });
 
 loginCheckedGet('/getShoutouts/:email/:type', async (req, user) => ({
-  shoutouts: await getShoutouts(req.params.email, req.params.type, user)
+  shoutouts: await getShoutouts(
+    req.params.email,
+    req.params.type as 'given' | 'received',
+    user
+  )
 }));
 
 loginCheckedPost('/giveShoutout', async (req, user) => ({

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -2,7 +2,10 @@ import { memberCollection, shoutoutCollection } from '../firebase';
 import { Shoutout, DBShoutout } from '../DataTypes';
 
 export default class ShoutoutsDao {
-  static async getShoutouts(email: string, type: string): Promise<Shoutout[]> {
+  static async getShoutouts(
+    email: string,
+    type: 'given' | 'received'
+  ): Promise<Shoutout[]> {
     const givenOrReceived = type === 'given' ? 'giver' : 'receiver';
     const shoutoutRefs = await shoutoutCollection
       .where(givenOrReceived, '==', memberCollection.doc(email))

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -1,0 +1,33 @@
+import { memberCollection, shoutoutCollection } from '../firebase';
+import { Shoutout, DBShoutout } from '../DataTypes';
+
+export default class ShoutoutsDao {
+  static async getShoutouts(email: string, type: string): Promise<Shoutout[]> {
+    const givenOrReceived = type === 'given' ? 'giver' : 'receiver';
+    const shoutoutRefs = await shoutoutCollection
+      .where(givenOrReceived, '==', memberCollection.doc(email))
+      .get();
+    return Promise.all(
+      shoutoutRefs.docs.map(async (shoutoutRef) => {
+        const { giver, receiver, message } = shoutoutRef.data();
+        return {
+          giver: (await giver.get().then((doc) => doc.data())) as IdolMember,
+          receiver: (await receiver
+            .get()
+            .then((doc) => doc.data())) as IdolMember,
+          message
+        };
+      })
+    );
+  }
+
+  static async setShoutout(shoutout: Shoutout): Promise<Shoutout> {
+    const shoutoutRef: DBShoutout = {
+      ...shoutout,
+      giver: memberCollection.doc(shoutout.giver.email),
+      receiver: memberCollection.doc(shoutout.receiver.email)
+    };
+    await shoutoutCollection.doc().set(shoutoutRef);
+    return shoutout;
+  }
+}

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -1,5 +1,5 @@
 import admin from 'firebase-admin';
-import { DBTeam } from './DataTypes';
+import { DBShoutout, DBTeam, Shoutout } from './DataTypes';
 
 require('dotenv').config();
 
@@ -58,6 +58,17 @@ export const teamCollection: admin.firestore.CollectionReference<DBTeam> = db
       return snapshot.data() as DBTeam;
     },
     toFirestore(userData: DBTeam) {
+      return userData;
+    }
+  });
+
+export const shoutoutCollection: admin.firestore.CollectionReference<DBShoutout> = db
+  .collection('shoutouts')
+  .withConverter({
+    fromFirestore(snapshot): DBShoutout {
+      return snapshot.data() as DBShoutout;
+    },
+    toFirestore(userData: DBShoutout) {
       return userData;
     }
   });

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -1,5 +1,5 @@
 import admin from 'firebase-admin';
-import { DBShoutout, DBTeam, Shoutout } from './DataTypes';
+import { DBShoutout, DBTeam } from './DataTypes';
 
 require('dotenv').config();
 

--- a/backend/src/permissions.ts
+++ b/backend/src/permissions.ts
@@ -22,11 +22,11 @@ export class PermissionsManager {
   }
 
   static async canReviewChanges(mem: IdolMember): Promise<boolean> {
-    return mem.role === 'lead' || this.isAdmin(mem);  
+    return mem.role === 'lead' || this.isAdmin(mem);
   }
-  
+
   static async canGetShoutouts(mem: IdolMember): Promise<boolean> {
-    return mem.role === 'lead' || this.isAdmin(mem); 
+    return mem.role === 'lead' || this.isAdmin(mem);
   }
 
   public static async isAdmin(mem: IdolMember): Promise<boolean> {

--- a/backend/src/permissions.ts
+++ b/backend/src/permissions.ts
@@ -21,6 +21,10 @@ export class PermissionsManager {
     return mem.role === 'lead' || this.isAdmin(mem);
   }
 
+  static async canGetShoutouts(mem: IdolMember): Promise<boolean> {
+    return mem.role === 'lead' || this.isAdmin(mem);
+  }
+
   public static async isAdmin(mem: IdolMember): Promise<boolean> {
     const member = (await adminCollection.doc(mem.email).get()).data();
     return member !== undefined;

--- a/backend/src/shoutoutAPI.ts
+++ b/backend/src/shoutoutAPI.ts
@@ -17,7 +17,7 @@ export const giveShoutout = async (
 
 export const getShoutouts = async (
   memberEmail: string,
-  type: string,
+  type: 'given' | 'received',
   user: IdolMember
 ): Promise<Shoutout[]> => {
   const canEdit: boolean = await PermissionsManager.canGetShoutouts(user);

--- a/backend/src/shoutoutAPI.ts
+++ b/backend/src/shoutoutAPI.ts
@@ -1,0 +1,31 @@
+import { PermissionsManager } from './permissions';
+import { PermissionError } from './errors';
+import { Shoutout } from './DataTypes';
+import ShoutoutsDao from './dao/ShoutoutsDao';
+
+export const giveShoutout = async (
+  body: Shoutout,
+  user: IdolMember
+): Promise<Shoutout> => {
+  if (body.giver.email !== user.email) {
+    throw new PermissionError(
+      `User with email: ${user.email} can't post a shoutout from a different user!`
+    );
+  }
+  return ShoutoutsDao.setShoutout(body);
+};
+
+export const getShoutouts = async (
+  memberEmail: string,
+  type: string,
+  user: IdolMember
+): Promise<Shoutout[]> => {
+  const canEdit: boolean = await PermissionsManager.canGetShoutouts(user);
+  if (!canEdit && memberEmail !== user.email) {
+    throw new PermissionError(
+      `User with email: ${user.email} does not have permission to get shoutouts!`
+    );
+  }
+  const shoutouts = await ShoutoutsDao.getShoutouts(memberEmail, type);
+  return shoutouts;
+};

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -15,7 +15,10 @@ type ShoutoutResponseObj = {
 };
 
 export class ShoutoutsAPI {
-  public static getShoutouts(email: string, type: string): Promise<Shoutout[]> {
+  public static getShoutouts(
+    email: string,
+    type: 'given' | 'received'
+  ): Promise<Shoutout[]> {
     const responseProm = APIWrapper.get(
       `${backendURL}/getShoutouts/${email}/${type}`
     ).then((res) => res.data);

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -1,0 +1,40 @@
+import { backendURL } from '../environment';
+import { Member } from './MembersAPI';
+import APIWrapper from './APIWrapper';
+import Emitters from '../EventEmitter/constant-emitters';
+
+export type Shoutout = {
+  giver: Member;
+  receiver: Member;
+  message: string;
+};
+
+type ShoutoutResponseObj = {
+  shoutout: Shoutout;
+  error?: string;
+};
+
+export class ShoutoutsAPI {
+  public static getShoutouts(email: string, type: string): Promise<Shoutout[]> {
+    const responseProm = APIWrapper.get(
+      `${backendURL}/getShoutouts/${email}/${type}`
+    ).then((res) => res.data);
+    return responseProm.then((val) => {
+      if (val.error) {
+        Emitters.generalError.emit({
+          headerMsg: `Couldn't get ${type} shoutouts!`,
+          contentMsg: `Error was: ${val.error}`
+        });
+        return [];
+      }
+      const shoutouts = val.shoutouts as Shoutout[];
+      return shoutouts;
+    });
+  }
+
+  public static giveShoutout(shoutout: Shoutout): Promise<ShoutoutResponseObj> {
+    return APIWrapper.post(`${backendURL}/giveShoutout`, shoutout).then(
+      (res) => res.data
+    );
+  }
+}

--- a/frontend/src/User/ShoutoutsPage/ShoutoutCard/ShoutoutCard.tsx
+++ b/frontend/src/User/ShoutoutsPage/ShoutoutCard/ShoutoutCard.tsx
@@ -1,24 +1,22 @@
 import { Card } from 'semantic-ui-react';
+import { Member } from '../../../API/MembersAPI';
 
 type Props = {
-  readonly shoutoutGiverEmail: string;
-  readonly shoutoutRecipientEmail: string;
+  readonly giver: Member;
+  readonly receiver: Member;
   readonly message: string;
 };
 
-const ShoutoutCard = ({
-  shoutoutGiverEmail,
-  shoutoutRecipientEmail,
-  message
-}: Props): JSX.Element => (
+const ShoutoutCard = ({ giver, receiver, message }: Props): JSX.Element => (
   <Card style={{ width: '100%' }}>
-    <Card.Content header={`To: ${shoutoutRecipientEmail}`} />
+    <Card.Content
+      header={`To: ${receiver?.firstName} ${receiver?.lastName} (${receiver.email})`}
+    />
     <Card.Meta
       style={{ paddingLeft: '1rem' }}
-      content={`From: ${shoutoutGiverEmail}`}
+      content={`From: ${giver?.firstName} ${giver?.lastName} (${giver.email})`}
     />
     <Card.Content description={message} />
   </Card>
 );
-
 export default ShoutoutCard;

--- a/frontend/src/User/ShoutoutsPage/ShoutoutList/ShoutoutList.tsx
+++ b/frontend/src/User/ShoutoutsPage/ShoutoutList/ShoutoutList.tsx
@@ -1,24 +1,15 @@
-import { Card, Message } from 'semantic-ui-react';
+import { Card } from 'semantic-ui-react';
 import ShoutoutCard from '../ShoutoutCard/ShoutoutCard';
-import { Shoutout } from '../ShoutoutsPage';
+import { Shoutout } from '../../../API/ShoutoutsAPI';
 
-const ShoutoutList = (props: {
-  shoutouts?: Shoutout[];
-  emptyMessage: string;
-}): JSX.Element => {
-  const { shoutouts, emptyMessage } = props;
+const ShoutoutList = (props: { shoutouts: Shoutout[] }): JSX.Element => {
+  const { shoutouts } = props;
   return (
-    <div>
-      {shoutouts ? (
-        <Card.Group>
-          {shoutouts.map((shoutout, i) => (
-            <ShoutoutCard key={i} {...shoutout} />
-          ))}
-        </Card.Group>
-      ) : (
-        <Message>{emptyMessage}</Message>
-      )}
-    </div>
+    <Card.Group>
+      {shoutouts.map((shoutout, i) => (
+        <ShoutoutCard key={i} {...shoutout} />
+      ))}
+    </Card.Group>
   );
 };
 

--- a/frontend/src/User/ShoutoutsPage/ShoutoutsPage.tsx
+++ b/frontend/src/User/ShoutoutsPage/ShoutoutsPage.tsx
@@ -1,45 +1,91 @@
-import React from 'react';
+import React, { useContext, useState, useEffect } from 'react';
+import { Message } from 'semantic-ui-react';
+import { UserContext } from '../../UserProvider/UserProvider';
+import Emitters from '../../EventEmitter/constant-emitters';
 import ShoutoutForm from './ShoutoutForm/ShoutoutForm';
 import ShoutoutList from './ShoutoutList/ShoutoutList';
 import styles from './ShoutoutsPage.module.css';
+import { Shoutout, ShoutoutsAPI } from '../../API/ShoutoutsAPI';
 
-export type Shoutout = {
-  shoutoutGiverEmail: string;
-  shoutoutRecipientEmail: string;
-  message: string;
+const ShoutoutsPage: React.FC = () => {
+  const userEmail = useContext(UserContext).user?.email;
+  const [givenShoutouts, setGivenShoutouts] = useState<Shoutout[] | undefined>(
+    undefined
+  );
+  const [receivedShoutouts, setReceivedShoutouts] = useState<
+    Shoutout[] | undefined
+  >(undefined);
+
+  const getShoutouts = async (
+    email: string,
+    type: string
+  ): Promise<Shoutout[]> => {
+    const shoutouts = await ShoutoutsAPI.getShoutouts(email, type);
+    return shoutouts;
+  };
+
+  useEffect(() => {
+    if (userEmail) {
+      getShoutouts(userEmail, 'given')
+        .then((given) => {
+          setGivenShoutouts(given);
+        })
+        .catch((error) => {
+          Emitters.generalError.emit({
+            headerMsg: `Couldn't get given shoutouts!`,
+            contentMsg: `Error was: ${error}`
+          });
+        });
+
+      getShoutouts(userEmail, 'received')
+        .then((received) => {
+          setReceivedShoutouts(received);
+        })
+        .catch((error) => {
+          Emitters.generalError.emit({
+            headerMsg: `Couldn't get received shoutouts!`,
+            contentMsg: `Error was: ${error}`
+          });
+        });
+    }
+  }, [userEmail]);
+
+  return (
+    <div>
+      <div
+        style={{
+          width: '50%',
+          alignSelf: 'center',
+          margin: 'auto',
+          paddingTop: '10vh',
+          height: 'calc(100vh - 80px - 25vh)'
+        }}
+      >
+        <ShoutoutForm />
+      </div>
+
+      <div className={styles.listsContainer}>
+        <div className={styles.listContainer}>
+          <h2 className={styles.shoutoutTitle}>Given Shoutouts</h2>
+          {givenShoutouts && givenShoutouts.length > 0 ? (
+            <ShoutoutList shoutouts={givenShoutouts} />
+          ) : (
+            <Message>Give someone a shoutout!</Message>
+          )}
+        </div>
+
+        <div className={styles.listContainer}>
+          <h2 className={styles.shoutoutTitle}>Received Shoutouts</h2>
+
+          {receivedShoutouts && receivedShoutouts.length > 0 ? (
+            <ShoutoutList shoutouts={receivedShoutouts} />
+          ) : (
+            <Message>You currently have no shoutouts.</Message>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 };
-
-const ShoutoutsPage: React.FC = () => (
-  <div>
-    <div
-      style={{
-        width: '50%',
-        alignSelf: 'center',
-        margin: 'auto',
-        paddingTop: '10vh',
-        height: 'calc(100vh - 80px - 25vh)'
-      }}
-    >
-      <ShoutoutForm />
-    </div>
-
-    <div className={styles.listsContainer}>
-      <div className={styles.listContainer}>
-        <h2 className={styles.shoutoutTitle}>Given Shoutouts</h2>
-        <ShoutoutList
-          shoutouts={undefined}
-          emptyMessage="Give someone a shoutout!"
-        />
-      </div>
-      <div className={styles.listContainer}>
-        <h2 className={styles.shoutoutTitle}>Received Shoutouts</h2>
-        <ShoutoutList
-          shoutouts={undefined}
-          emptyMessage="You currently have no shoutouts."
-        />
-      </div>
-    </div>
-  </div>
-);
 
 export default ShoutoutsPage;

--- a/frontend/src/User/ShoutoutsPage/ShoutoutsPage.tsx
+++ b/frontend/src/User/ShoutoutsPage/ShoutoutsPage.tsx
@@ -18,7 +18,7 @@ const ShoutoutsPage: React.FC = () => {
 
   const getShoutouts = async (
     email: string,
-    type: string
+    type: 'given' | 'received'
   ): Promise<Shoutout[]> => {
     const shoutouts = await ShoutoutsAPI.getShoutouts(email, type);
     return shoutouts;

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = false;
+export const useProdDb = true;
 
 export const backendURL =
   isProduction || !useProdBackendForDev

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = true;
+export const useProdDb = false;
 
 export const backendURL =
   isProduction || !useProdBackendForDev


### PR DESCRIPTION
### Summary

This pull request is the next step towards implementing the shoutouts page on IDOL. The user can now send shoutouts to other DTI members and view their given and received shoutouts from Firebase.

- [x] implemented backend routes
- [ ] implemented option to give an anonymous shoutout
- [ ] implemented option to give multiple people a shoutout at once

### Test Plan

- Ensured that nothing breaks when users have either or both lists of shoutouts empty
- Ensure that users can’t post shoutouts for themselves

### Notes

- Right now users can view their shoutouts right as they are posted, not sure if we would want to give the leads the ability to look over each shoutout before confirming that they are ok?