### PR TITLE
Fix typo in zing description

### DIFF
--- a/dti-website/src/data/all-projects.json
+++ b/dti-website/src/data/all-projects.json
@@ -388,7 +388,7 @@
     "hero": {
       "header": "What We Do",
       "image": "",
-      "subheader": "Zing is an all-in-one web interface for professors to create optimal groups for class projects based on students’ study preferences. Built with the GroupEng algorithm developed by the Director of Cornell Engineering’s MTEI program, Zing enables professors to customize grouping criteria and easily match studetnts. Our team also supports the Learning Strategies Center’s Study Partner program as a companion tool. Together, Zing helps student succeed inside and outside the classroom."
+      "subheader": "Zing is an all-in-one web interface for professors to create optimal groups for class projects based on students’ study preferences. Built with the GroupEng algorithm developed by the Director of Cornell Engineering’s MTEI program, Zing enables professors to customize grouping criteria and easily match students. Our team also supports the Learning Strategies Center’s Study Partner program as a companion tool. Together, Zing helps student succeed inside and outside the classroom."
     },
     "github": "https://github.com/cornell-dti/zing",
     "heroStartingColor": "#1AA9A5",


### PR DESCRIPTION
### Summary <!-- Required -->

Fix typo on https://www.cornelldti.org/projects/zing

![image](https://user-images.githubusercontent.com/65922473/152710461-af12350c-2e9e-40f8-8476-aaee62049728.png)

"studetnts" --> "students" 

### Test Plan <!-- Required -->
👀
