### PR TITLE
Speed up website builds

### DIFF
--- a/dti-website/next.config.js
+++ b/dti-website/next.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   webpack5: true,
+  experimental: { swcLoader: true },
+  typescript: { ignoreBuildErrors: true },
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   webpack5: true,
+  experimental: { swcLoader: true },
+  typescript: { ignoreBuildErrors: true },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
### Summary <!-- Required -->

- Skip type checking during build since it's checked in other CI scripts
- Use rust-based swc tooling: https://nextjs.org/blog/next-11-1#adopting-rust-based-swc

### Test Plan <!-- Required -->

CI. Preview shouldn't change.