### PR TITLE
Fix search bar error for members

### DIFF
--- a/backend/tests/data/jagger-profile.json
+++ b/backend/tests/data/jagger-profile.json
@@ -1,8 +1,8 @@
 {
   "graduation": "May 2021",
   "website": "https://jagger.netlify.app/",
-  "subteams": ["leads", "dev-leads"],
-  "formerSubteams": ["idol"],
+  "subteams": ["dev-leads"],
+  "formerSubteams": [],
   "github": "https://github.com/JBoss925/",
   "linkedin": "https://www.linkedin.com/in/jagger-brulato-896968149/",
   "hometown": "Mooresville, NC",
@@ -12,7 +12,7 @@
   "email": "jb2375@cornell.edu",
   "major": "Computer Science",
   "netid": "jb2375",
-  "doubleMajor": "Economics",
+  "doubleMajor": "Economics", 
   "lastName": "Brulato",
   "about": "Hey! I'm Jagger. I'm a senior majoring in CS and Economics. I like to make funk-fusion music, and I do a lot of board sports. I also play a lot of chess (d4 > e4, @Fischer) and Tetris.",
   "role": "lead"

--- a/frontend/src/components/Admin/EditTeam.tsx
+++ b/frontend/src/components/Admin/EditTeam.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-  Card,
-  Loader,
-  Button,
-  Form,
-  Input,
-  Label,
-  Segment,
-  StrictRatingIconProps
-} from 'semantic-ui-react';
+import { Card, Loader, Button, Form, Input, Label, Segment } from 'semantic-ui-react';
 import styles from './EditTeam.module.css';
 import ErrorModal from '../Modals/ErrorModal';
 import { APICache, Emitters } from '../../utils';
@@ -44,20 +35,6 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
         });
       });
     });
