### PR TITLE
Testing as non-admin user locally

### DIFF
--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -4,6 +4,7 @@ import { onSnapshot } from 'firebase/firestore';
 import { adminsCollection, membersCollection, approvedMembersCollection } from '../../firebase';
 import { useUserEmail } from './UserProvider';
 import { Team } from '../../API/TeamsAPI';
+import { allowAdmin } from '../../environment';
 
 type ListenedFirestoreData = {
   readonly adminEmails?: readonly string[];
@@ -34,7 +35,7 @@ export const useHasAdminPermission = (): boolean => {
   const userEmail = useUserEmail();
   const self = useSelf();
   const adminEmails = useAdminEmails();
-  return self?.role === 'lead' || adminEmails.includes(userEmail);
+  return allowAdmin && (self?.role === 'lead' || adminEmails.includes(userEmail));
 };
 
 export const useTeamNames = (): readonly string[] => {

--- a/frontend/src/environment.test.ts
+++ b/frontend/src/environment.test.ts
@@ -1,5 +1,7 @@
-import { useProdDb, useProdBackendForDev } from './environment';
+import { useProdDb, useProdBackendForDev, allowAdmin } from './environment';
 
 test('useProdDb check', () => expect(useProdDb).toEqual(true));
 
 test('useProdBackendForDev', () => expect(useProdBackendForDev).toEqual(false));
+
+test('allowAdmin', () => expect(allowAdmin).toBe(true));

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -6,6 +6,9 @@ export const useProdBackendForDev = false;
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
 export const useProdDb = true;
 
+/** Switch to false to test IDOL as a non-admin user. Change back to true before committing. */
+export const allowAdmin = true;
+
 export const backendURL =
   isProduction || !useProdBackendForDev
     ? '/.netlify/functions/api'


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds a feature that allows testing as a non-admin user locally. You can do this by setting `allowAdmin` in `frontend/src/environmen.ts` to `false` and you will effectively be a non-admin user on IDOL. 

### Test Plan <!-- Required -->

N/A

