### PR TITLE
Admin page for shoutouts

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -17,7 +17,7 @@ import {
 } from './memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './imageAPI';
 import { allTeams, setTeam, deleteTeam } from './teamAPI';
-import { getShoutouts, giveShoutout } from './shoutoutAPI';
+import { getAllShoutouts, getShoutouts, giveShoutout } from './shoutoutAPI';
 import {
   acceptIDOLChanges,
   getIDOLChangesPR,
@@ -219,12 +219,16 @@ loginCheckedGet('/getShoutouts/:email/:type', async (req, user) => ({
   )
 }));
 
+loginCheckedGet('/allShoutouts', async () => ({
+  shoutouts: await getAllShoutouts()
+}));
+
 loginCheckedPost('/giveShoutout', async (req, user) => ({
   shoutout: await giveShoutout(req.body, user)
 }));
 
 // Permissions
-loginCheckedGet('/isAdmin/:email', async (_, user) => ({
+loginCheckedGet('/isAdmin', async (_, user) => ({
   isAdmin: await PermissionsManager.isAdmin(user)
 }));
 

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -2,6 +2,27 @@ import { memberCollection, shoutoutCollection } from '../firebase';
 import { Shoutout, DBShoutout } from '../DataTypes';
 
 export default class ShoutoutsDao {
+  static async getAllShoutouts(): Promise<Shoutout[]> {
+    return Promise.all(
+      await shoutoutCollection.get().then((shoutoutRefs) =>
+        shoutoutRefs.docs.map(async (doc) => {
+          const dbShoutout = doc.data() as DBShoutout;
+          const giver = (await dbShoutout.giver
+            .get()
+            .then((doc) => doc.data())) as IdolMember;
+          const receiver = (await dbShoutout.receiver
+            .get()
+            .then((doc) => doc.data())) as IdolMember;
+          return {
+            ...dbShoutout,
+            giver,
+            receiver
+          };
+        })
+      )
+    );
+  }
+
   static async getShoutouts(
     email: string,
     type: 'given' | 'received'

--- a/backend/src/permissions.ts
+++ b/backend/src/permissions.ts
@@ -31,6 +31,6 @@ export class PermissionsManager {
 
   public static async isAdmin(mem: IdolMember): Promise<boolean> {
     const member = (await adminCollection.doc(mem.email).get()).data();
-    return member !== undefined;
+    return mem.role === 'lead' || member !== undefined;
   }
 }

--- a/backend/src/shoutoutAPI.ts
+++ b/backend/src/shoutoutAPI.ts
@@ -3,6 +3,9 @@ import { PermissionError } from './errors';
 import { Shoutout } from './DataTypes';
 import ShoutoutsDao from './dao/ShoutoutsDao';
 
+export const getAllShoutouts = (): Promise<Shoutout[]> =>
+  ShoutoutsDao.getAllShoutouts();
+
 export const giveShoutout = async (
   body: Shoutout,
   user: IdolMember

--- a/frontend/src/API/PermissionsAPI.ts
+++ b/frontend/src/API/PermissionsAPI.ts
@@ -4,16 +4,13 @@ import PermissionsError from '../Errors/PermissionsError';
 import APIWrapper from './APIWrapper';
 
 export default class PermissionsAPI {
-  public static async isAdmin(email: string): Promise<{ isAdmin: boolean }> {
+  public static async isAdmin(): Promise<{ isAdmin: boolean }> {
     const funcName = 'isAdmin';
     if (APICache.has(funcName)) {
       return Promise.resolve(APICache.retrieve(funcName));
     }
-    const res = await APIWrapper.get(`${backendURL}/isAdmin/${email}`);
+    const res = await APIWrapper.get(`${backendURL}/isAdmin`);
     const isAdmin = res.data;
-    if (!isAdmin.isAdmin) {
-      throw new PermissionsError(isAdmin);
-    }
     APICache.cache(funcName, isAdmin);
     return isAdmin;
   }

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -15,6 +15,23 @@ type ShoutoutResponseObj = {
 };
 
 export class ShoutoutsAPI {
+  public static getAllShoutouts(): Promise<Shoutout[]> {
+    const responseProm = APIWrapper.get(`${backendURL}/allShoutouts`).then(
+      (res) => res.data
+    );
+    return responseProm.then((val) => {
+      if (val.error) {
+        Emitters.generalError.emit({
+          headerMsg: "Couldn't get all shoutouts",
+          contentMsg: `Eror was: ${val.err}`
+        });
+        return [];
+      }
+      const shoutouts = val.shoutouts as Shoutout[];
+      return shoutouts;
+    });
+  }
+
   public static getShoutouts(
     email: string,
     type: 'given' | 'received'

--- a/frontend/src/Admin/AdminBase/AdminBase.tsx
+++ b/frontend/src/Admin/AdminBase/AdminBase.tsx
@@ -9,6 +9,7 @@ import {
 import { Card, Button } from 'semantic-ui-react';
 import SiteDeployer from '../DTI-Site-Deployer/SiteDeployer';
 import MemberReview from '../MemberReview/MemberReview';
+import AdminShoutouts from '../AdminShoutouts/AdminShoutouts';
 import styles from './AdminBase.module.css';
 
 const AdminBase: React.FC = () => {
@@ -52,6 +53,21 @@ const AdminBase: React.FC = () => {
                 </div>
               </Card.Content>
             </Card>
+            <Card>
+              <Card.Content>
+                <Card.Header>View Shoutouts</Card.Header>
+                <Card.Description>View recent shoutouts</Card.Description>
+              </Card.Content>
+              <Card.Content extra>
+                <div className="ui one buttons">
+                  <Link to="admin/shoutouts">
+                    <Button basic color="blue">
+                      Go To
+                    </Button>
+                  </Link>
+                </div>
+              </Card.Content>
+            </Card>
           </Card.Group>
         </div>
       </div>
@@ -66,6 +82,9 @@ const AdminBase: React.FC = () => {
           </Route>
           <Route path="/admin/site-deployer">
             <SiteDeployer />
+          </Route>
+          <Route path="/admin/shoutouts">
+            <AdminShoutouts />
           </Route>
           <Route path="/*"></Route>
         </Switch>

--- a/frontend/src/Admin/AdminShoutouts/AdminShoutouts.module.css
+++ b/frontend/src/Admin/AdminShoutouts/AdminShoutouts.module.css
@@ -1,0 +1,10 @@
+.shoutoutsContainer {
+  padding-left: 5%;
+  padding-top: 5%;
+}
+
+.Wrapper {
+  margin-left: 2rem;
+  margin-right: 2rem;
+  padding-top: 2rem;
+}

--- a/frontend/src/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { Item, Card } from 'semantic-ui-react';
+import { ShoutoutsAPI, Shoutout } from '../../API/ShoutoutsAPI';
+import PermissionsAPI from '../../API/PermissionsAPI';
+import Emitters from '../../EventEmitter/constant-emitters';
+import styles from './AdminShoutouts.module.css';
+
+const AdminShoutouts: React.FC = () => {
+  const [shoutouts, setShoutouts] = useState<Shoutout[]>([]);
+
+  useEffect(() => {
+    PermissionsAPI.isAdmin().then(({ isAdmin }) => {
+      if (isAdmin) {
+        ShoutoutsAPI.getAllShoutouts().then((shoutouts) =>
+          setShoutouts(shoutouts)
+        );
+      } else {
+        Emitters.generalError.emit({
+          headerMsg: 'Access Denied',
+          contentMsg: 'Insufficient permissions'
+        });
+      }
+    });
+  }, []);
+
+  return (
+    <div className={styles.shoutoutsContainer}>
+      {shoutouts.length === 0 ? (
+        <Card style={{ width: '100%', whiteSpace: 'pre-wrap' }}>
+          <Card.Content>No shoutouts.</Card.Content>
+        </Card>
+      ) : (
+        <Item.Group divided>
+          {shoutouts.map((shoutout, i) => (
+            <Item key={i}>
+              <Item.Content>
+                <Item.Header>
+                  {`${shoutout.receiver.firstName} ${shoutout.receiver.lastName}`}
+                </Item.Header>
+                <Item.Meta>{`From: ${shoutout.giver.firstName} ${shoutout.giver.lastName}`}</Item.Meta>
+                <Item.Description>{shoutout.message}</Item.Description>
+              </Item.Content>
+            </Item>
+          ))}
+        </Item.Group>
+      )}
+    </div>
+  );
+};
+
+export default AdminShoutouts;

--- a/frontend/src/Admin/DTI-Site-Deployer/SiteDeployer.tsx
+++ b/frontend/src/Admin/DTI-Site-Deployer/SiteDeployer.tsx
@@ -41,7 +41,7 @@ const SiteDeployer: React.FC = () => {
         .then(async (mem) => {
           if (
             !(
-              (await PermissionsAPI.isAdmin(mem.email).catch((err) => false)) ||
+              (await PermissionsAPI.isAdmin().catch((err) => false)) ||
               mem.role === 'lead'
             )
           ) {


### PR DESCRIPTION
### Summary <!-- Required -->

Admin page that allows admins to see all shoutouts 

![image](https://user-images.githubusercontent.com/65922473/117524156-54eb8180-af8a-11eb-85a2-d38e5f9e049b.png)


### Test Plan <!-- Required -->

Check IDOL deploy preview 

### Notes <!-- Optional -->

This is currently a very simple implementation. In the future, we may want to implement filtering by varying amounts of time. 


