### PR TITLE
Candidate Decider admin page 

### DIFF
--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -86,3 +86,11 @@ interface EventProofImage {
   readonly url: string;
   readonly fileName: string;
 }
+
+interface CandidateDeciderInstance {
+  readonly name: string;
+  readonly headers: string[];
+  readonly candidates: any[];
+  readonly uuid: string;
+  isOpen: boolean;
+}

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -87,10 +87,27 @@ interface EventProofImage {
   readonly fileName: string;
 }
 
+interface CandidateDeciderRating {
+  readonly reviewer: IdolMember;
+  readonly rating: number;
+}
+
+interface CandidateDeciderComment {
+  readonly reviewer: IdolMember;
+  readonly comment: string;
+}
+
+interface CandidateDeciderCandidate {
+  readonly responses: any[];
+  readonly id: number;
+  ratings: CandidateDeciderRating[];
+  comments: CandidateDeciderComment[];
+}
+
 interface CandidateDeciderInstance {
   readonly name: string;
   readonly headers: string[];
-  readonly candidates: any[];
+  readonly candidates: CandidateDeciderCandidate[];
   readonly uuid: string;
   isOpen: boolean;
 }

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -98,7 +98,7 @@ interface CandidateDeciderComment {
 }
 
 interface CandidateDeciderCandidate {
-  readonly responses: any[];
+  readonly responses: string[];
   readonly id: number;
   ratings: CandidateDeciderRating[];
   comments: CandidateDeciderComment[];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^17.0.9",
     "axios": "^0.22.0",
     "common-types": "1.0.0",
+    "csvtojson": "^2.0.10",
     "firebase": "^9.1.1",
     "moment": "^2.29.1",
     "next": "^12.0.1",

--- a/frontend/src/components/Admin/AdminCandidateDecider.module.css
+++ b/frontend/src/components/Admin/AdminCandidateDecider.module.css
@@ -1,0 +1,14 @@
+#adminCandidateDeciderContainer {
+  width: 60%;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 5%;
+}
+
+#submitButton {
+  margin-top: 1rem;
+}
+
+#listContainer {
+  margin-top: 3rem;
+}

