### PR TITLE
Fix typo in developer apply section

### DIFF
--- a/dti-website/src/data/apply.json
+++ b/dti-website/src/data/apply.json
@@ -141,7 +141,7 @@
         "sections": [
           {
             "header": "What We're Looking For",
-            "content": "You should be an inventive and communicate individual with a desire to learn new technologies and apply them to real-world problems. You should have some background in computer science or app/web development, but specific technologies will be taught within your project and we do not expect applicants to understand every aspect of application development."
+            "content": "You should be an inventive and communicative individual with a desire to learn new technologies and apply them to real-world problems. You should have some background in computer science or app/web development, but specific technologies will be taught within your project and we do not expect applicants to understand every aspect of application development."
           },
           {
             "header": "What You'll Do",


### PR DESCRIPTION


### Summary <!-- Required -->

Fixes typo communicate -> communicative

### Test Plan <!-- Required -->

communicative is spelled correctly and is an adjective

![image](https://user-images.githubusercontent.com/3837473/149998360-1755efb5-b7ea-4013-a52a-09d5f88004d0.png)
