### PR TITLE
Add TeamEvent type for team event tracking

### DIFF
--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -72,3 +72,9 @@ interface SignInForm {
   readonly createdAt: number;
   readonly id: string;
 }
+
+interface TeamEvent {
+  readonly name: string,
+  readonly attendees: IdolMember[],
+  readonly uuid: string
+}

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -74,7 +74,7 @@ interface SignInForm {
 }
 
 interface TeamEvent {
-  readonly name: string,
-  readonly attendees: IdolMember[],
-  readonly uuid: string
+  readonly name: string;
+  readonly attendees: IdolMember[];
+  readonly uuid: string;
 }


### PR DESCRIPTION
### Summary <!-- Required -->
Added new `TeamEvent` type to `common-types` for team event tracking 
```
interface TeamEvent {
  readonly name: string,
  readonly attendees: IdolMember[],
  readonly uuid: string
}
```

### Test Plan <!-- Required -->
No functional changes, only added new type 