### PR TITLE
Use classnames instead of inline styles

### DIFF
--- a/frontend/src/components/Admin/AddUser.module.css
+++ b/frontend/src/components/Admin/AddUser.module.css
@@ -1,6 +1,3 @@
-.AddUser {
-}
-
 .content {
   margin-left: 2rem;
   margin-right: 2rem;
@@ -33,7 +30,26 @@
   overflow-x: auto;
 }
 
+.subteamEditorCardGroup {
+  margin-top: 1em !important;
+}
+
 .cardHeader {
   position: fixed;
   top: 2rem;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.halfWidth {
+  width: 50%;
+}
+
+.userEmail {
+  margin: 0;
+  color: gray;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/frontend/src/components/Admin/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser.tsx
@@ -34,14 +34,14 @@ function MemberSubteamEditor({
           }));
         }}
       />
-      <Card.Group style={{ marginTop: '1rem' }}>
+      <Card.Group className={styles.subteamEditorCardGroup}>
         {(member[subteamKey] ?? []).map((subteam, ind) => (
           <Card key={ind}>
             <Card.Content>
               <Card.Header>{subteam}</Card.Header>
             </Card.Content>
             <Card.Content extra>
-              <div className="ui one buttons" style={{ width: '100%' }}>
+              <div className={`ui one buttons ${styles.fullWidth}`}>
                 <Button
                   basic
                   color="red"
@@ -145,9 +145,6 @@ export default function AddUser(): JSX.Element {
                   <Card
                     key={ind}
                     style={{
-                      marginBottom: '0.25rem',
-                      marginTop: '0.5rem',
-                      width: 'calc(100% - 1rem)',
                       background:
                         mem.email === state.currentSelectedMember?.email
                           ? 'var(--offWhite)'
@@ -156,37 +153,31 @@ export default function AddUser(): JSX.Element {
                     onClick={() => setState({ currentSelectedMember: mem, isCreatingUser: false })}
                   >
                     <Card.Content>
-                      <Card.Header style={{ margin: 0 }}>
-                        {`${mem.firstName} ${mem.lastName}`}
-                      </Card.Header>
-                      <p
-                        style={{
-                          margin: 0,
-                          color: 'GrayText',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis'
-                        }}
-                      >
-                        {mem.email}
-                      </p>
+                      <Card.Header>{`${mem.firstName} ${mem.lastName}`}</Card.Header>
+                      <p className={styles.userEmail}>{mem.email}</p>
                     </Card.Content>
                   </Card>
                 ))}
               </Card.Content>
             </div>
             <Card.Content extra>
-              <div className="ui one buttons" style={{ width: '100%' }}>
+              <div className={`ui one buttons ${styles.fullWidth}`}>
                 <Button
                   basic
                   color="red"
-                  style={{ width: '50%' }}
+                  className={styles.halfWidth}
                   onClick={() => {
                     if (state.currentSelectedMember) deleteUser(state.currentSelectedMember.email);
                   }}
                 >
                   Delete User
                 </Button>
-                <Button basic color="blue" style={{ width: '50%' }} onClick={() => createNewUser()}>
+                <Button
+                  basic
+                  color="blue"
+                  className={styles.halfWidth}
+                  onClick={() => createNewUser()}
+                >
                   Create User
                 </Button>
               </div>
@@ -390,7 +381,7 @@ export default function AddUser(): JSX.Element {
                 />
               </Card.Content>
               <Card.Content extra>
-                <div className="ui one buttons" style={{ width: '100%' }}>
+                <div className={`ui one buttons ${styles.fullWidth}`}>
                   <Button
                     basic
                     color="green"

--- a/frontend/src/components/Admin/AdminShoutouts.module.css
+++ b/frontend/src/components/Admin/AdminShoutouts.module.css
@@ -3,6 +3,11 @@
   padding-top: 5%;
 }
 
+.noShoutoutsContainer {
+  width: 90% !important;
+  white-space: pre-wrap;
+}
+
 .Wrapper {
   margin-left: 2rem;
   margin-right: 2rem;

--- a/frontend/src/components/Admin/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts.tsx
@@ -13,7 +13,7 @@ const AdminShoutouts: React.FC = () => {
   return (
     <div className={styles.shoutoutsContainer}>
       {shoutouts.length === 0 ? (
-        <Card style={{ width: '100%', whiteSpace: 'pre-wrap' }}>
+        <Card className={styles.noShoutoutsContainer}>
           <Card.Content>No shoutouts.</Card.Content>
         </Card>
       ) : (

--- a/frontend/src/components/Admin/EditTeam.module.css
+++ b/frontend/src/components/Admin/EditTeam.module.css
@@ -1,11 +1,20 @@
 .EditTeam {
 }
 
+.teamMemberEditorCardGroup {
+  margin-top: 1em !important;
+}
+
 .content {
   margin-left: 2rem;
   margin-right: 2rem;
   padding-top: 5rem;
   padding-bottom: 2rem;
+}
+
+.memberCount {
+  margin: 0;
+  color: gray;
 }
 
 .cardContent {
@@ -18,4 +27,12 @@
 .cardHeader {
   position: fixed;
   top: 2rem;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.halfWidth {
+  width: 50%;
 }

--- a/frontend/src/components/Admin/EditTeam.tsx
+++ b/frontend/src/components/Admin/EditTeam.tsx
@@ -32,7 +32,7 @@ function TeamMemberEditor({
           }));
         }}
       />
-      <Card.Group style={{ marginTop: '1rem' }}>
+      <Card.Group className={styles.teamMemberEditorCardGroup}>
         {currentSelectedTeam[membersKey].map((member, ind) => (
           <Card key={ind}>
             <Card.Content>
@@ -40,7 +40,7 @@ function TeamMemberEditor({
               <Card.Description>{member.email}</Card.Description>
             </Card.Content>
             <Card.Content extra>
-              <div className="ui one buttons" style={{ width: '100%' }}>
+              <div className={`ui one buttons ${styles.fullWidth}`}>
                 <Button
                   basic
                   color="red"
@@ -132,17 +132,14 @@ export default function EditTeam(): JSX.Element {
                   <Card
                     key={ind}
                     style={{
-                      marginBottom: '0.25rem',
-                      marginTop: '0.5rem',
-                      width: 'calc(100% - 1rem)',
                       background:
                         team.name === currentSelectedTeam?.name ? 'var(--offWhite)' : undefined
                     }}
                     onClick={() => setCurrentSelectedTeamAllowUndefined(team)}
                   >
                     <Card.Content>
-                      <Card.Header style={{ margin: 0 }}>{team.name}</Card.Header>
-                      <p style={{ margin: 0, color: 'GrayText' }}>
+                      <Card.Header>{team.name}</Card.Header>
+                      <p className={styles.memberCount}>
                         {`${team.leaders.length + team.members.length} members`}
                       </p>
                     </Card.Content>
@@ -151,18 +148,18 @@ export default function EditTeam(): JSX.Element {
               </Card.Content>
             </div>
             <Card.Content extra>
-              <div className="ui one buttons" style={{ width: '100%' }}>
+              <div className={`ui one buttons ${styles.fullWidth}`}>
                 <Button
                   basic
                   color="red"
-                  style={{ width: '50%' }}
+                  className={styles.halfWidth}
                   onClick={() => {
                     if (currentSelectedTeam) deleteTeam(currentSelectedTeam);
                   }}
                 >
                   Delete Team
                 </Button>
-                <Button basic color="blue" style={{ width: '50%' }} onClick={createNewTeam}>
+                <Button basic color="blue" className={styles.halfWidth} onClick={createNewTeam}>
                   Create Team
                 </Button>
               </div>
@@ -206,7 +203,7 @@ export default function EditTeam(): JSX.Element {
                 />
               </Card.Content>
               <Card.Content extra>
-                <div className="ui one buttons" style={{ width: '100%' }}>
+                <div className={`ui one buttons ${styles.fullWidth}`}>
                   <Button basic color="green" onClick={() => setTeam(currentSelectedTeam)}>
                     Save Team
                   </Button>

--- a/frontend/src/components/Common/UserProvider.module.css
+++ b/frontend/src/components/Common/UserProvider.module.css
@@ -1,2 +1,4 @@
-.UserProvider {
+.LoaderContainer {
+  width: 100vw;
+  height: 100vh;
 }

--- a/frontend/src/components/Common/UserProvider.tsx
+++ b/frontend/src/components/Common/UserProvider.tsx
@@ -5,6 +5,8 @@ import { auth } from '../../firebase';
 import SignIn from './SignIn.lazy';
 import EmailNotFoundErrorModal from '../Modals/EmailNotFoundErrorModal';
 
+import styles from './UserProvider.module.css';
+
 type UserContextType = { readonly email: string } | 'INIT' | null;
 
 const UserContext = createContext<UserContextType>(null);
@@ -55,7 +57,7 @@ export default function UserProvider({ children }: { readonly children: ReactNod
   if (user === 'INIT') {
     return (
       <div data-testid="UserProvider" className="App">
-        <div style={{ height: '100vh', width: '100vw' }}>
+        <div className={styles.LoaderContainer}>
           <Loader active={true} size="massive">
             Signing you in...
           </Loader>

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
@@ -3,7 +3,7 @@
   align-self: center;
   margin: auto;
   padding-top: 10vh;
-  height: calc(100vh - 80px - 25vh)
+  height: calc(100vh - 80px - 25vh);
 }
 
 .shoutoutTitle {

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
@@ -1,3 +1,11 @@
+.shoutoutFormContainer {
+  width: 50%;
+  align-self: center;
+  margin: auto;
+  padding-top: 10vh;
+  height: calc(100vh - 80px - 25vh)
+}
+
 .shoutoutTitle {
   text-align: center;
 }

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
@@ -38,15 +38,7 @@ const ShoutoutsPage: React.FC = () => {
 
   return (
     <div>
-      <div
-        style={{
-          width: '50%',
-          alignSelf: 'center',
-          margin: 'auto',
-          paddingTop: '10vh',
-          height: 'calc(100vh - 80px - 25vh)'
-        }}
-      >
+      <div className={styles.shoutoutFormContainer}>
         <ShoutoutForm />
       </div>
 

--- a/frontend/src/components/Forms/UserProfile/ProfileImageEditor.module.css
+++ b/frontend/src/components/Forms/UserProfile/ProfileImageEditor.module.css
@@ -30,6 +30,10 @@
   margin-left: 1rem;
 }
 
+.inputWithLabel {
+  margin-left: 1rem;
+}
+
 @media only screen and (max-width: 800px) {
   .avatarAndEditorContainer {
     flex-direction: column;

--- a/frontend/src/components/Forms/UserProfile/ProfileImageEditor.tsx
+++ b/frontend/src/components/Forms/UserProfile/ProfileImageEditor.tsx
@@ -88,7 +88,7 @@ class ProfileImageEditor extends React.Component<Props, EditProfileImageState> {
               type="file"
               accept="image/png, image/jpeg"
               onChange={this.handleNewImage}
-              style={{ marginLeft: '1rem' }}
+              className={styles.inputWithLabel}
             />
           </div>
 
@@ -104,7 +104,7 @@ class ProfileImageEditor extends React.Component<Props, EditProfileImageState> {
               max="2"
               step="0.01"
               defaultValue="1"
-              style={{ marginLeft: '1rem' }}
+              className={styles.inputWithLabel}
             />
           </div>
 
@@ -112,13 +112,13 @@ class ProfileImageEditor extends React.Component<Props, EditProfileImageState> {
             <label className={styles.label}>Rotate:</label>
             <Button
               onClick={this.handleRotateLeft}
-              style={{ marginLeft: '1rem' }}
+              className={styles.inputWithLabel}
               content="Left"
               size="mini"
             ></Button>
             <Button
               onClick={this.handleRotateRight}
-              style={{ marginLeft: '1rem' }}
+              className={styles.inputWithLabel}
               content="Right"
               size="mini"
             ></Button>
@@ -135,7 +135,7 @@ class ProfileImageEditor extends React.Component<Props, EditProfileImageState> {
               icon="checkmark"
               onClick={this.props.cropAndSubmitImage}
               positive
-              style={{ marginLeft: '1rem' }}
+              className={styles.inputWithLabel}
             />
           </div>
         </div>

--- a/frontend/src/components/Homepage/Spotlight.module.css
+++ b/frontend/src/components/Homepage/Spotlight.module.css
@@ -2,6 +2,11 @@
   width: fit-content;
 }
 
+.Header {
+  text-align: center;
+  font-family: var(--mainFontFamily);
+}
+
 .headshot {
   margin-bottom: 1rem;
   border-radius: 4px 4px 4px 4px;

--- a/frontend/src/components/Homepage/Spotlight.tsx
+++ b/frontend/src/components/Homepage/Spotlight.tsx
@@ -5,7 +5,7 @@ import AramHeadshot from '../../static/images/aram-headshot.jpg';
 
 const Spotlight: React.FC = () => (
   <div className={styles.Spotlight} data-testid="Spotlight">
-    <h2 style={{ textAlign: 'center', fontFamily: 'var(--mainFontFamily)' }}>
+    <h2 className={styles.Header}>
       This Week's Spotlight
       <span role="img" aria-label="Light emoji">
         💡

--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -1,8 +1,24 @@
 .App {
   text-align: left;
+  min-height: 100vh;
+  max-height: 100vh;
+  min-width: 100vw;
+  position: relative;
+}
+
+.appSidebarContainer {
+  position: absolute;
+  top: 80px;
+  height: calc(100vh - 80px);
 }
 
 .appSidebar {
   height: calc(100vh - 80px);
   padding-top: 80px;
+}
+
+.appSidebarDimmer {
+  width: 100vw;
+  margin: 0;
+  padding: 0;
 }

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -60,23 +60,9 @@ function AppContent({ children }: { readonly children: ReactNode }): JSX.Element
       <ErrorModal onEmitter={Emitters.generalError}></ErrorModal>
       <ErrorModal onEmitter={Emitters.userEditError}></ErrorModal>
       <SuccessModal onEmitter={Emitters.generalSuccess}></SuccessModal>
-      <div
-        className="App"
-        style={{
-          minHeight: '100vh',
-          maxHeight: '100vh',
-          minWidth: '100vw',
-          position: 'relative'
-        }}
-      >
+      <div className="App">
         <SiteHeader />
-        <div
-          style={{
-            position: 'absolute',
-            top: '80px',
-            height: 'calc(100vh - 80px)'
-          }}
-        >
+        <div className="appSidebarContainer">
           <Sidebar
             as={Menu}
             animation="overlay"
@@ -95,15 +81,7 @@ function AppContent({ children }: { readonly children: ReactNode }): JSX.Element
           </Sidebar>
           <Sidebar.Pushable>
             <Sidebar.Pusher dimmed={navVisible}>
-              <div
-                style={{
-                  width: '100vw',
-                  margin: 0,
-                  padding: 0
-                }}
-              >
-                {children}
-              </div>
+              <div className="appSidebarDimmer">{children}</div>
             </Sidebar.Pusher>
           </Sidebar.Pushable>
         </div>


### PR DESCRIPTION
### Summary <!-- Required -->

Use classnames to replace inline styles. Some of the rules have to have `!important` added because the default semantic UI css is too specific. This is probably one of the reasons we should eventually replace it, but it's probably a project for next semester...

### Test Plan <!-- Required -->

Affected pages all look fine:
<img width="1624" alt="edit-user" src="https://user-images.githubusercontent.com/4290500/144461333-09cf0335-19f1-4c68-9a57-c53e11aa06ae.png">
<img width="1624" alt="homepage" src="https://user-images.githubusercontent.com/4290500/144461344-fc555dbe-f49c-4467-ae32-4830c8fbbe56.png">
<img width="1624" alt="no-shoutouts" src="https://user-images.githubusercontent.com/4290500/144461369-2150bb52-ad50-4d09-b87d-2b2db2471c10.png">
<img width="1624" alt="profile-image" src="https://user-images.githubusercontent.com/4290500/144461374-140aa531-44cb-4608-a4d1-a9c28e7d7ff7.png">
<img width="1624" alt="shoutout" src="https://user-images.githubusercontent.com/4290500/144461448-1ad52f94-5d7b-4353-9d82-c6e96e79cc4e.png">
<img width="1624" alt="sidebar" src="https://user-images.githubusercontent.com/4290500/144461463-2aa730a1-1184-4379-8c99-4eaa574c1e8d.png">
<img width="1624" alt="team-editor" src="https://user-images.githubusercontent.com/4290500/144461486-4aa6e509-1d25-41e4-b9fa-312de4227fa1.png">



