### PR TITLE
Fix team page

### DIFF
--- a/dti-website/src/components/RoleSelector.scss
+++ b/dti-website/src/components/RoleSelector.scss
@@ -84,13 +84,6 @@
     }
   }
 
-  .desktop-selector-header {
-    margin-bottom: 2rem;
-    text-align: center;
-    font-weight: bold;
-    font-size: 3rem;
-  }
-
   .apply-row:not(.desktop-selector-container) {
     border-left: 5px solid black;
     font-size: 18px;

--- a/dti-website/src/components/RoleSelector.tsx
+++ b/dti-website/src/components/RoleSelector.tsx
@@ -61,7 +61,6 @@ export default function RoleSelector({
 
   return (
     <div className={clsx('role-selector-component', className)}>
-      <Row className="justify-content-center desktop-selector-header">Applications 👇</Row>
       <Row className="filter-btn-group desktop-selector-container">
         {showAll && (
           <Col

--- a/dti-website/src/pages/apply.scss
+++ b/dti-website/src/pages/apply.scss
@@ -454,4 +454,11 @@
       }
     }
   }
+
+  .desktop-selector-header {
+    margin-bottom: 2rem;
+    text-align: center;
+    font-weight: bold;
+    font-size: 3rem;
+  }
 }

--- a/dti-website/src/pages/apply.scss
+++ b/dti-website/src/pages/apply.scss
@@ -455,7 +455,7 @@
     }
   }
 
-  .desktop-selector-header {
+  .selector-header {
     margin-bottom: 2rem;
     text-align: center;
     font-weight: bold;

--- a/dti-website/src/pages/apply.tsx
+++ b/dti-website/src/pages/apply.tsx
@@ -175,7 +175,7 @@ export default function ApplyPage(): JSX.Element {
           </Row>
         )}
         <Container>
-          <Row className="justify-content-center desktop-selector-header">Applications 👇</Row>
+          <Row className="justify-content-center selector-header">Applications 👇</Row>
           <RoleSelector
             roleId={roleId}
             onRoleIdChange={setRoleId}

--- a/dti-website/src/pages/apply.tsx
+++ b/dti-website/src/pages/apply.tsx
@@ -175,6 +175,7 @@ export default function ApplyPage(): JSX.Element {
           </Row>
         )}
         <Container>
+          <Row className="justify-content-center desktop-selector-header">Applications 👇</Row>
           <RoleSelector
             roleId={roleId}
             onRoleIdChange={setRoleId}


### PR DESCRIPTION
### Summary <!-- Required -->

Previously a header that said "Applications 👇" was added to the RoleSelector component, which was used in multiple places in the website. This resulted in the header appearing in unintended places.

The header has been factored out of the RoleSelector component and into the `apply` page ONLY, which is its intended behavior.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
![image](https://user-images.githubusercontent.com/3837473/131612643-fba19450-5dc8-48f7-b21e-54d60cb57ef0.png)
![image](https://user-images.githubusercontent.com/3837473/131612667-7e897938-3c84-43cb-b643-35a96f34c1a3.png)

