### PR TITLE
Allow past members to signin

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -72,7 +72,7 @@ const loginCheckedHandler =
       res.status(440).json({ error: 'Not logged in!' });
       return;
     }
-    const user = await MembersDao.getMember(userEmail);
+    const user = await MembersDao.getCurrentOrPastMemberByEmail(userEmail);
     if (!user) {
       res.status(401).send({ error: `No user with email: ${userEmail}` });
       return;

--- a/backend/src/dao/SignInFormDao.ts
+++ b/backend/src/dao/SignInFormDao.ts
@@ -46,7 +46,7 @@ export default class SignInFormDao {
           throw new NotFoundError(`This should be impossible. CODE: DTI-2`);
         const userProms = formData.users.map((u) => {
           const memberID = u.user.id;
-          return MembersDao.getMember(memberID).then((value) => {
+          return MembersDao.getCurrentOrPastMemberByEmail(memberID).then((value) => {
             if (value === undefined)
               throw new NotFoundError(`This should be impossible. CODE: DTI-3`);
             return {

--- a/backend/src/memberAPI.ts
+++ b/backend/src/memberAPI.ts
@@ -53,7 +53,7 @@ export const getMember = async (memberEmail: string, user: IdolMember): Promise<
       `User with email: ${user.email} does not have permission to get members!`
     );
   }
-  const member = await MembersDao.getMember(memberEmail);
+  const member = await MembersDao.getCurrentOrPastMemberByEmail(memberEmail);
   if (member == null) {
     throw new NotFoundError(`Member with email: ${memberEmail} does not exist`);
   }

--- a/backend/src/members-archive/index.ts
+++ b/backend/src/members-archive/index.ts
@@ -1,7 +1,15 @@
 import sp21 from './sp21.json';
 
-const archivedMembers: Readonly<Record<string, readonly IdolMember[]>> = {
+export const archivedMembersBySemesters: Readonly<Record<string, readonly IdolMember[]>> = {
   'Spring 2021': sp21.members as unknown as readonly IdolMember[]
 };
 
-export default archivedMembers;
+export const archivedMembersByEmail: Readonly<Record<string, IdolMember>> = (() => {
+  const map: Record<string, IdolMember> = {};
+  Object.values(archivedMembersBySemesters).forEach((members) => {
+    members.forEach((member) => {
+      map[member.email] = member;
+    });
+  });
+  return map;
+})();


### PR DESCRIPTION
### Summary <!-- Required -->

This PR implements signin support for past members that have been removed from `members` collection, so that they can continue access the site, and most importantly, play DTI48. After this PR, the project to allow past members to play DTI48 is done.

It's achieved by making the members stored inside the archive as a fallback.

### Test Plan <!-- Required -->

1. Temporarily remove yourself in the members collection.
2. Try to sign in. You should be able to successfully signin.
3. Try to play DTI48 as yourself in spring 2021. It should still be the default choice.

### Notes

It's important to note that this does open up some security issues, although not that critical. For example, past leads will be still be able to have admin permissions. In the future,  I plan to attach an optional flag `isPastMember` so that we can distinguish current and past members by looking at the returned `IdolMember` object.