--- a/frontend/src/components/Admin/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider.tsx
@@ -31,7 +31,7 @@ const CandidateDeciderInstanceCreator: React.FC = () => {
   const [name, setName] = useState<string>('');
   const [success, setSuccess] = useState<boolean>(false);
   const [headers, setHeaders] = useState<string[]>([]);
-  const [responses, setResponses] = useState<any[]>([]);
+  const [responses, setResponses] = useState<string[]>([]);
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
@@ -42,8 +42,11 @@ const CandidateDeciderInstanceCreator: React.FC = () => {
     reader.onload = () => {
       const str = reader.result as string;
       const headers = str.slice(0, str.indexOf('\n')).split(',');
+      const rows = str.slice(str.indexOf('\n') + 1).split('\n');
       setHeaders(headers);
-      csv()
+      csv({
+        noheader: true
+      })
         .fromString(str)
         .then((parsedResponses) => setResponses(parsedResponses));
     };

--- a/frontend/src/components/Admin/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider.tsx
@@ -31,7 +31,7 @@ const CandidateDeciderInstanceCreator: React.FC = () => {
   const [name, setName] = useState<string>('');
   const [success, setSuccess] = useState<boolean>(false);
   const [headers, setHeaders] = useState<string[]>([]);
-  const [responses, setResponses] = useState<string[]>([]);
+  const [responses, setResponses] = useState<string[][]>([[]]);
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
@@ -42,12 +42,13 @@ const CandidateDeciderInstanceCreator: React.FC = () => {
     reader.onload = () => {
       const str = reader.result as string;
       const headers = str.slice(0, str.indexOf('\n')).split(',');
-      const rows = str.slice(str.indexOf('\n') + 1).split('\n');
+      const rows = str.slice(str.indexOf('\n') + 1);
       setHeaders(headers);
       csv({
-        noheader: true
+        noheader: true,
+        output: 'csv'
       })
-        .fromString(str)
+        .fromString(rows)
         .then((parsedResponses) => setResponses(parsedResponses));
     };
   };

--- a/frontend/src/components/Admin/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider.tsx
@@ -1,0 +1,5 @@
+const AdminCandidateDecider = () => {
+  return 'Hello World';
+};
+
+export default AdminCandidateDecider;

--- a/frontend/src/components/Admin/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button, Form, Loader, Header, Message, Card, Checkbox } from 'semantic-ui-react';
-import styles from './AdminCandidateDecider.module.css';
 import csv from 'csvtojson';
+import styles from './AdminCandidateDecider.module.css';
 
 const mockInstances = [
   {
@@ -20,14 +20,12 @@ const mockInstances = [
   }
 ];
 
-const AdminCandidateDeciderBase: React.FC = () => {
-  return (
-    <div id={styles.adminCandidateDeciderContainer}>
-      <CandidateDeciderInstanceCreator />
-      <CandidateDeciderInstanceList />
-    </div>
-  );
-};
+const AdminCandidateDeciderBase: React.FC = () => (
+  <div id={styles.adminCandidateDeciderContainer}>
+    <CandidateDeciderInstanceCreator />
+    <CandidateDeciderInstanceList />
+  </div>
+);
 
 const CandidateDeciderInstanceCreator: React.FC = () => {
   const [name, setName] = useState<string>('');

--- a/frontend/src/components/Admin/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Button, Form, Loader, Header, Message, Card } from 'semantic-ui-react';
+import { Button, Form, Loader, Header, Message, Card, Checkbox } from 'semantic-ui-react';
 import styles from './AdminCandidateDecider.module.css';
 import csv from 'csvtojson';
 
@@ -9,7 +9,14 @@ const mockInstances = [
     isOpen: true,
     headers: [],
     candidates: [],
-    uuid: 'life'
+    uuid: 'asdfjkl'
+  },
+  {
+    name: 'Developer Fall 2022 Recruitment',
+    isOpen: true,
+    headers: [],
+    candidates: [],
+    uuid: 'hello-world'
   }
 ];
 
@@ -46,11 +53,13 @@ const CandidateDeciderInstanceCreator: React.FC = () => {
 
   const handleSubmit = () => {
     const instance = {
+      uuid: '',
       name,
       headers,
-      candidates: responses,
+      candidates: responses.map((res, i) => ({ id: i, responses: res, comments: [], ratings: [] })),
       isOpen: true
     };
+    setSuccess(true);
     console.log(instance);
     console.log('FORM SUBMITTED');
   };
@@ -84,9 +93,18 @@ const CandidateDeciderInstanceList: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
+    // TODO pull from backend
     setInstances(mockInstances);
     setIsLoading(false);
   }, []);
+
+  const toggleIsOpen = (uuid: string) => {
+    const updatedInstances = instances.map((instance) =>
+      instance.uuid === uuid ? { ...instance, isOpen: !instance.isOpen } : instance
+    );
+    setInstances(updatedInstances);
+    // TODO update in backend
+  };
 
   return (
     <div id={styles.listContainer}>
@@ -99,11 +117,18 @@ const CandidateDeciderInstanceList: React.FC = () => {
             {instances.map((instance) => (
               <Card
                 color={instance.isOpen ? 'green' : 'red'}
-                href={`candidate-decider/${instance.uuid}`}
+                // href={`candidate-decider/${instance.uuid}`}
+                key={instance.uuid}
               >
+                {console.log(instance.isOpen)}
                 <Card.Content>
                   <Card.Header>{instance.name}</Card.Header>
                   <Card.Meta>{instance.isOpen ? 'Open' : 'Closed'}</Card.Meta>
+                  <Checkbox
+                    toggle
+                    defaultChecked={instance.isOpen}
+                    onChange={() => toggleIsOpen(instance.uuid)}
+                  />
                 </Card.Content>
               </Card>
             ))}

--- a/frontend/src/components/Admin/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider.tsx
@@ -1,5 +1,42 @@
-const AdminCandidateDecider = () => {
-  return 'Hello World';
+import React, { useState } from 'react';
+import { Button, Form } from 'semantic-ui-react';
+
+const parseCSV = (str: string, delimiter: string): any[] => {
+  return [];
 };
 
-export default AdminCandidateDecider;
+const AdminCandidateDeciderBase: React.FC = () => {
+  return <CandidateDeciderInstanceCreator />;
+};
+
+const CandidateDeciderInstanceCreator: React.FC = () => {
+  const [name, setName] = useState<string>('');
+  const [responses, setResponses] = useState<any[]>([]);
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    const file = e.target.files[0];
+    const reader = new FileReader();
+
+    reader.readAsText(file);
+    reader.onload = () => {
+      setResponses(parseCSV(reader.result as string, ','));
+    };
+  };
+
+  const handleSubmit = () => {
+    console.log('FORM SUBMISSION');
+  };
+
+  return (
+    <Form>
+      <Form.Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+      <input type="file" accept=".csv" onChange={handleFileUpload} />
+      <Button type="submit" onClick={handleSubmit} disabled={!name || responses.length === 0}>
+        Create Candidate Decider Instance
+      </Button>
+    </Form>
+  );
+};
+
+export default AdminCandidateDeciderBase;

--- a/frontend/src/components/Admin/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider.tsx
@@ -1,16 +1,31 @@
-import React, { useState } from 'react';
-import { Button, Form } from 'semantic-ui-react';
+import React, { useState, useEffect } from 'react';
+import { Button, Form, Loader, Header, Message, Card } from 'semantic-ui-react';
+import styles from './AdminCandidateDecider.module.css';
+import csv from 'csvtojson';
 
-const parseCSV = (str: string, delimiter: string): any[] => {
-  return [];
-};
+const mockInstances = [
+  {
+    name: 'Developer Spring 2022 Recruitment',
+    isOpen: true,
+    headers: [],
+    candidates: [],
+    uuid: 'life'
+  }
+];
 
 const AdminCandidateDeciderBase: React.FC = () => {
-  return <CandidateDeciderInstanceCreator />;
+  return (
+    <div id={styles.adminCandidateDeciderContainer}>
+      <CandidateDeciderInstanceCreator />
+      <CandidateDeciderInstanceList />
+    </div>
+  );
 };
 
 const CandidateDeciderInstanceCreator: React.FC = () => {
   const [name, setName] = useState<string>('');
+  const [success, setSuccess] = useState<boolean>(false);
+  const [headers, setHeaders] = useState<string[]>([]);
   const [responses, setResponses] = useState<any[]>([]);
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -20,22 +35,82 @@ const CandidateDeciderInstanceCreator: React.FC = () => {
 
     reader.readAsText(file);
     reader.onload = () => {
-      setResponses(parseCSV(reader.result as string, ','));
+      const str = reader.result as string;
+      const headers = str.slice(0, str.indexOf('\n')).split(',');
+      setHeaders(headers);
+      csv()
+        .fromString(str)
+        .then((parsedResponses) => setResponses(parsedResponses));
     };
   };
 
   const handleSubmit = () => {
-    console.log('FORM SUBMISSION');
+    const instance = {
+      name,
+      headers,
+      candidates: responses,
+      isOpen: true
+    };
+    console.log(instance);
+    console.log('FORM SUBMITTED');
   };
 
   return (
-    <Form>
-      <Form.Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
-      <input type="file" accept=".csv" onChange={handleFileUpload} />
-      <Button type="submit" onClick={handleSubmit} disabled={!name || responses.length === 0}>
-        Create Candidate Decider Instance
-      </Button>
-    </Form>
+    <div>
+      <Header as="h2">Create a new Candidate Decider instance</Header>
+      <Form success={success}>
+        <Form.Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <input type="file" accept=".csv" onChange={handleFileUpload} />
+        <Message
+          success
+          header="Form Submitted"
+          content="Successfully created a new Candidate Decider instance"
+        ></Message>
+        <Button
+          id={styles.submitButton}
+          type="submit"
+          onClick={handleSubmit}
+          disabled={!name || responses.length === 0}
+        >
+          Create Candidate Decider Instance
+        </Button>
+      </Form>
+    </div>
+  );
+};
+
+const CandidateDeciderInstanceList: React.FC = () => {
+  const [instances, setInstances] = useState<CandidateDeciderInstance[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    setInstances(mockInstances);
+    setIsLoading(false);
+  }, []);
+
+  return (
+    <div id={styles.listContainer}>
+      <Header as="h2">All Candidate Decider Instances</Header>
+      {isLoading ? (
+        <Loader active size="large" />
+      ) : (
+        <div id={styles.itemsContainer}>
+          <Card.Group>
+            {instances.map((instance) => (
+              <Card
+                color={instance.isOpen ? 'green' : 'red'}
+                href={`candidate-decider/${instance.uuid}`}
+              >
+                <Card.Content>
+                  <Card.Header>{instance.name}</Card.Header>
+                  <Card.Meta>{instance.isOpen ? 'Open' : 'Closed'}</Card.Meta>
+                </Card.Content>
+              </Card>
+            ))}
+          </Card.Group>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/frontend/src/components/Admin/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider.tsx
@@ -113,12 +113,7 @@ const CandidateDeciderInstanceList: React.FC = () => {
         <div id={styles.itemsContainer}>
           <Card.Group>
             {instances.map((instance) => (
-              <Card
-                color={instance.isOpen ? 'green' : 'red'}
-                // href={`candidate-decider/${instance.uuid}`}
-                key={instance.uuid}
-              >
-                {console.log(instance.isOpen)}
+              <Card color={instance.isOpen ? 'green' : 'red'} key={instance.uuid}>
                 <Card.Content>
                   <Card.Header>{instance.name}</Card.Header>
                   <Card.Meta>{instance.isOpen ? 'Open' : 'Closed'}</Card.Meta>

--- a/frontend/src/pages/admin/candidate-decider.tsx
+++ b/frontend/src/pages/admin/candidate-decider.tsx
@@ -1,0 +1,3 @@
+import AdminCandidateDecider from '../../components/Admin/AdminCandidateDecider';
+
+export default AdminCandidateDecider;

--- a/frontend/src/pages/admin/candidate-decider.tsx
+++ b/frontend/src/pages/admin/candidate-decider.tsx
@@ -1,3 +1,3 @@
-import AdminCandidateDecider from '../../components/Admin/AdminCandidateDecider';
+import AdminCandidateDeciderBase from '../../components/Admin/AdminCandidateDecider';
 
-export default AdminCandidateDecider;
+export default AdminCandidateDeciderBase;

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -44,6 +44,12 @@ const navCardItems: readonly NavigationCardItem[] = [
     adminOnly: true
   },
   {
+    header: 'Edit Candidate Decider Instances',
+    description: 'Create, edit, or delete Candidate Decider instances',
+    link: '/admin/candidate-decider',
+    adminOnly: true
+  },
+  {
     header: 'Example Unstable Hidden Page',
     description: 'An example page visible to admin only. It can be used to gate unstable features.',
     link: '/admin/hidden',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4978,6 +4978,15 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
   integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
 
+csvtojson@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/csvtojson/-/csvtojson-2.0.10.tgz#11e7242cc630da54efce7958a45f443210357574"
+  integrity sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==
+  dependencies:
+    bluebird "^3.5.1"
+    lodash "^4.17.3"
+    strip-bom "^2.0.0"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -9543,7 +9552,7 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request is the first step towards integrating Candidate Decider into IDOL. It adds an admin page for creating new "instances" of Candidate Decider where IDOL admins can upload a csv file of the application results spreadsheet to create a new instance. 

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/65922473/153489531-eeb1b699-402d-48d0-96c8-5551ecc49466.png">

The uploaded csv file is parsed into `CandidateDeciderInstance` type: 
```
interface CandidateDeciderRating {
  readonly reviewer: IdolMember;
  readonly rating: number;
}

interface CandidateDeciderComment {
  readonly reviewer: IdolMember;
  readonly comment: string;
}

interface CandidateDeciderCandidate {
  readonly responses: any[];
  readonly id: number;
  ratings: CandidateDeciderRating[];
  comments: CandidateDeciderComment[];
}

interface CandidateDeciderInstance {
  readonly name: string;
  readonly headers: string[];
  readonly candidates: CandidateDeciderCandidate[];
  readonly uuid: string;
  isOpen: boolean;
}

```


### Test Plan <!-- Required -->
👀 
