### PR TITLE
[DTI48] Fix an edge case of keyboard control

### DIFF
--- a/frontend/src/User/DTI48/DTI48MainGame.tsx
+++ b/frontend/src/User/DTI48/DTI48MainGame.tsx
@@ -10,11 +10,12 @@ type Props = { readonly members: readonly IdolMember[] };
 export default function DTI48MainGame({ members }: Props): JSX.Element {
   const userEmail = useContext(UserContext).user?.email ?? '@cornell.edu';
   const netID = userEmail.split('@')[0];
+  const [changeIndex, setChangeIndex] = useState(0);
   const [playerNetID, setPlayerNetID] = useState(netID);
   const [searchTyping, setSearchTyping] = useState(false);
 
   return (
-    <div>
+    <div key={`${playerNetID}-${changeIndex}`}>
       <Dropdown
         placeholder="Select a DTI member to play as"
         className={styles.Dropdown}
@@ -27,11 +28,15 @@ export default function DTI48MainGame({ members }: Props): JSX.Element {
           text: `${member.firstName} ${member.lastName} (${member.netid})`
         }))}
         onChange={(_, data) => setPlayerNetID(data.value as string)}
+        onClose={() => {
+          setChangeIndex((i) => i + 1);
+          setSearchTyping(false);
+        }}
+        value={playerNetID}
         onFocus={() => setSearchTyping(true)}
         onBlur={() => setSearchTyping(false)}
       />
       <DTI48GameCard
-        key={playerNetID}
         chain={computeDTI48UpgradeChain(playerNetID, members)}
         searchTyping={searchTyping}
       />


### PR DESCRIPTION
### Summary <!-- Required -->

There is currently a subtle bug on master about keyboard control.

When you are selecting a player, you can type in using keyboard. If you type `Henry` and hit enter, then `Henry Li` will be selected, but the focus is still on the dropdown, so when the user wants to play the game using wsad, it will reopen the dropdown, which is very confusing.

This PR fixes that by force changing the key when dropdown closes (i.e. finished selection), so that the entire DOM tree will be nuked on rerender, which ensures that the dropdown will not be kept focused.

### Test Plan <!-- Required -->

Before:
https://user-images.githubusercontent.com/4290500/117400643-10e87600-aed1-11eb-8a42-bc9207ee522d.mov
After:
https://user-images.githubusercontent.com/4290500/117400642-10e87600-aed1-11eb-8e16-7984de9538a3.mov