### PR TITLE
Set `resave: false` to try to unbreak session invalidation

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -54,7 +54,7 @@ app.use(bodyParser.json());
 app.use(
   session({
     secret: process.env.SESSION_SECRET as string,
-    resave: true,
+    resave: false,
     saveUninitialized: true,
     store: new MemoryStore(),
     cookie: {


### PR DESCRIPTION
### Summary <!-- Required -->

According to the [docs](https://www.npmjs.com/package/express-session#resave), setting it to `true` can potentially cause race conditions. In our shoutouts page, we make 3 concurrent requests to the backend. Due to much higher latency from client to prod server than local client to server, it becomes increasing likely that the server is handling concurrent requests, which can mess up.

This PR sets it to false to see whether the issue can be fixed.

### Test Plan <!-- Required -->

Test in staging site.