-  }
-
-  checkMembers(queryLower: string, member: Member): boolean {
-    return (
-      (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
-      (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
-      (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
-      (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
-      ((member.firstName &&
-        member.lastName &&
-        `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
-          queryLower
-        )) as boolean)
-    );
   }
 
   createNewTeam(): void {
@@ -241,7 +218,19 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         )}
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
-                          return this.checkMembers(queryLower, member);
+                          return (
+                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName &&
+                              member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName &&
+                              member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
+                            ((member.firstName &&
+                              member.lastName &&
+                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
+                                queryLower
+                              )) as boolean)
+                          );
                         }}
                         selectCallback={(mem: Member) => {
                           if (this.state.currentSelectedTeam) {
@@ -304,7 +293,19 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         )}
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
-                          return this.checkMembers(queryLower, member);
+                          return (
+                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName &&
+                              member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName &&
+                              member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
+                            ((member.firstName &&
+                              member.lastName &&
+                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
+                                queryLower
+                              )) as boolean)
+                          );
                         }}
                         selectCallback={(mem: Member) => {
                           if (this.state.currentSelectedTeam) {
@@ -367,7 +368,19 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         )}
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
-                          return this.checkMembers(queryLower, member);
+                          return (
+                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName &&
+                              member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName &&
+                              member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
+                            ((member.firstName &&
+                              member.lastName &&
+                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
+                                queryLower
+                              )) as boolean)
+                          );
                         }}
                         selectCallback={(mem: Member) => {
                           if (this.state.currentSelectedTeam) {

--- a/frontend/src/components/Admin/EditTeam.tsx
+++ b/frontend/src/components/Admin/EditTeam.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Card, Loader, Button, Form, Input, Label, Segment } from 'semantic-ui-react';
+import {
+  Card,
+  Loader,
+  Button,
+  Form,
+  Input,
+  Label,
+  Segment,
+  StrictRatingIconProps
+} from 'semantic-ui-react';
 import styles from './EditTeam.module.css';
 import ErrorModal from '../Modals/ErrorModal';
 import { APICache, Emitters } from '../../utils';
@@ -35,6 +44,20 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
         });
       });
     });
+  }
+
+  checkMembers(queryLower: string, member: Member): boolean {
+    return (
+      (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
+      (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
+      (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
+      (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
+      ((member.firstName &&
+        member.lastName &&
+        `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
+          queryLower
+        )) as boolean)
+    );
   }
 
   createNewTeam(): void {
@@ -218,19 +241,7 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         )}
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
-                          return (
-                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName &&
-                              member.firstName.toLowerCase().startsWith(queryLower)) ||
-                            (member.lastName &&
-                              member.lastName.toLowerCase().startsWith(queryLower)) ||
-                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
-                            ((member.firstName &&
-                              member.lastName &&
-                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
-                                queryLower
-                              )) as boolean)
-                          );
+                          return this.checkMembers(queryLower, member);
                         }}
                         selectCallback={(mem: Member) => {
                           if (this.state.currentSelectedTeam) {
@@ -293,19 +304,7 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         )}
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
-                          return (
-                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName &&
-                              member.firstName.toLowerCase().startsWith(queryLower)) ||
-                            (member.lastName &&
-                              member.lastName.toLowerCase().startsWith(queryLower)) ||
-                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
-                            ((member.firstName &&
-                              member.lastName &&
-                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
-                                queryLower
-                              )) as boolean)
-                          );
+                          return this.checkMembers(queryLower, member);
                         }}
                         selectCallback={(mem: Member) => {
                           if (this.state.currentSelectedTeam) {
@@ -368,19 +367,7 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         )}
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
-                          return (
-                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName &&
-                              member.firstName.toLowerCase().startsWith(queryLower)) ||
-                            (member.lastName &&
-                              member.lastName.toLowerCase().startsWith(queryLower)) ||
-                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
-                            ((member.firstName &&
-                              member.lastName &&
-                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
-                                queryLower
-                              )) as boolean)
-                          );
+                          return this.checkMembers(queryLower, member);
                         }}
                         selectCallback={(mem: Member) => {
                           if (this.state.currentSelectedTeam) {

--- a/frontend/src/components/Admin/EditTeam.tsx
+++ b/frontend/src/components/Admin/EditTeam.tsx
@@ -220,13 +220,16 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                           const queryLower = query.toLowerCase();
                           return (
                             (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
-                            (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName &&
+                              member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName &&
+                              member.lastName.toLowerCase().startsWith(queryLower)) ||
                             (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName && member.lastName && 
+                            ((member.firstName &&
+                              member.lastName &&
                               `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
-                              queryLower
-                            )) as boolean 
+                                queryLower
+                              )) as boolean)
                           );
                         }}
                         selectCallback={(mem: Member) => {
@@ -292,13 +295,16 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                           const queryLower = query.toLowerCase();
                           return (
                             (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
-                            (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName &&
+                              member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName &&
+                              member.lastName.toLowerCase().startsWith(queryLower)) ||
                             (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName && member.lastName && 
+                            ((member.firstName &&
+                              member.lastName &&
                               `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
-                              queryLower
-                            )) as boolean 
+                                queryLower
+                              )) as boolean)
                           );
                         }}
                         selectCallback={(mem: Member) => {
@@ -364,13 +370,16 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                           const queryLower = query.toLowerCase();
                           return (
                             (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
-                            (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName &&
+                              member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName &&
+                              member.lastName.toLowerCase().startsWith(queryLower)) ||
                             (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
-                            (member.firstName && member.lastName && 
+                            ((member.firstName &&
+                              member.lastName &&
                               `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
-                              queryLower
-                            )) as boolean 
+                                queryLower
+                              )) as boolean)
                           );
                         }}
                         selectCallback={(mem: Member) => {

--- a/frontend/src/components/Admin/EditTeam.tsx
+++ b/frontend/src/components/Admin/EditTeam.tsx
@@ -219,13 +219,14 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
                           return (
-                            member.email.toLowerCase().startsWith(queryLower) ||
-                            member.firstName.toLowerCase().startsWith(queryLower) ||
-                            member.lastName.toLowerCase().startsWith(queryLower) ||
-                            member.role.toLowerCase().startsWith(queryLower) ||
-                            `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
+                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName && member.lastName && 
+                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
                               queryLower
-                            )
+                            )) as boolean 
                           );
                         }}
                         selectCallback={(mem: Member) => {
@@ -290,13 +291,14 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
                           return (
-                            member.email.toLowerCase().startsWith(queryLower) ||
-                            member.firstName.toLowerCase().startsWith(queryLower) ||
-                            member.lastName.toLowerCase().startsWith(queryLower) ||
-                            member.role.toLowerCase().startsWith(queryLower) ||
-                            `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
+                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName && member.lastName && 
+                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
                               queryLower
-                            )
+                            )) as boolean 
                           );
                         }}
                         selectCallback={(mem: Member) => {
@@ -361,13 +363,14 @@ class EditTeam extends React.Component<Record<string, unknown>, EditTeamState> {
                         matchChecker={(query: string, member: Member) => {
                           const queryLower = query.toLowerCase();
                           return (
-                            member.email.toLowerCase().startsWith(queryLower) ||
-                            member.firstName.toLowerCase().startsWith(queryLower) ||
-                            member.lastName.toLowerCase().startsWith(queryLower) ||
-                            member.role.toLowerCase().startsWith(queryLower) ||
-                            `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
+                            (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
+                            (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
+                            (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
+                            (member.firstName && member.lastName && 
+                              `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
                               queryLower
-                            )
+                            )) as boolean 
                           );
                         }}
                         selectCallback={(mem: Member) => {

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -92,10 +92,11 @@ const ShoutoutForm: React.FC = () => {
                 (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
                 (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
                 (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
-                (member.firstName && member.lastName && 
+                ((member.firstName &&
+                  member.lastName &&
                   `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
-                  queryLower
-                )) as boolean 
+                    queryLower
+                  )) as boolean)
               );
             }}
             selectCallback={(mem: Member) => {

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -88,13 +88,14 @@ const ShoutoutForm: React.FC = () => {
             matchChecker={(query: string, member: Member) => {
               const queryLower = query.toLowerCase();
               return (
-                member.email.toLowerCase().startsWith(queryLower) ||
-                member.firstName.toLowerCase().startsWith(queryLower) ||
-                member.lastName.toLowerCase().startsWith(queryLower) ||
-                member.role.toLowerCase().startsWith(queryLower) ||
-                `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
+                (member.email && member.email.toLowerCase().startsWith(queryLower)) ||
+                (member.firstName && member.firstName.toLowerCase().startsWith(queryLower)) ||
+                (member.lastName && member.lastName.toLowerCase().startsWith(queryLower)) ||
+                (member.role && member.role.toLowerCase().startsWith(queryLower)) ||
+                (member.firstName && member.lastName && 
+                  `${member.firstName.toLowerCase()} ${member.lastName.toLowerCase()}`.startsWith(
                   queryLower
-                )
+                )) as boolean 
               );
             }}
             selectCallback={(mem: Member) => {


### PR DESCRIPTION
Co-authored-by: Henry Li <hl738@cornell.edu>

### Summary <!-- Required -->

This fixed the issue where the search bar for members was not auto-populating search results. The issue was resolved by checking that the field for a member was not null before trying to match it to what was being searched. 

### Test Plan <!-- Required -->

Tested on local machine and was able to find a member and add/delete them from a team. 