### PR TITLE
Fix issue with sign in form creator page forever loading 

### DIFF
--- a/frontend/src/components/Common/UserProvider.tsx
+++ b/frontend/src/components/Common/UserProvider.tsx
@@ -22,6 +22,8 @@ export const useUserEmail = (): string => {
 
 let cachedUser: User | null = null;
 
+let updateCachedUser = async (userAuth: User) => (cachedUser = userAuth);
+
 export const getUserIdToken = async (): Promise<string | null> => {
   if (cachedUser == null) return null;
   return cachedUser.getIdToken();
@@ -29,13 +31,11 @@ export const getUserIdToken = async (): Promise<string | null> => {
 
 export default function UserProvider({ children }: { readonly children: ReactNode }): JSX.Element {
   const [user, setUser] = useState<UserContextType>('INIT');
-
   useEffect(
     () =>
       auth.onAuthStateChanged(async (userAuth) => {
         if (userAuth) {
-          setUser({ email: getUserEmail(userAuth) });
-          cachedUser = userAuth;
+          updateCachedUser(userAuth).then(() => setUser({ email: getUserEmail(userAuth) }));
         } else {
           setUser(null);
         }

--- a/frontend/src/components/Common/UserProvider.tsx
+++ b/frontend/src/components/Common/UserProvider.tsx
@@ -22,7 +22,9 @@ export const useUserEmail = (): string => {
 
 let cachedUser: User | null = null;
 
-let updateCachedUser = async (userAuth: User) => (cachedUser = userAuth);
+const updateCachedUser = async (userAuth: User) => {
+  cachedUser = userAuth;
+};
 
 export const getUserIdToken = async (): Promise<string | null> => {
   if (cachedUser == null) return null;


### PR DESCRIPTION
### Summary <!-- Required -->
On page reload, the page would be stuck on the loading symbol.

![image](https://user-images.githubusercontent.com/65922473/137570459-f54bf669-6a99-4010-922c-14f5a7ffeced.png)

Seemed like it was an issue with async commands executing in the wrong order in `UserProvider.tsx`
```
setUser({ email: getUserEmail(userAuth) });
cachedUser = userAuth;
```
where `setUser` was completing before `cacheduser = userAuth` causing `cachedUser` to be `null`. 

The solution in this PR is just to chain the commands with `.then()` so the assignment always finishes first. 

### Test Plan <!-- Required -->
Check on netlify preview that sign in forms load after refresh 