### PR TITLE
[easy] A small framework to hide entry point if user is not admin

### DIFF
--- a/frontend/src/components/Common/NavigationCard.tsx
+++ b/frontend/src/components/Common/NavigationCard.tsx
@@ -1,38 +1,49 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Card, Button } from 'semantic-ui-react';
 import styles from './NavigationCard.module.css';
+import PermissionsAPI from '../../API/PermissionsAPI';
 
 export type NavigationCardItem = {
   readonly header: string;
   readonly description: string;
   readonly link: string;
+  readonly unstable?: boolean;
 };
 
 type Props = { readonly testID?: string; readonly items: readonly NavigationCardItem[] };
 
 export default function NavigationCard({ testID, items }: Props): JSX.Element {
+  const [allowUnstable, setAllowUnstable] = useState(false);
+
+  useEffect(() => {
+    PermissionsAPI.isAdmin().then(({ isAdmin }) => setAllowUnstable(isAdmin));
+  }, []);
+
   return (
     <div data-testid={testID}>
       <div className={styles.content}>
         <Card.Group>
-          {items.map(({ header, description, link }) => (
-            <Card key={link}>
-              <Card.Content>
-                <Card.Header>{header}</Card.Header>
-                <Card.Description>{description}</Card.Description>
-              </Card.Content>
-              <Card.Content extra>
-                <div className="ui one buttons">
-                  <Link href={link}>
-                    <Button basic color="blue">
-                      Go To
-                    </Button>
-                  </Link>
-                </div>
-              </Card.Content>
-            </Card>
-          ))}
+          {items.map(
+            ({ header, description, link, unstable }) =>
+              (!unstable || allowUnstable) && (
+                <Card key={link}>
+                  <Card.Content>
+                    <Card.Header>{header}</Card.Header>
+                    <Card.Description>{description}</Card.Description>
+                  </Card.Content>
+                  <Card.Content extra>
+                    <div className="ui one buttons">
+                      <Link href={link}>
+                        <Button basic color="blue">
+                          Go To
+                        </Button>
+                      </Link>
+                    </div>
+                  </Card.Content>
+                </Card>
+              )
+          )}
         </Card.Group>
       </div>
     </div>

--- a/frontend/src/pages/admin/hidden.tsx
+++ b/frontend/src/pages/admin/hidden.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function HiddenPage(): JSX.Element {
+  return <div>An example hidden page.</div>;
+}

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -26,6 +26,12 @@ const navCardItems: readonly NavigationCardItem[] = [
     header: 'Edit Teams',
     description: 'Create, read, edit, or delete teams in the system.',
     link: '/admin/teams/edit'
+  },
+  {
+    header: 'Example Unstable Hidden Page',
+    description: 'An example page visible to admin only. It can be used to gate unstable features.',
+    link: '/admin/hidden',
+    unstable: true
   }
 ];
 


### PR DESCRIPTION
### Summary <!-- Required -->

Add `unstable: true` to a navigation card data and they will be hidden if you are not admin.

### Test Plan <!-- Required -->

Added an example hidden page for admin. It will not be visible if you are not admin.

<img width="1792" alt="Screen Shot 2021-10-30 at 17 14 59" src="https://user-images.githubusercontent.com/4290500/139558550-ef564623-a8f9-4044-a570-e7fbc8ca1a9d.png">

