### PR TITLE
Try fixing race condition in session

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -54,8 +54,8 @@ app.use(bodyParser.json());
 app.use(
   session({
     secret: process.env.SESSION_SECRET as string,
-    resave: true,
-    saveUninitialized: true,
+    resave: false,
+    saveUninitialized: false,
     store: new MemoryStore(),
     cookie: {
       secure: !!isProd,


### PR DESCRIPTION
### Summary <!-- Required -->

According to the [docs](https://www.npmjs.com/package/express-session#resave), setting them to `true` can potentially cause race conditions. In our shoutouts page, we make 3 concurrent requests to the backend. Due to much higher latency from client to prod server than local client to server, it becomes increasing likely that the server is handling concurrent requests, which can mess up.

This PR sets it them false to see whether the issue can be fixed.

### Test Plan <!-- Required -->

Test in staging