### PR TITLE
Setup firestore listeners for members and approved members collection

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   webpack5: true,
   typescript: { ignoreBuildErrors: true },
-  swcMinify: true,
   async rewrites() {
     return [
       {

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -36,9 +36,17 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
       };
     }
     const unsubscriberOfMembers = onSnapshot(membersCollection, (snapshot) => {
+      console.log(
+        'members',
+        snapshot.docs.map((it) => it.data())
+      );
       setMembers(snapshot.docs.map((it) => it.data()));
     });
     const unsubscriberOfApprovedMembers = onSnapshot(approvedMembersCollection, (snapshot) => {
+      console.log(
+        'approved-members',
+        snapshot.docs.map((it) => it.data())
+      );
       setApprovedMembers(snapshot.docs.map((it) => it.data()));
     });
     return () => {

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -1,0 +1,59 @@
+import { Loader } from 'semantic-ui-react';
+import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import { onSnapshot } from 'firebase/firestore';
+import { membersCollection, approvedMembersCollection } from '../../firebase';
+import { useUserEmail } from './UserProvider';
+
+type ListenedFirestoreData = {
+  readonly members?: readonly IdolMember[];
+  readonly approvedMembers?: readonly IdolMember[];
+};
+
+const FirestoreDataContext = createContext<ListenedFirestoreData>({});
+
+export const useApprovedMembers = (): readonly IdolMember[] =>
+  useContext(FirestoreDataContext).approvedMembers || [];
+
+export const useMembers = (): readonly IdolMember[] =>
+  useContext(FirestoreDataContext).members || [];
+
+/** @returns a member with given `email`, or `undefined` if there is no such member. */
+export const useMember = (email: string): IdolMember | undefined =>
+  useMembers().find((it) => it.email === email);
+
+/** @returns yourself as a member, or `undefined` if data is not properly initialized. */
+export const useSelf = (): IdolMember | undefined => useMember(useUserEmail());
+
+type Props = { readonly children: ReactNode };
+
+export default function FirestoreDataProvider({ children }: Props): JSX.Element {
+  const [members, setMembers] = useState<readonly IdolMember[] | undefined>();
+  const [approvedMembers, setApprovedMembers] = useState<readonly IdolMember[] | undefined>();
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'test') {
+      return () => {
+        // Do not run firestore listeners in test environment.
+      };
+    }
+    const unsubscriberOfMembers = onSnapshot(membersCollection, (snapshot) => {
+      setMembers(snapshot.docs.map((it) => it.data()));
+    });
+    const unsubscriberOfApprovedMembers = onSnapshot(approvedMembersCollection, (snapshot) => {
+      setApprovedMembers(snapshot.docs.map((it) => it.data()));
+    });
+    return () => {
+      unsubscriberOfMembers();
+      unsubscriberOfApprovedMembers();
+    };
+  }, []);
+
+  return (
+    <FirestoreDataContext.Provider value={{ members, approvedMembers }}>
+      {members == null || approvedMembers == null ? (
+        <Loader active={true} size="massive" />
+      ) : (
+        children
+      )}
+    </FirestoreDataContext.Provider>
+  );
+}

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -36,17 +36,9 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
       };
     }
     const unsubscriberOfMembers = onSnapshot(membersCollection, (snapshot) => {
-      console.log(
-        'members',
-        snapshot.docs.map((it) => it.data())
-      );
       setMembers(snapshot.docs.map((it) => it.data()));
     });
     const unsubscriberOfApprovedMembers = onSnapshot(approvedMembersCollection, (snapshot) => {
-      console.log(
-        'approved-members',
-        snapshot.docs.map((it) => it.data())
-      );
       setApprovedMembers(snapshot.docs.map((it) => it.data()));
     });
     return () => {

--- a/frontend/src/components/Common/Search.tsx
+++ b/frontend/src/components/Common/Search.tsx
@@ -42,7 +42,7 @@ function makeReducer<T>() {
 }
 
 type CustomSearchProps<T> = {
-  source: T[];
+  source: readonly T[];
   resultRenderer?: (props: SearchResultProps) => React.ReactElement;
   matchChecker: (input: string, object: T) => boolean;
   selectCallback: (selected: T) => void;

--- a/frontend/src/components/Common/UserProvider.tsx
+++ b/frontend/src/components/Common/UserProvider.tsx
@@ -35,13 +35,17 @@ export default function UserProvider({ children }: { readonly children: ReactNod
   const [user, setUser] = useState<UserContextType>('INIT');
   useEffect(
     () =>
-      auth.onAuthStateChanged(async (userAuth) => {
-        if (userAuth) {
-          updateCachedUser(userAuth).then(() => setUser({ email: getUserEmail(userAuth) }));
-        } else {
-          setUser(null);
-        }
-      }),
+      process.env.NODE_ENV === 'test'
+        ? () => {
+            // Do not run firebase auth in test environment.
+          }
+        : auth.onAuthStateChanged(async (userAuth) => {
+            if (userAuth) {
+              updateCachedUser(userAuth).then(() => setUser({ email: getUserEmail(userAuth) }));
+            } else {
+              setUser(null);
+            }
+          }),
     []
   );
 

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -10,7 +10,6 @@ import { useMembers } from '../../Common/FirestoreDataProvider';
 const ShoutoutForm: React.FC = () => {
   const userEmail = useUserEmail();
   const members = useMembers();
-  console.log(members);
   const user = members.find((it) => it.email === userEmail);
   const [recipient, setRecipient] = useState<IdolMember | undefined>(undefined);
   const [message, setMessage] = useState('');

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -1,30 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Form, TextArea, Segment, Label, Button, Checkbox } from 'semantic-ui-react';
 import { useUserEmail } from '../../Common/UserProvider';
 import CustomSearch from '../../Common/Search';
 import { Emitters } from '../../../utils';
-import { Member, MembersAPI } from '../../../API/MembersAPI';
+import { Member } from '../../../API/MembersAPI';
 import { Shoutout, ShoutoutsAPI } from '../../../API/ShoutoutsAPI';
+import { useMembers } from '../../Common/FirestoreDataProvider';
 
 const ShoutoutForm: React.FC = () => {
   const userEmail = useUserEmail();
-  const [members, setMembers] = useState<IdolMember[] | undefined>(undefined);
-  const [user, setUser] = useState<IdolMember | undefined>(undefined);
+  const members = useMembers();
+  const user = members.find((it) => it.email === userEmail);
   const [recipient, setRecipient] = useState<IdolMember | undefined>(undefined);
   const [message, setMessage] = useState('');
   const [isAnon, setIsAnon] = useState(false);
-
-  useEffect(() => {
-    MembersAPI.getAllMembers()
-      .then((mems) => {
-        setMembers(mems);
-      })
-      .then(() => {
-        if (userEmail) {
-          MembersAPI.getMember(userEmail).then((mem) => setUser(mem));
-        }
-      });
-  }, [userEmail]);
 
   const giveShoutout = () => {
     if (!recipient) {
@@ -76,7 +65,7 @@ const ShoutoutForm: React.FC = () => {
       </label>
 
       <div style={{ display: 'flex', alignItems: 'center' }}>
-        {members && !recipient ? (
+        {!recipient ? (
           <CustomSearch
             source={members}
             resultRenderer={(mem) => (

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -10,6 +10,7 @@ import { useMembers } from '../../Common/FirestoreDataProvider';
 const ShoutoutForm: React.FC = () => {
   const userEmail = useUserEmail();
   const members = useMembers();
+  console.log(members);
   const user = members.find((it) => it.email === userEmail);
   const [recipient, setRecipient] = useState<IdolMember | undefined>(undefined);
   const [message, setMessage] = useState('');

--- a/frontend/src/firebase.ts
+++ b/frontend/src/firebase.ts
@@ -1,5 +1,6 @@
 import { getApps, initializeApp } from 'firebase/app';
 import { Auth, getAuth, GoogleAuthProvider } from 'firebase/auth';
+import { Firestore, getFirestore, collection } from 'firebase/firestore';
 import { useProdDb } from './environment';
 
 const firebaseConfig = useProdDb
@@ -27,3 +28,21 @@ if (!getApps().length) initializeApp(firebaseConfig);
 
 export const auth: Auth = getAuth();
 export const provider: GoogleAuthProvider = new GoogleAuthProvider();
+
+const firestore: Firestore = getFirestore();
+export const membersCollection = collection(firestore, 'members').withConverter({
+  fromFirestore(snapshot): IdolMember {
+    return snapshot.data() as IdolMember;
+  },
+  toFirestore(teamEventData: IdolMember) {
+    return teamEventData;
+  }
+});
+export const approvedMembersCollection = collection(firestore, 'approved-members').withConverter({
+  fromFirestore(snapshot): IdolMember {
+    return snapshot.data() as IdolMember;
+  },
+  toFirestore(teamEventData: IdolMember) {
+    return teamEventData;
+  }
+});

--- a/frontend/src/firebase.ts
+++ b/frontend/src/firebase.ts
@@ -24,12 +24,12 @@ const firebaseConfig = useProdDb
       measurementId: 'G-2QB5YJ3CHC'
     };
 
-if (!getApps().length) initializeApp(firebaseConfig);
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApps()[0];
 
-export const auth: Auth = getAuth();
+export const auth: Auth = getAuth(app);
 export const provider: GoogleAuthProvider = new GoogleAuthProvider();
 
-const firestore: Firestore = getFirestore();
+const firestore: Firestore = getFirestore(app);
 export const membersCollection = collection(firestore, 'members').withConverter({
   fromFirestore(snapshot): IdolMember {
     return snapshot.data() as IdolMember;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Sidebar, Menu, Icon, Loader } from 'semantic-ui-react';
 import SignIn from '../components/Common/SignIn.lazy';
 import UserProvider, { useUserContext } from '../components/Common/UserProvider';
+import FirestoreDataProvider from '../components/Common/FirestoreDataProvider';
 import SiteHeader from '../components/Common/SiteHeader';
 import { Emitters } from '../utils';
 import EmailNotFoundErrorModal from '../components/Modals/EmailNotFoundErrorModal';
@@ -32,7 +33,9 @@ export default function AppTemplate(props: AppProps): JSX.Element {
       </Head>
       <UserProvider>
         <AppContent>
-          <Component {...pageProps} />
+          <FirestoreDataProvider>
+            <Component {...pageProps} />
+          </FirestoreDataProvider>
         </AppContent>
       </UserProvider>
     </>


### PR DESCRIPTION
### Summary <!-- Required -->

By listening these data in real-time, we can avoid API calls to the backend here and there, and make the dev experience a lot better by avoiding a lot of async calls. See https://firebase.google.com/docs/firestore/query-data/listen

I migrated some of the components to use the new API, but more remains unmigrated to keep this PR small.

### Test Plan <!-- Required -->

Affected pages (shortout, site deployer) work without issue.
