### PR TITLE
edit existing team events

### DIFF
--- a/frontend/src/components/Admin/EditTeamEvent.tsx
+++ b/frontend/src/components/Admin/EditTeamEvent.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Modal, Button } from 'semantic-ui-react';
+import TeamEventForm from './TeamEventForm';
+import { TeamEvent } from './TeamEvents';
+
+const EditTeamEvent = (props: { teamEvent: TeamEvent }): JSX.Element => {
+  const { teamEvent } = props;
+  const [open, setOpen] = useState(false);
+
+  const editTeamEvent = (teamEvent: TeamEvent) => {
+    // send edited event to backend
+  };
+
+  return (
+    <Modal
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
+      open={open}
+      trigger={<Button>Edit Event</Button>}
+    >
+      <Modal.Header>Edit Team Event</Modal.Header>
+      <Modal.Content>
+        <TeamEventForm
+          formType={'edit'}
+          teamEvent={teamEvent}
+          editTeamEvent={editTeamEvent}
+          setOpen={setOpen}
+        ></TeamEventForm>
+      </Modal.Content>
+    </Modal>
+  );
+};
+export default EditTeamEvent;

--- a/frontend/src/components/Admin/TeamEventDetails.module.css
+++ b/frontend/src/components/Admin/TeamEventDetails.module.css
@@ -3,7 +3,7 @@
   margin: 5em auto;
 }
 
