### PR TITLE
make pronouns required and show error modal

### DIFF
--- a/frontend/src/components/Forms/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/Forms/UserProfile/UserProfile.tsx
@@ -24,6 +24,8 @@ const UserProfile: React.FC = () => {
   const [linkedin, setLinkedin] = useState(userInfoBeforeEdit?.linkedin ?? '');
   const [github, setGithub] = useState(userInfoBeforeEdit?.github ?? '');
 
+  const initialPronouns = userInfoBeforeEdit?.pronouns;
+
   const updateUser = async (member: Member): Promise<void> => {
     MembersAPI.updateMember(member).then((val) => {
       if (val.error) {
@@ -68,6 +70,11 @@ const UserProfile: React.FC = () => {
         formerSubteams: userInfoBeforeEdit?.formerSubteams ?? []
       };
       updateUser(updatedUser);
+    } else {
+      Emitters.generalError.emit({
+        headerMsg: 'Complete Required Fields',
+        contentMsg: 'Please fill out all required fields!'
+      });
     }
   };
 
@@ -80,7 +87,7 @@ const UserProfile: React.FC = () => {
       }}
     >
       <h2 style={{ fontFamily: 'var(--mainFontFamily)', marginBottom: '2vh' }}>
-        {firstName} {lastName} {pronouns}
+        {firstName} {lastName} <span style={{ color: '#808080' }}>({initialPronouns})</span>
       </h2>
       <Form.Group>
         <Form.Input
@@ -108,6 +115,7 @@ const UserProfile: React.FC = () => {
           label="Pronouns"
           value={pronouns}
           onChange={(e) => setPronouns(e.target.value)}
+          required
         />
       </Form.Group>
 


### PR DESCRIPTION
### Summary

This PR fixes some issues with the profile editor #222. It makes pronouns a required field and shows the error modal when not all fields are filled out.

This pull request is the first step towards implementing feature Foo

- [x] Added the required flag on the pronouns input
- [x] Added modal for invalid profile data when trying to save profile info

### Test Plan

<img width="1252" alt="profile" src="https://user-images.githubusercontent.com/49768384/144329194-0c60bd31-9518-4bb3-bb79-b50928c7975d.png">

<img width="1252" alt="profile-error" src="https://user-images.githubusercontent.com/49768384/144329262-dc80d46a-b509-4c07-90ea-ffccd892b91a.png">


