### PR TITLE
admins approve/reject credit requests

### DIFF
--- a/backend/src/DataTypes.d.ts
+++ b/backend/src/DataTypes.d.ts
@@ -47,8 +47,8 @@ export type DBTeamEvent = {
   date: string;
   numCredits: string;
   hasHours: boolean;
-  membersPending: firestore.DocumentReference[];
-  membersApproved: firestore.DocumentReference[];
+  requests: firestore.DocumentReference[];
+  attendees: firestore.DocumentReference[];
   uuid: string;
 };
 
@@ -57,7 +57,7 @@ export type TeamEvent = {
   date: string;
   numCredits: string;
   hasHours: boolean;
-  membersPending: IdolMember[];
-  membersApproved: IdolMember[];
+  requests: IdolMember[];
+  attendees: IdolMember[];
   uuid: string;
 };

--- a/backend/src/dao/TeamEventsDao.ts
+++ b/backend/src/dao/TeamEventsDao.ts
@@ -9,18 +9,17 @@ export default class TeamEventsDao {
 
     return Promise.all(
       eventRefs.docs.map(async (eventRef) => {
-        const { name, date, numCredits, hasHours, membersPending, membersApproved, uuid } =
-          eventRef.data();
+        const { name, date, numCredits, hasHours, requests, attendees, uuid } = eventRef.data();
         return {
           name,
           date,
           numCredits,
           hasHours,
-          membersPending: await Promise.all(
-            membersPending.map((ref) => ref.get().then((doc) => doc.data() as IdolMember))
+          requests: await Promise.all(
+            requests.map((ref) => ref.get().then((doc) => doc.data() as IdolMember))
           ),
-          membersApproved: await Promise.all(
-            membersApproved.map((ref) => ref.get().then((doc) => doc.data() as IdolMember))
+          attendees: await Promise.all(
+            attendees.map((ref) => ref.get().then((doc) => doc.data() as IdolMember))
           ),
           uuid
         };
@@ -42,8 +41,8 @@ export default class TeamEventsDao {
       date: event.date,
       numCredits: event.numCredits,
       hasHours: event.hasHours,
-      membersPending: event.membersPending.map((mem) => memberCollection.doc(mem.email)),
-      membersApproved: event.membersApproved.map((mem) => memberCollection.doc(mem.email))
+      requests: event.requests.map((mem) => memberCollection.doc(mem.email)),
+      attendees: event.attendees.map((mem) => memberCollection.doc(mem.email))
     };
 
     await teamEventsCollection.doc(teamEventRef.uuid).set(teamEventRef);
@@ -57,8 +56,8 @@ export default class TeamEventsDao {
 
     const teamEventRef: DBTeamEvent = {
       ...event,
-      membersPending: event.membersPending.map((mem) => memberCollection.doc(mem.email)),
-      membersApproved: event.membersApproved.map((mem) => memberCollection.doc(mem.email))
+      requests: event.requests.map((mem) => memberCollection.doc(mem.email)),
+      attendees: event.attendees.map((mem) => memberCollection.doc(mem.email))
     };
 
     await eventDoc.update(teamEventRef);

--- a/backend/tests/TeamEventsAPI.test.ts
+++ b/backend/tests/TeamEventsAPI.test.ts
@@ -16,8 +16,8 @@ const testTeamEvent = {
   date: '11/26/2020',
   numCredits: '1',
   hasHours: false,
-  membersPending: [jaggerData],
-  membersApproved: [],
+  requests: [jaggerData],
+  attendees: [],
   uuid: 'test123'
 };
 
@@ -35,8 +35,8 @@ test('does not create team event because user does not have permission', async (
 
 const updatedTestTeamEvent = {
   ...testTeamEvent,
-  membersPending: [],
-  membersApproved: [jaggerData]
+  requests: [],
+  attendees: [jaggerData]
 };
 
 test('does not get all team events because user does not have permission', async () => {

--- a/backend/tests/TeamEventsDao.test.ts
+++ b/backend/tests/TeamEventsDao.test.ts
@@ -8,8 +8,8 @@ const test_event: TeamEvent = {
   hasHours: true,
   name: 'testevent1',
   numCredits: '1',
-  membersApproved: [],
-  membersPending: [jaggerData],
+  attendees: [],
+  requests: [jaggerData],
   uuid: 'test'
 };
 
@@ -30,8 +30,8 @@ test('Add new event', async () => {
 test('Update existing event', async () => {
   const updated_event: TeamEvent = {
     ...test_event,
-    membersPending: [],
-    membersApproved: [jaggerData]
+    requests: [],
+    attendees: [jaggerData]
   };
 
   // make sure event is in db first

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -76,9 +76,19 @@ interface SignInForm {
   readonly expireAt: number;
 }
 
+interface TeamEventAttendance {
+  member: IdolMember;
+  hoursAttended?: number;
+  image: string;
+}
+
 interface TeamEvent {
-  readonly name: string;
-  readonly attendees: IdolMember[];
+  name: string;
+  date: string;
+  numCredits: string;
+  hasHours: boolean;
+  readonly attendees: TeamEventAttendance[];
+  readonly requests: TeamEventAttendance[];
   readonly uuid: string;
 }
 

--- a/frontend/src/components/Admin/EditTeamEvent.tsx
+++ b/frontend/src/components/Admin/EditTeamEvent.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Modal, Button } from 'semantic-ui-react';
 import TeamEventForm from './TeamEventForm';
-import { TeamEvent } from './TeamEvents';
 
 const EditTeamEvent = (props: { teamEvent: TeamEvent }): JSX.Element => {
   const { teamEvent } = props;

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -3,15 +3,14 @@ import { Card, Message, Modal, Button } from 'semantic-ui-react';
 import Link from 'next/link';
 import EditTeamEvent from './EditTeamEvent';
 import styles from './TeamEventDetails.module.css';
-import { TeamEvent } from './TeamEvents';
 
 const mockTeamEvent: TeamEvent = {
   name: 'Info Session',
   date: '2021-11-17',
   numCredits: '1',
   hasHours: false,
-  membersPending: [],
-  membersApproved: [],
+  requests: [],
+  attendees: [],
   uuid: '1'
 };
 
@@ -43,15 +42,15 @@ const TeamEventDetails: React.FC = () => (
       <div className={styles.listContainer}>
         <h2 className={styles.memberTitle}>Members Pending</h2>
 
-        {mockTeamEvent.membersPending.length > 0 ? (
+        {mockTeamEvent.requests.length > 0 ? (
           <Card.Group>
-            {mockTeamEvent.membersPending.map((member) => (
-              <Card key={member.netid}>
+            {mockTeamEvent.requests.map((req) => (
+              <Card key={req.member.netid}>
                 <Card.Content>
                   <Card.Header>
-                    {member.firstName} {member.lastName}
+                    {req.member.firstName} {req.member.lastName}
                   </Card.Header>
-                  <Card.Meta>{member.email}</Card.Meta>
+                  <Card.Meta>{req.member.email}</Card.Meta>
                 </Card.Content>
               </Card>
             ))}
@@ -64,15 +63,15 @@ const TeamEventDetails: React.FC = () => (
       <div className={styles.listContainer}>
         <h2 className={styles.memberTitle}>Members Approved</h2>
 
-        {mockTeamEvent.membersApproved.length > 0 ? (
+        {mockTeamEvent.attendees.length > 0 ? (
           <Card.Group>
-            {mockTeamEvent.membersApproved.map((member) => (
-              <Card key={member.netid}>
+            {mockTeamEvent.attendees.map((req) => (
+              <Card key={req.member.netid}>
                 <Card.Content>
                   <Card.Header>
-                    {member.firstName} {member.lastName}
+                    {req.member.firstName} {req.member.lastName}
                   </Card.Header>
-                  <Card.Meta>{member.email}</Card.Meta>
+                  <Card.Meta>{req.member.email}</Card.Meta>
                 </Card.Content>
               </Card>
             ))}

--- a/frontend/src/components/Admin/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEventForm.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Form, Radio, Button } from 'semantic-ui-react';
 import { Emitters } from '../../utils';
 import styles from './TeamEventForm.module.css';
-import { TeamEvent } from './TeamEvents';
 
 type Props = {
   formType: string;
@@ -64,8 +63,8 @@ const TeamEventForm = (props: Props): JSX.Element => {
         date: teamEventDate,
         numCredits: teamEventCreditNum,
         hasHours: teamEventHasHours,
-        membersPending: [],
-        membersApproved: []
+        requests: [],
+        attendees: []
       };
       createTeamEvent(newTeamEvent);
       Emitters.generalSuccess.emit({

--- a/frontend/src/components/Admin/TeamEvents.module.css
+++ b/frontend/src/components/Admin/TeamEvents.module.css
@@ -1,11 +1,18 @@
-.formWrapper {
+.wrapper {
   width: 60%;
-  align-self: center;
   margin: auto;
-  padding: 3rem 0 5rem 0;
+  margin-bottom: 4em;
 }
 
-.eventsWrapper {
-  width: 60%;
-  margin: auto;
+.formWrapper {
+  padding-top: 3rem;
+}
+
+.memberCard {
+  align-items: center;
+}
+
+.creditImage {
+  margin-bottom: 1rem;
+  border-radius: 4px 4px 4px 4px;
 }

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -2,27 +2,8 @@ import React from 'react';
 import { Card, Button, Message, Image } from 'semantic-ui-react';
 import Link from 'next/link';
 import TeamEventForm from './TeamEventForm';
-import { Member } from '../../API/MembersAPI';
 import styles from './TeamEvents.module.css';
 import AramHeadshot from '../../static/images/aram-headshot.jpg';
-
-export type TeamEvent = {
-  name: string;
-  date: string;
-  numCredits: string;
-  hasHours: boolean;
-  membersPending: Member[];
-  membersApproved: Member[];
-  uuid: string;
-};
-
-type TeamEventAttendance = {
-  memberName: string;
-  memberEmail: string;
-  teamEventName: string;
-  hoursAttended?: string;
-  image: string;
-};
 
 const TeamEvents: React.FC = () => {
   const teamEvents: TeamEvent[] = [
@@ -31,8 +12,8 @@ const TeamEvents: React.FC = () => {
       date: '2021-11-17',
       numCredits: '0.5',
       hasHours: false,
-      membersPending: [],
-      membersApproved: [],
+      requests: [],
+      attendees: [],
       uuid: '1'
     },
     {
@@ -41,27 +22,12 @@ const TeamEvents: React.FC = () => {
       date: '2021-11-17',
       numCredits: '0.5',
       hasHours: true,
-      membersPending: [],
-      membersApproved: []
+      requests: [],
+      attendees: []
     }
   ];
 
-  // should requests have ids?
-  const pendingRequests: TeamEventAttendance[] = [
-    {
-      memberName: 'Morgan Belous',
-      memberEmail: 'mhb224@cornell.edu',
-      teamEventName: 'Propel Demo Day',
-      image: ''
-    },
-    {
-      memberName: 'Morgan Belous',
-      memberEmail: 'mhb224@cornell.edu',
-      teamEventName: 'Club Fest',
-      hoursAttended: '2',
-      image: ''
-    }
-  ];
+  const pendingRequests: TeamEventAttendance[] = [];
 
   const handleCreditRequest = () => {
     // if approved, move to approved list of the event
@@ -99,9 +65,10 @@ const TeamEvents: React.FC = () => {
               <Card className={styles.memberCard} key={i}>
                 <Card.Content>
                   <Image size="medium" className={styles.creditImage} src={AramHeadshot.src} />
-                  <Card.Header>{request.memberName} </Card.Header>
-                  <Card.Meta>{request.memberEmail}</Card.Meta>
-                  <Card.Description>{request.teamEventName}</Card.Description>
+                  <Card.Header>
+                    {request.member.firstName} {request.member.lastName}
+                  </Card.Header>
+                  <Card.Meta>{request.member.email}</Card.Meta>
                   {request.hoursAttended && (
                     <Card.Description> Hours Attended: {request.hoursAttended}</Card.Description>
                   )}

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Card } from 'semantic-ui-react';
+import { Card, Button, Message, Image } from 'semantic-ui-react';
 import Link from 'next/link';
 import TeamEventForm from './TeamEventForm';
 import { Member } from '../../API/MembersAPI';
 import styles from './TeamEvents.module.css';
+import AramHeadshot from '../../static/images/aram-headshot.jpg';
 
 export type TeamEvent = {
   name: string;
@@ -13,6 +14,14 @@ export type TeamEvent = {
   membersPending: Member[];
   membersApproved: Member[];
   uuid: string;
+};
+
+type TeamEventAttendance = {
+  memberName: string;
+  memberEmail: string;
+  teamEventName: string;
+  hoursAttended?: string;
+  image: string;
 };
 
 const TeamEvents: React.FC = () => {
@@ -37,14 +46,36 @@ const TeamEvents: React.FC = () => {
     }
   ];
 
+  // should requests have ids?
+  const pendingRequests: TeamEventAttendance[] = [
+    {
+      memberName: 'Morgan Belous',
+      memberEmail: 'mhb224@cornell.edu',
+      teamEventName: 'Propel Demo Day',
+      image: ''
+    },
+    {
+      memberName: 'Morgan Belous',
+      memberEmail: 'mhb224@cornell.edu',
+      teamEventName: 'Club Fest',
+      hoursAttended: '2',
+      image: ''
+    }
+  ];
+
+  const handleCreditRequest = () => {
+    // if approved, move to approved list of the event
+    // remove from total pending list and event pending list
+  };
+
   return (
     <div>
-      <div className={styles.formWrapper}>
+      <div className={[styles.formWrapper, styles.wrapper].join(' ')}>
         <h1>Create a Team Event</h1>
         <TeamEventForm formType={'create'}></TeamEventForm>
       </div>
 
-      <div className={styles.eventsWrapper}>
+      <div className={styles.wrapper}>
         <h2>View All Team Events</h2>
         <Card.Group>
           {teamEvents.map((teamEvent) => (
@@ -58,6 +89,37 @@ const TeamEvents: React.FC = () => {
             </Link>
           ))}
         </Card.Group>
+      </div>
+      <div className={styles.wrapper}>
+        <h2>Approve Pending Credit Requests</h2>
+
+        {pendingRequests.length !== 0 ? (
+          <Card.Group>
+            {pendingRequests.map((request, i) => (
+              <Card className={styles.memberCard} key={i}>
+                <Card.Content>
+                  <Image size="medium" className={styles.creditImage} src={AramHeadshot.src} />
+                  <Card.Header>{request.memberName} </Card.Header>
+                  <Card.Meta>{request.memberEmail}</Card.Meta>
+                  <Card.Description>{request.teamEventName}</Card.Description>
+                  {request.hoursAttended && (
+                    <Card.Description> Hours Attended: {request.hoursAttended}</Card.Description>
+                  )}
+                </Card.Content>
+                <Card.Content extra>
+                  <Button basic color="green" onClick={handleCreditRequest}>
+                    Approve
+                  </Button>
+                  <Button basic color="red" onClick={handleCreditRequest}>
+                    Reject
+                  </Button>
+                </Card.Content>
+              </Card>
+            ))}
+          </Card.Group>
+        ) : (
+          <Message>There are currently no pending credit requests.</Message>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import TeamEventForm from './TeamEventForm';
 import styles from './TeamEvents.module.css';
 import AramHeadshot from '../../static/images/aram-headshot.jpg';
+import { convertCompilerOptionsFromJson } from 'typescript';
 
 const TeamEvents: React.FC = () => {
   const teamEvents: TeamEvent[] = [
@@ -30,6 +31,7 @@ const TeamEvents: React.FC = () => {
   const pendingRequests: TeamEventAttendance[] = [];
 
   const handleCreditRequest = () => {
+    console.log('handleCreditRequest'); // just want to trigger re-run
     // if approved, move to approved list of the event
     // remove from total pending list and event pending list
   };

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -40,7 +40,6 @@ const TeamEvents: React.FC = () => {
         <h1>Create a Team Event</h1>
         <TeamEventForm formType={'create'}></TeamEventForm>
       </div>
-
       <div className={styles.wrapper}>
         <h2>View All Team Events</h2>
         <Card.Group>

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import TeamEventForm from './TeamEventForm';
 import styles from './TeamEvents.module.css';
 import AramHeadshot from '../../static/images/aram-headshot.jpg';
-import { convertCompilerOptionsFromJson } from 'typescript';
 
 const TeamEvents: React.FC = () => {
   const teamEvents: TeamEvent[] = [

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -1,26 +1,8 @@
 import React, { useState } from 'react';
 import { Form, Segment, Label, Button } from 'semantic-ui-react';
-import { Member } from '../../../API/MembersAPI';
 import { Emitters } from '../../../utils';
 import CustomSearch from '../../Common/Search';
 import { useSelf } from '../../Common/FirestoreDataProvider';
-
-type TeamEvent = {
-  name: string;
-  date: string;
-  numCredits: string;
-  hasHours: boolean;
-  membersPending: Member[];
-  membersApproved: Member[];
-};
-
-type TeamEventAttendance = {
-  memberName: string;
-  memberEmail: string;
-  teamEventName: string;
-  hoursAttended?: string;
-  image: string;
-};
 
 const TeamEventCreditForm: React.FC = () => {
   // When the user is logged in, `useSelf` always return non-null data.
@@ -60,10 +42,8 @@ const TeamEventCreditForm: React.FC = () => {
       });
     } else {
       const newTeamEventAttendance: TeamEventAttendance = {
-        memberName: `${userInfo.firstName} ${userInfo.lastName}`,
-        memberEmail: userInfo.email,
-        teamEventName: teamEvent.name,
-        hoursAttended: hours,
+        member: userInfo,
+        hoursAttended: Number(hours),
         image
       };
       requestTeamEventCredit(newTeamEventAttendance);
@@ -80,16 +60,18 @@ const TeamEventCreditForm: React.FC = () => {
       date: 'Sept 3',
       numCredits: '0.5',
       hasHours: false,
-      membersPending: [],
-      membersApproved: []
+      requests: [],
+      attendees: [],
+      uuid: '4'
     },
     {
       name: 'Club Fest',
       date: 'Sept 5',
       numCredits: '0.5',
       hasHours: true,
-      membersPending: [],
-      membersApproved: []
+      requests: [],
+      attendees: [],
+      uuid: '7'
     }
   ];
 

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -15,6 +15,7 @@ type TeamEvent = {
 };
 
 type TeamEventAttendance = {
+  memberName: string;
   memberEmail: string;
   teamEventName: string;
   hoursAttended?: string;
@@ -59,6 +60,7 @@ const TeamEventCreditForm: React.FC = () => {
       });
     } else {
       const newTeamEventAttendance: TeamEventAttendance = {
+        memberName: `${userInfo.firstName} ${userInfo.lastName}`,
         memberEmail: userInfo.email,
         teamEventName: teamEvent.name,
         hoursAttended: hours,


### PR DESCRIPTION
### Summary

This PR is the next step towards implementing team event credits on IDOL. It allows admins to see a list of pending credit requests, view the request's attached image, and decide whether or not to approve the credit request.

- [x] implemented approving/rejecting team event credit requests
- [ ] fetch data from image API

### Test Plan
<img width="1426" alt="credit-requests" src="https://user-images.githubusercontent.com/49768384/145728732-227bd78b-9924-4b63-a597-862121bd2e6f.png">