### PR TITLE
Fix backend testing config 

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Format
         run: yarn format:check
       - name: Test
+        env:
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          FIREBASE_PRIVATE_KEY_ID: ${{ secrets.FIREBASE_PRIVATE_KEY_ID }}
+          USE_PROD_DB: ${{ secrets.USE_PROD_DB }}
         run: yarn test
   build:
     runs-on: ubuntu-latest

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -1,0 +1,1 @@
+require('dotenv').config({ path: 'backend/.env' });

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,10 +23,11 @@ module.exports = {
     },
     {
       displayName: 'IDOL Backend Tests',
-      testMatch: ['<rootDir>/backend/**/*.test.ts'],
+      testMatch: ['<rootDir>/**/*.test.ts'],
       transform: {
         '^.+\\.(ts|tsx)$': 'babel-jest'
       },
+      setupFiles: ['backend/tests/setup.ts'],
       rootDir: '<rootDir>/backend/'
     }
   ]


### PR DESCRIPTION
### Summary <!-- Required -->
Fixed the config for jest backend testing, the original config for testing the backend wasn't finding any tests.

Changes:
- `testMatch`: changed from `<rootDir>/backend/**/*.test.ts` to `<rootDir>/**/*.test.ts'`
- `backend/tests/setup.ts`: created setup file to configure `.env` when running tests locally 

Also added Firebase private keys to repo secrets so that Firebase can be configured during test workflow 

### Test Plan <!-- Required -->
Test step now runs `IDOL Backend Tests` in CI checks and pass 