-.arrowAndDelete {
+.arrowAndButtons {
   display: flex;
   justify-content: space-between;
 }

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -1,21 +1,13 @@
+import React from 'react';
 import { Card, Message, Modal, Button } from 'semantic-ui-react';
 import Link from 'next/link';
-import { Member } from '../../API/MembersAPI';
+import EditTeamEvent from './EditTeamEvent';
 import styles from './TeamEventDetails.module.css';
-
-type TeamEvent = {
-  uuid: string;
-  name: string;
-  date: string;
-  numCredits: string;
-  hasHours: boolean;
-  membersPending: Member[];
-  membersApproved: Member[];
-};
+import { TeamEvent } from './TeamEvents';
 
 const mockTeamEvent: TeamEvent = {
   name: 'Info Session',
-  date: 'Sept 3',
+  date: '2021-11-17',
   numCredits: '1',
   hasHours: false,
   membersPending: [],
@@ -28,16 +20,20 @@ const TeamEventDetails: React.FC = () => (
   // const { query } = useRouter();
 
   <div className={styles.container}>
-    <div className={styles.arrowAndDelete}>
+    <div className={styles.arrowAndButtons}>
       <Link href="/admin/team-events">
         <span className={styles.arrow}>&#8592;</span>
       </Link>
-      <Modal
-        trigger={<Button color="red">Delete Event</Button>}
-        header="Delete Team Event"
-        content="Are you sure that you want to delete this event?"
-        actions={['Go Back', { key: 'deleteEvent', content: 'Delete Event', color: 'red' }]}
-      />
+
+      <div>
+        <EditTeamEvent teamEvent={mockTeamEvent}></EditTeamEvent>
+        <Modal
+          trigger={<Button color="red">Delete Event</Button>}
+          header="Delete Team Event"
+          content="Are you sure that you want to delete this event?"
+          actions={['Cancel', { key: 'deleteEvent', content: 'Delete Event', color: 'red' }]}
+        />
+      </div>
     </div>
 
     <h1 className={styles.eventName}>{mockTeamEvent.name}</h1>

--- a/frontend/src/components/Admin/TeamEventForm.module.css
+++ b/frontend/src/components/Admin/TeamEventForm.module.css
@@ -1,0 +1,12 @@
+.label {
+  font-weight: bold;
+}
+
+.required {
+  color: #db2828;
+}
+
+.buttonsWrapper {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/frontend/src/components/Admin/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEventForm.tsx
@@ -1,46 +1,23 @@
 import React, { useState } from 'react';
-import { Form, Radio, Card } from 'semantic-ui-react';
-import Link from 'next/link';
+import { Form, Radio, Button } from 'semantic-ui-react';
 import { Emitters } from '../../utils';
-import { Member } from '../../API/MembersAPI';
-import styles from './EditTeamEvents.module.css';
+import styles from './TeamEventForm.module.css';
+import { TeamEvent } from './TeamEvents';
 
-type TeamEvent = {
-  name: string;
-  date: string;
-  numCredits: string;
-  hasHours: boolean;
-  membersPending: Member[];
-  membersApproved: Member[];
-  uuid: string;
+type Props = {
+  formType: string;
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
+  teamEvent?: TeamEvent;
+  editTeamEvent?: (teamEvent: TeamEvent) => void;
 };
 
-const EditTeamEvents: React.FC = () => {
-  const [teamEventName, setTeamEventName] = useState('');
-  const [teamEventDate, setTeamEventDate] = useState('');
-  const [teamEventCreditNum, setTeamEventCreditNum] = useState('');
-  const [teamEventHasHours, setTeamEventHasHours] = useState(false);
+const TeamEventForm = (props: Props): JSX.Element => {
+  const { formType, setOpen, teamEvent, editTeamEvent } = props;
 
-  const teamEvents: TeamEvent[] = [
-    {
-      name: 'Coffee Chat',
-      date: 'Sept 3',
-      numCredits: '0.5',
-      hasHours: false,
-      membersPending: [],
-      membersApproved: [],
-      uuid: '1'
-    },
-    {
-      uuid: '2',
-      name: 'Club Fest',
-      date: 'Sept 5',
-      numCredits: '0.5',
-      hasHours: true,
-      membersPending: [],
-      membersApproved: []
-    }
-  ];
+  const [teamEventName, setTeamEventName] = useState(teamEvent?.name || '');
+  const [teamEventDate, setTeamEventDate] = useState(teamEvent?.date || '');
+  const [teamEventCreditNum, setTeamEventCreditNum] = useState(teamEvent?.numCredits || '');
+  const [teamEventHasHours, setTeamEventHasHours] = useState(teamEvent?.hasHours || false);
 
   const createTeamEvent = (teamEvent: TeamEvent) => {
     // send new event to backend
@@ -67,8 +44,20 @@ const EditTeamEvents: React.FC = () => {
         headerMsg: 'No Team Event Credit Amount',
         contentMsg: 'Please enter how many credits the event is worth!'
       });
+    } else if (teamEvent && editTeamEvent) {
+      const editedTeamEvent: TeamEvent = {
+        ...teamEvent,
+        name: teamEventName,
+        date: teamEventDate,
+        numCredits: teamEventCreditNum,
+        hasHours: teamEventHasHours
+      };
+      editTeamEvent(editedTeamEvent);
+      Emitters.generalSuccess.emit({
+        headerMsg: 'Team Event Updated!',
+        contentMsg: 'The team event was successfully updated!'
+      });
     } else {
-      // fix
       const newTeamEvent: TeamEvent = {
         uuid: '',
         name: teamEventName,
@@ -88,8 +77,7 @@ const EditTeamEvents: React.FC = () => {
 
   return (
     <div>
-      <Form className={styles.form}>
-        <h1>Create a Team Event</h1>
+      <Form>
         <Form.Input
           value={teamEventName}
           onChange={(event) => setTeamEventName(event.target.value)}
@@ -149,28 +137,30 @@ const EditTeamEvents: React.FC = () => {
           />
         </Form.Field>
 
-        <Form.Button floated="right" onClick={submitTeamEvent}>
-          Create Event
-        </Form.Button>
-      </Form>
+        {formType === 'create' && (
+          <Form.Button floated="right" onClick={submitTeamEvent}>
+            Create Event
+          </Form.Button>
+        )}
 
-      <div style={{ width: '60%', margin: 'auto' }}>
-        <h2>View All Team Events</h2>
-        <Card.Group>
-          {teamEvents.map((teamEvent, i) => (
-            <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
-              <Card>
-                <Card.Content>
-                  <Card.Header>{teamEvent.name} </Card.Header>
-                  <Card.Meta>{teamEvent.date}</Card.Meta>
-                </Card.Content>
-              </Card>
-            </Link>
-          ))}
-        </Card.Group>
-      </div>
+        {formType === 'edit' && setOpen && (
+          <div className={styles.buttonsWrapper}>
+            <Button onClick={() => setOpen(false)}>Cancel</Button>
+            <Button
+              content="Save"
+              labelPosition="right"
+              icon="checkmark"
+              onClick={() => {
+                setOpen(false);
+                submitTeamEvent();
+              }}
+              positive
+            />
+          </div>
+        )}
+      </Form>
     </div>
   );
 };
 
-export default EditTeamEvents;
+export default TeamEventForm;

--- a/frontend/src/components/Admin/TeamEvents.module.css
+++ b/frontend/src/components/Admin/TeamEvents.module.css
@@ -1,14 +1,11 @@
-.form {
+.formWrapper {
   width: 60%;
   align-self: center;
   margin: auto;
   padding: 3rem 0 5rem 0;
 }
 
-.label {
-  font-weight: bold;
-}
-
-.required {
-  color: #db2828;
+.eventsWrapper {
+  width: 60%;
+  margin: auto;
 }

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Card } from 'semantic-ui-react';
+import Link from 'next/link';
+import TeamEventForm from './TeamEventForm';
+import { Member } from '../../API/MembersAPI';
+import styles from './TeamEvents.module.css';
+
+export type TeamEvent = {
+  name: string;
+  date: string;
+  numCredits: string;
+  hasHours: boolean;
+  membersPending: Member[];
+  membersApproved: Member[];
+  uuid: string;
+};
+
+const TeamEvents: React.FC = () => {
+  const teamEvents: TeamEvent[] = [
+    {
+      name: 'Coffee Chat',
+      date: '2021-11-17',
+      numCredits: '0.5',
+      hasHours: false,
+      membersPending: [],
+      membersApproved: [],
+      uuid: '1'
+    },
+    {
+      uuid: '2',
+      name: 'Club Fest',
+      date: '2021-11-17',
+      numCredits: '0.5',
+      hasHours: true,
+      membersPending: [],
+      membersApproved: []
+    }
+  ];
+
+  return (
+    <div>
+      <div className={styles.formWrapper}>
+        <h1>Create a Team Event</h1>
+        <TeamEventForm formType={'create'}></TeamEventForm>
+      </div>
+
+      <div className={styles.eventsWrapper}>
+        <h2>View All Team Events</h2>
+        <Card.Group>
+          {teamEvents.map((teamEvent) => (
+            <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
+              <Card>
+                <Card.Content>
+                  <Card.Header>{teamEvent.name} </Card.Header>
+                  <Card.Meta>{teamEvent.date}</Card.Meta>
+                </Card.Content>
+              </Card>
+            </Link>
+          ))}
+        </Card.Group>
+      </div>
+    </div>
+  );
+};
+
+export default TeamEvents;

--- a/frontend/src/pages/admin/team-events.tsx
+++ b/frontend/src/pages/admin/team-events.tsx
@@ -1,3 +1,3 @@
-import EditTeamEvents from '../../components/Admin/EditTeamEvents';
+import TeamEvents from '../../components/Admin/TeamEvents';
 
-export default EditTeamEvents;
+export default TeamEvents;


### PR DESCRIPTION
### Summary

This pull request is the next step towards implementing tracking team event credits on IDOL. On the details page, admin members can edit the details of existing team events.
- [x] edit events
- [x] connect frontend to backend
- [ ] fix date display on details page and make dates optional

### Test Plan

<img width="1397" alt="details" src="https://user-images.githubusercontent.com/49768384/142772492-566d0a42-7813-4ecf-8701-8a51f9493633.png">

<img width="1397" alt="edit-event" src="https://user-images.githubusercontent.com/49768384/142772441-a52c865e-c470-448e-8cc2-c7e8c86ab4de.png">