### PR TITLE
Add backend api for handling event proof images

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -39,6 +39,13 @@ import {
   getAllTeamEvents,
   updateTeamEvent
 } from './team-eventsAPI';
+import {
+  allProofImagesForMember,
+  deleteProofImage,
+  deleteProofImagesForMember,
+  getProofImage,
+  setProofImage
+} from './team-events-imageAPI';
 
 // Constants and configurations
 const app = express();
@@ -205,6 +212,23 @@ loginCheckedGet('/getAllTeamEvents', async (_, user) => ({ events: getAllTeamEve
 loginCheckedPost('/updateTeamEvent', async (req, user) => updateTeamEvent(req.body, user));
 loginCheckedPost('/deleteTeamEvent', async (req, user) => ({
   team: await deleteTeamEvent(req.body, user)
+}));
+
+// Team Events Proof Images
+loginCheckedGet('/getEventProofImageSignedURL', async (req, user) => ({
+  url: await setProofImage(user, req.body.name)
+}));
+loginCheckedGet('/getEventProofImage', async (req, user) => ({
+  url: await getProofImage(user, req.body.name)
+}));
+loginCheckedGet('/getAllEventProofsForMember', async (_, user) => ({
+  url: await allProofImagesForMember(user)
+}));
+loginCheckedPost('/deleteEventProofImage', async (req, user) => ({
+  image: await deleteProofImage(user, req.body.name)
+}));
+loginCheckedPost('/deleteAllEventProofsForMember', async (_, user) => ({
+  image: await deleteProofImagesForMember(user)
 }));
 
 app.use('/.netlify/functions/api', router);

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -214,23 +214,6 @@ loginCheckedPost('/deleteTeamEvent', async (req, user) => ({
   team: await deleteTeamEvent(req.body, user)
 }));
 
-// Team Events Proof Images
-loginCheckedGet('/getEventProofImageSignedURL', async (req, user) => ({
-  url: await setProofImage(user, req.body.name)
-}));
-loginCheckedGet('/getEventProofImage', async (req, user) => ({
-  url: await getProofImage(user, req.body.name)
-}));
-loginCheckedGet('/getAllEventProofsForMember', async (_, user) => ({
-  url: await allProofImagesForMember(user)
-}));
-loginCheckedPost('/deleteEventProofImage', async (req, user) => ({
-  image: await deleteProofImage(user, req.body.name)
-}));
-loginCheckedPost('/deleteAllEventProofsForMember', async (_, user) => ({
-  image: await deleteProofImagesForMember(user)
-}));
-
 app.use('/.netlify/functions/api', router);
 
 // Startup local server if not production (prod is serverless)

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -39,13 +39,6 @@ import {
   getAllTeamEvents,
   updateTeamEvent
 } from './team-eventsAPI';
-import {
-  allProofImagesForMember,
-  deleteProofImage,
-  deleteProofImagesForMember,
-  getProofImage,
-  setProofImage
-} from './team-events-imageAPI';
 
 // Constants and configurations
 const app = express();

--- a/backend/src/team-events-imageAPI.ts
+++ b/backend/src/team-events-imageAPI.ts
@@ -1,0 +1,73 @@
+import { bucket } from './firebase';
+import { getNetIDFromEmail } from './util';
+import { NotFoundError } from './errors';
+
+export const setProofImage = async (user: IdolMember, name: string): Promise<string> => {
+  const netId: string = getNetIDFromEmail(user.email);
+  const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
+  const signedURL = await file.getSignedUrl({
+    action: 'write',
+    version: 'v4',
+    expires: Date.now() + 15 * 60000 // 15 min
+  });
+  return signedURL[0];
+};
+
+export const getProofImage = async (user: IdolMember, name: string): Promise<string> => {
+  const netId: string = getNetIDFromEmail(user.email);
+  const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
+  const fileExists = await file.exists().then((result) => result[0]);
+  if (!fileExists) {
+    throw new NotFoundError(`The requested image (${netId}/${name}.jpg) does not exist`);
+  }
+  const signedUrl = await file.getSignedUrl({
+    action: 'read',
+    expires: Date.now() + 15 * 60000
+  });
+  return signedUrl[0];
+};
+
+export const allProofImagesForMember = async (
+  user: IdolMember
+): Promise<readonly EventProofImage[]> => {
+  const netId: string = getNetIDFromEmail(user.email);
+  const files = await bucket.getFiles({ prefix: `eventProofs/${netId}` });
+  const images = await Promise.all(
+    files[0].map(async (file) => {
+      const signedURL = await file.getSignedUrl({
+        action: 'read',
+        expires: Date.now() + 15 * 60000 // 15 min
+      });
+      const fileName = await file.getMetadata().then((data) => data[1].body.name);
+      return {
+        fileName,
+        url: signedURL[0]
+      };
+    })
+  );
+
+  images
+    .filter((image) => image.fileName.length > 'eventProofs/'.length)
+    .map((image) => ({
+      ...image,
+      fileName: image.fileName.slice(image.fileName.indexOf('/') + 1)
+    }));
+
+  return images;
+};
+
+export const deleteProofImage = async (user: IdolMember, name: string): Promise<void> => {
+  const netId: string = getNetIDFromEmail(user.email);
+  const imageFile = bucket.file(`eventProofs/${netId}/${name}.jpg`);
+  await imageFile.delete();
+};
+
+export const deleteProofImagesForMember = async (user: IdolMember): Promise<void> => {
+  const netId: string = getNetIDFromEmail(user.email);
+  const files = await bucket.getFiles({ prefix: `eventProofs/${netId}` });
+  Promise.all(
+    files[0].map(async (file) => {
+      file.delete();
+    })
+  );
+};

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -81,3 +81,8 @@ interface TeamEvent {
   readonly attendees: IdolMember[];
   readonly uuid: string;
 }
+
+interface EventProofImage {
+  readonly url: string;
+  readonly fileName: string;
+}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements the backend for handling proof images for Team Event Credit. It does the following:
- sets proof image
- get proof image
- get all proof images for a member
- delete a proof image
- delete all proof images for a member

The images are stored in Firebase as `eventProofs/${netID}/{$name}` where `netID` is for identifying the user and `name` is the event name for which proof is uploaded.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Not tested yet.