### PR TITLE
Migrate DTI website to use bootstrap 5

### DIFF
--- a/dti-website/package.json
+++ b/dti-website/package.json
@@ -13,7 +13,7 @@
     "@octokit/rest": "^18.9.1",
     "@types/d3": "5.7.2",
     "@types/node-fetch": "^2.5.12",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^5.1.1",
     "clsx": "^1.1.1",
     "common-types": "1.0.0",
     "d3": "5.16.0",

--- a/dti-website/src/components/DtiFooter.scss
+++ b/dti-website/src/components/DtiFooter.scss
@@ -133,6 +133,7 @@
   }
 
   .brand {
+    width: auto;
     max-height: 4.5rem;
     @media (max-width: 1200px) {
       max-height: 3.5rem;

--- a/dti-website/src/components/DtiFooter.scss
+++ b/dti-website/src/components/DtiFooter.scss
@@ -211,6 +211,11 @@
 
     .copyright,
     .attribution {
+      width: auto;
+    }
+
+    .copyright,
+    .attribution {
       display: inline;
       color: rgb(255, 255, 255);
       font-weight: 400;

--- a/dti-website/src/components/DtiMainMenu.scss
+++ b/dti-website/src/components/DtiMainMenu.scss
@@ -21,6 +21,19 @@
 
 .navbar-dti {
   transition: background-color 500ms linear;
+  padding: 0.5rem 1rem;
+
+  &.fixed-bottom,
+  &.fixed-top {
+    position: fixed;
+    right: 0;
+    left: 0;
+    z-index: 1030;
+  }
+
+  &.bg-transparent {
+    background-color: transparent !important;
+  }
 
   .navbar-toggler {
     outline: none !important;
@@ -31,6 +44,10 @@
 
   &.navbar-dti-light {
     box-shadow: 0 2px 7px 0 rgba(0, 0, 0, 0.3);
+  }
+
+  .navbar-nav {
+    margin-left: auto;
   }
 
   @media (min-width: 992px) {

--- a/dti-website/src/components/DtiMainMenu.tsx
+++ b/dti-website/src/components/DtiMainMenu.tsx
@@ -97,7 +97,7 @@ export default function DtiMainMenu({ light }: Props): JSX.Element {
       </Button>
 
       <Navbar.Collapse id="nav_collapse" style={navShown ? {} : { display: 'none' }}>
-        <ul className="navbar-nav ml-auto">
+        <ul className="navbar-nav">
           <NavItem to="/">Home</NavItem>
           <NavItem to="/team/">Team</NavItem>
           <NavItem to="/projects/">Projects</NavItem>

--- a/dti-website/src/components/HeadshotCard.scss
+++ b/dti-website/src/components/HeadshotCard.scss
@@ -22,6 +22,17 @@
     height: 6.5rem;
     flex-grow: 1;
 
+    .col {
+      padding: 0 calc(var(--bs-gutter-x) * 0.25);
+    }
+
+    .h-75 {
+      height: 75%;
+    }
+    .h-25 {
+      height: 25%;
+    }
+
     .name {
       font-size: 1.125rem;
       font-weight: 500;
@@ -49,6 +60,10 @@
   .image-row {
     height: 12rem;
     overflow: hidden;
+
+    .col {
+      padding: 0;
+    }
   }
 
   img {

--- a/dti-website/src/components/MemberProfile.tsx
+++ b/dti-website/src/components/MemberProfile.tsx
@@ -7,7 +7,7 @@ import GitHub from '../assets/social/github.svg';
 import LinkedIn from '../assets/social/linkedin.svg';
 import MissingImage from '../assets/other/missing.svg';
 
-import { teams as teamsJson } from '../data/sets/teams.json';
+import teamsJson from '../data/sets/teams.json';
 
 type Props = {
   readonly profile: { readonly info: NovaMember };
@@ -31,7 +31,7 @@ export default function MemberProfile({ profile, className }: Props): JSX.Elemen
   else allSubteams = [];
 
   const teams = allSubteams
-    .map((team) => teamsJson.find((teamData) => teamData.id === team))
+    .map((team) => teamsJson.teams.find((teamData) => teamData.id === team))
     .filter((d): d is Team => d != null);
 
   return (

--- a/dti-website/src/pages/courses.scss
+++ b/dti-website/src/pages/courses.scss
@@ -191,4 +191,8 @@ $dark-gray: #4a4a4a;
   &-small {
     font-size: 1.3rem;
   }
+
+  &-inline {
+    width: auto;
+  }
 }

--- a/dti-website/src/pages/courses.tsx
+++ b/dti-website/src/pages/courses.tsx
@@ -102,7 +102,7 @@ export default function CoursesPage(): JSX.Element {
                   <Button
                     variant="secondary"
                     href={c.courseWebsiteLink}
-                    className="social-button-red social-button-small"
+                    className="social-button-red social-button-small social-button-inline"
                   >
                     <div className="course-website-text">Course Textbook</div>
                   </Button>

--- a/dti-website/src/pages/sponsor.scss
+++ b/dti-website/src/pages/sponsor.scss
@@ -124,7 +124,6 @@
     font-size: 1.5625rem;
     margin: auto;
     text-align: center;
-    width: 90%;
   }
 
   margin-bottom: 6rem;
@@ -136,7 +135,6 @@
     font-size: 1.5625rem;
     margin: auto;
     text-align: center;
-    width: 70%;
   }
 }
 
@@ -262,4 +260,8 @@
       }
     }
   }
+}
+
+.contact-us-btn {
+  width: auto;
 }

--- a/dti-website/src/pages/sponsor.tsx
+++ b/dti-website/src/pages/sponsor.tsx
@@ -193,7 +193,11 @@ export default function SponsorPage(): JSX.Element {
               <h2>Sponsor us to help make community impact!</h2>
             </Row>
             <Row className="justify-content-center sponsor-contact">
-              <Button variant="secondary" href="mailto:hello@cornelldti.org">
+              <Button
+                variant="secondary"
+                href="mailto:hello@cornelldti.org"
+                className="contact-us-btn"
+              >
                 Contact Us
               </Button>
             </Row>

--- a/dti-website/src/pages/team.scss
+++ b/dti-website/src/pages/team.scss
@@ -2,6 +2,14 @@
   $primary: #ff324a;
   $secondary: #f6f6f6;
 
+  .h-100 {
+    height: 100%;
+  }
+
+  .percentage-number-donut {
+    font-size: 1.25em;
+  }
+
   .team-hero {
     height: 80vh;
     width: 100vw;
@@ -77,6 +85,7 @@
     color: #ffffff;
 
     .graph-datum-description {
+      text-align: center;
       font-size: 1.5rem;
       font-size: 1.125rem;
       letter-spacing: 0.7px;

--- a/dti-website/src/pages/team.tsx
+++ b/dti-website/src/pages/team.tsx
@@ -70,11 +70,15 @@ export default function TeamPage(): JSX.Element {
                         <div className="text-center graph-data h-100">
                           <Row className="h-100 align-items-center">
                             <Col className="col-6 graph-datum">
-                              <h3>{`${Math.round(100 * malePercentage)}%`}</h3>
+                              <h3 className="percentage-number-donut">{`${Math.round(
+                                100 * malePercentage
+                              )}%`}</h3>
                               <p className="graph-datum-description">Male</p>
                             </Col>
                             <Col className="col-6 graph-datum red">
-                              <h3>{`${Math.round(100 * femalePercentage)}%`}</h3>
+                              <h3 className="percentage-number-donut">{`${Math.round(
+                                100 * femalePercentage
+                              )}%`}</h3>
                               <p className="graph-datum-description">Female</p>
                             </Col>
                           </Row>

--- a/dti-website/src/pages/team.tsx
+++ b/dti-website/src/pages/team.tsx
@@ -12,13 +12,13 @@ import PageSection from '../components/PageSection';
 import RoleSelector, { RoleId } from '../components/RoleSelector';
 
 import members from '../data/all-members.json';
-import { diversity } from '../data/sets/diversity.json';
+import diversityJSON from '../data/sets/diversity.json';
 
 export default function TeamPage(): JSX.Element {
   const [roleId, setRoleId] = useState<RoleId>('');
 
-  const malePercentage = 1 - diversity.femalePercentage[roleId];
-  const femalePercentage = diversity.femalePercentage[roleId];
+  const malePercentage = 1 - diversityJSON.diversity.femalePercentage[roleId];
+  const femalePercentage = diversityJSON.diversity.femalePercentage[roleId];
 
   const filterMembers = (role = '', isLead = false): readonly { info: NovaMember; id: string }[] =>
     (members as NovaMember[])

--- a/dti-website/src/scss/index.scss
+++ b/dti-website/src/scss/index.scss
@@ -4,7 +4,6 @@
 @import '~bootstrap/scss/bootstrap-grid';
 @import '~bootstrap/scss/buttons';
 @import '~bootstrap/scss/card';
-@import '~bootstrap/scss/custom-forms';
 @import '~bootstrap/scss/modal';
 @import '~bootstrap/scss/nav';
 @import '~bootstrap/scss/navbar';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4454,10 +4454,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"
-  integrity sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==
+bootstrap@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.1.tgz#9d6eed81e08feaccedf3adaca51fe4b73a2871df"
+  integrity sha512-/jUa4sSuDZWlDLQ1gwQQR8uoYSvLJzDd8m5o6bPKh3asLAMYVZKdRCjb1joUd5WXf0WwCNzd2EjwQQhupou0dA==
 
 boxen@^1.2.1:
   version "1.3.0"


### PR DESCRIPTION
### Summary <!-- Required -->

Bootstrap 4's scss uses a lot of deprecated features, and it's causing a lot of non-actionable warnings in the build.
In this PR, I migrated it to bootstrap 5 to eliminate all the build warnings and keep things up-to-date.

Changed items:
- navbar
- footer
- profile card
- donut graph
- sponsor page and courses page buttons

### Test Plan <!-- Required -->

Check each page to see nothing goes wrong.