### PR TITLE
Allow both accept and revert in member reviews

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -13,7 +13,7 @@ import {
   deleteMember,
   updateMember,
   getUserInformationDifference,
-  approveUserInformationChange
+  reviewUserInformationChange
 } from './memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './imageAPI';
 import { allTeams, setTeam, deleteTeam } from './teamAPI';
@@ -181,8 +181,12 @@ loginCheckedPost('/updateMember', async (req, user) => ({
 loginCheckedGet('/memberDiffs', async (_, user) => ({
   diffs: await getUserInformationDifference(user)
 }));
-loginCheckedPost('/approveMemberDiffs', async (req, user) => ({
-  member: await approveUserInformationChange(req.body.approved, user)
+loginCheckedPost('/reviewMemberDiffs', async (req, user) => ({
+  member: await reviewUserInformationChange(
+    req.body.approved,
+    req.body.rejected,
+    user
+  )
 }));
 
 // Teams

--- a/backend/src/memberAPI.ts
+++ b/backend/src/memberAPI.ts
@@ -101,8 +101,9 @@ export const getUserInformationDifference = async (
   return computeMembersDiff(allApprovedMembersList, allLatestMembersList);
 };
 
-export const approveUserInformationChange = async (
+export const reviewUserInformationChange = async (
   approved: readonly string[],
+  rejected: readonly string[],
   user: IdolMember
 ): Promise<void> => {
   const canReview = await PermissionsManager.canReviewChanges(user);
@@ -111,5 +112,8 @@ export const approveUserInformationChange = async (
       `User with email: ${user.email} does not have permission to review members information diff!`
     );
   }
-  await MembersDao.approveMemberInformationChanges(approved);
+  await Promise.all([
+    MembersDao.approveMemberInformationChanges(approved),
+    MembersDao.revertMemberInformationChanges(rejected)
+  ]);
 };


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds support for reverting a change in member information. This is helpful in several scanarios:

- Some member just puts some bad stuff that can never be accepted, so it's better to reject it.
- We put in some changes to test the system. It's handy to build some UI to revert some of the testing changes.

### Test Plan <!-- Required -->

<img width="1139" alt="Screen Shot 2021-05-01 at 19 25 53" src="https://user-images.githubusercontent.com/4290500/116797380-30d40000-aab3-11eb-9114-0485f2bb5232.png">
