### PR TITLE
Fix spacing on teams page role selector 

### DIFF
--- a/dti-website/src/components/RoleSelector.tsx
+++ b/dti-website/src/components/RoleSelector.tsx
@@ -80,7 +80,7 @@ export default function RoleSelector({
           <Col
             md={density === 'compact' ? 'auto' : undefined}
             key={role.id}
-            className="text-center"
+            className="col-auto my-auto text-center"
           >
             <div
               className={btnCSS(roleId === role.id, density, bold, dark)}


### PR DESCRIPTION
### Summary <!-- Required -->

Fix regression on role selector on the teams page. Regression seems to be caused by #159 when Bootstrap version was upgraded to 5.

Current role selector:
![image](https://user-images.githubusercontent.com/65922473/142056487-6db82a65-dd82-4481-987d-90ffb19b56d6.png)

Fixed role selector: 
![image](https://user-images.githubusercontent.com/65922473/142056449-b9ea2183-c529-4e72-976d-1db6efb57459.png)

### Test Plan <!-- Required -->
Check preview