### PR TITLE
Connect admin forms for team event credit to the api and display details

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -216,7 +216,7 @@ loginCheckedPost('/updateTeamEvent', async (req, user) => ({
   event: await updateTeamEvent(req.body, user)
 }));
 loginCheckedPost('/deleteTeamEvent', async (req, user) => ({
-  team: await deleteTeamEvent(req.body, user)
+  event: await deleteTeamEvent(req.body, user)
 }));
 
 // Candidate Decider

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -36,6 +36,7 @@ import {
   createTeamEvent,
   deleteTeamEvent,
   getAllTeamEvents,
+  getTeamEvent,
   updateTeamEvent
 } from './team-eventsAPI';
 
@@ -207,6 +208,9 @@ loginCheckedPost('/signinAll', async (_, user) => allSignInForms(user));
 
 // Team Events
 loginCheckedPost('/createTeamEvent', async (req, user) => createTeamEvent(req.body, user));
+loginCheckedGet('/getTeamEvent/:uuid', async (req, user) => ({
+  event: await getTeamEvent(req.params.uuid, user)
+}));
 loginCheckedGet('/getAllTeamEvents', async (_, user) => ({ events: await getAllTeamEvents(user) }));
 loginCheckedPost('/updateTeamEvent', async (req, user) => ({
   event: await updateTeamEvent(req.body, user)

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -215,9 +215,10 @@ loginCheckedGet('/getAllTeamEvents', async (_, user) => ({ events: await getAllT
 loginCheckedPost('/updateTeamEvent', async (req, user) => ({
   event: await updateTeamEvent(req.body, user)
 }));
-loginCheckedPost('/deleteTeamEvent', async (req, user) => ({
-  event: await deleteTeamEvent(req.body, user)
-}));
+loginCheckedPost('/deleteTeamEvent', async (req, user) => {
+  await deleteTeamEvent(req.body, user);
+  return {};
+});
 
 // Candidate Decider
 loginCheckedGet('/getAllCandidateDeciderInstances', async (_, user) => ({

--- a/backend/src/team-eventsAPI.ts
+++ b/backend/src/team-eventsAPI.ts
@@ -37,3 +37,6 @@ export const updateTeamEvent = async (
   await TeamEventsDao.updateTeamEvent(teamEvent);
   return teamEvent;
 };
+
+export const getTeamEvent = async (uuid: string, user: IdolMember): Promise<TeamEvent> =>
+  TeamEventsDao.getTeamEvent(uuid);

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -45,4 +45,12 @@ export class TeamEventsAPI {
       (res) => res.data.event
     );
   }
+
+  public static deleteTeamEventForm(teamEvent: Event): Promise<TeamEventResponseObj> {
+    return APIWrapper.post(`${backendURL}/deleteTeamEvent`, teamEvent).then((rest) => rest.data.event);
+  }
+
+  public static updateTeamEventForm(teamEvent: Event): Promise<TeamEventResponseObj> {
+    return APIWrapper.post(`${backendURL}/updateTeamEvent`, teamEvent).then((rest) => rest.data.event);
+  }
 }

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -27,6 +27,14 @@ export class TeamEventsAPI {
     });
   }
 
+  public static getTeamEventForm(uuid: string): Promise<Event> {
+    const eventProm = APIWrapper.get(`${backendURL}/getTeamEvent/${uuid}`).then((res) => res.data);
+    return eventProm.then((val) => {
+      const event = val.event as Event;
+      return event;
+    });
+  }
+
   public static createTeamEventForm(teamEvent: Event): Promise<TeamEventResponseObj> {
     return APIWrapper.post(`${backendURL}/createTeamEvent`, teamEvent).then((res) => res.data);
   }

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -46,8 +46,8 @@ export class TeamEventsAPI {
     );
   }
 
-  public static deleteTeamEventForm(teamEvent: Event): Promise<TeamEventResponseObj> {
-    return APIWrapper.post(`${backendURL}/deleteTeamEvent`, teamEvent).then((rest) => rest.data.event);
+  public static async deleteTeamEventForm(teamEvent: Event): Promise<void> {
+    await APIWrapper.post(`${backendURL}/deleteTeamEvent`, teamEvent);
   }
 
   public static updateTeamEventForm(teamEvent: Event): Promise<TeamEventResponseObj> {

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -51,6 +51,8 @@ export class TeamEventsAPI {
   }
 
   public static updateTeamEventForm(teamEvent: Event): Promise<TeamEventResponseObj> {
-    return APIWrapper.post(`${backendURL}/updateTeamEvent`, teamEvent).then((rest) => rest.data.event);
+    return APIWrapper.post(`${backendURL}/updateTeamEvent`, teamEvent).then(
+      (rest) => rest.data.event
+    );
   }
 }

--- a/frontend/src/components/Admin/EditTeamEvent.tsx
+++ b/frontend/src/components/Admin/EditTeamEvent.tsx
@@ -17,8 +17,8 @@ const EditTeamEvent = (props: { teamEvent: TeamEvent }): JSX.Element => {
         });
       } else {
         Emitters.generalSuccess.emit({
-          headerMsg: 'Team Event Created!',
-          contentMsg: 'The team event was successfully editted!'
+          headerMsg: 'Team Event Edited!',
+          contentMsg: 'The team event was successfully edited!'
         });
       }
     });

--- a/frontend/src/components/Admin/EditTeamEvent.tsx
+++ b/frontend/src/components/Admin/EditTeamEvent.tsx
@@ -20,6 +20,7 @@ const EditTeamEvent = (props: { teamEvent: TeamEvent }): JSX.Element => {
           headerMsg: 'Team Event Edited!',
           contentMsg: 'The team event was successfully edited!'
         });
+        Emitters.teamEventsUpdated.emit();
       }
     });
   };

--- a/frontend/src/components/Admin/EditTeamEvent.tsx
+++ b/frontend/src/components/Admin/EditTeamEvent.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { Modal, Button } from 'semantic-ui-react';
+import { TeamEventsAPI } from '../../API/TeamEventsAPI';
+import { Emitters } from '../../utils';
 import TeamEventForm from './TeamEventForm';
 
 const EditTeamEvent = (props: { teamEvent: TeamEvent }): JSX.Element => {
@@ -7,7 +9,19 @@ const EditTeamEvent = (props: { teamEvent: TeamEvent }): JSX.Element => {
   const [open, setOpen] = useState(false);
 
   const editTeamEvent = (teamEvent: TeamEvent) => {
-    // send edited event to backend
+    TeamEventsAPI.updateTeamEventForm(teamEvent).then((val) => {
+      if (val.error) {
+        Emitters.generalError.emit({
+          headerMsg: "Couldn't edit the team event!",
+          contentMsg: val.error
+        });
+      } else {
+        Emitters.generalSuccess.emit({
+          headerMsg: 'Team Event Created!',
+          contentMsg: 'The team event was successfully editted!'
+        });
+      }
+    });
   };
 
   return (

--- a/frontend/src/components/Admin/TeamEventDetails.module.css
+++ b/frontend/src/components/Admin/TeamEventDetails.module.css
@@ -20,14 +20,15 @@
 
 .eventDetailsContainer {
   display: flex;
-  flex-direction: row;
-  justify-content: space-between; 
-  align-items: center;
+  justify-content: space-between;
+  margin: 1em;
+  align-self: center;
 }
 
 .eventDetails {
   color: gray;
-  border: 1px solid;
+  display: inline-block;
+  margin: auto;
 }
 
 .listsContainer {
@@ -38,6 +39,10 @@
 .listContainer {
   width: 50%;
   margin: 0 2em;
+}
+
+.memberGroup {
+  justify-content: center;
 }
 
 .memberTitle {

--- a/frontend/src/components/Admin/TeamEventDetails.module.css
+++ b/frontend/src/components/Admin/TeamEventDetails.module.css
@@ -14,13 +14,20 @@
   cursor: pointer;
 }
 
-.eventName,
-.eventDate {
+.eventName {
   text-align: center;
 }
 
-.eventDate {
+.eventDetailsContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between; 
+  align-items: center;
+}
+
+.eventDetails {
   color: gray;
+  border: 1px solid;
 }
 
 .listsContainer {

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -23,7 +23,8 @@ const TeamEventDetails: React.FC = () => {
 
   useEffect(() => {
     TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => setTeamEvent(teamEvent));
-  });
+    console.log("here");
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -23,7 +23,6 @@ const TeamEventDetails: React.FC = () => {
 
   useEffect(() => {
     TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => setTeamEvent(teamEvent));
-    console.log("here");
   }, []);
 
   return (
@@ -55,7 +54,7 @@ const TeamEventDetails: React.FC = () => {
           <h2 className={styles.memberTitle}>Members Pending</h2>
 
           {teamEvent.requests.length > 0 ? (
-            <Card.Group>
+            <Card.Group className={styles.memberGroup}>
               {teamEvent.requests.map((req) => (
                 <Card key={req.member.netid}>
                   <Card.Content>
@@ -76,7 +75,7 @@ const TeamEventDetails: React.FC = () => {
           <h2 className={styles.memberTitle}>Members Approved</h2>
 
           {teamEvent.attendees.length > 0 ? (
-            <Card.Group>
+            <Card.Group className={styles.memberGroup}>
               {teamEvent.attendees.map((req) => (
                 <Card key={req.member.netid}>
                   <Card.Content>

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -17,7 +17,6 @@ const defaultTeamEvent: TeamEvent = {
 };
 
 const TeamEventDetails: React.FC = () => {
-  // use query.uuid to fetch the team event from firebase
   const location = useRouter();
   const uuid = location.query.uuid as string;
   const [teamEvent, setTeamEvent] = useState<TeamEvent>(defaultTeamEvent);
@@ -44,7 +43,11 @@ const TeamEventDetails: React.FC = () => {
       </div>
 
       <h1 className={styles.eventName}>{teamEvent.name}</h1>
-      <h2 className={styles.eventDate}>{teamEvent.date}</h2>
+      <div className={styles.eventDetailsContainer}>
+        <h3 className={styles.eventDetails}>Date: {teamEvent.date}</h3>
+        <h3 className={styles.eventDetails}>Credits: {teamEvent.numCredits}</h3>
+        <h3 className={styles.eventDetails}>Has Hours: {teamEvent.hasHours ? 'yes' : 'no'}</h3>
+      </div>
 
       <div className={styles.listsContainer}>
         <div className={styles.listContainer}>

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -28,10 +28,10 @@ const TeamEventDetails: React.FC = () => {
 
   const deleteTeamEvent = () => {
     TeamEventsAPI.deleteTeamEventForm(teamEvent).then(() => {
-        Emitters.generalSuccess.emit({
-          headerMsg: 'Team Event Deleted!',
-          contentMsg: 'The team event was successfully deleted!'
-        });
+      Emitters.generalSuccess.emit({
+        headerMsg: 'Team Event Deleted!',
+        contentMsg: 'The team event was successfully deleted!'
+      });
     });
     location.push('/admin/team-events');
   };
@@ -48,7 +48,15 @@ const TeamEventDetails: React.FC = () => {
             trigger={<Button color="red">Delete Event</Button>}
             header="Delete Team Event"
             content="Are you sure that you want to delete this event?"
-            actions={['Cancel', { key: 'deleteEvent', content: 'Delete Event', color: 'red', onClick: deleteTeamEvent}]}
+            actions={[
+              'Cancel',
+              {
+                key: 'deleteEvent',
+                content: 'Delete Event',
+                color: 'red',
+                onClick: deleteTeamEvent
+              }
+            ]}
           />
         </div>
       </div>

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -39,7 +39,7 @@ const TeamEventDetails: React.FC = () => {
   });
 
   useEffect(() => {
-    if(isLoading) {
+    if (isLoading) {
       TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => setTeamEvent(teamEvent));
       setLoading(false);
     }

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -1,86 +1,95 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, Message, Modal, Button } from 'semantic-ui-react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import EditTeamEvent from './EditTeamEvent';
 import styles from './TeamEventDetails.module.css';
+import { TeamEventsAPI } from '../../API/TeamEventsAPI';
 
-const mockTeamEvent: TeamEvent = {
-  name: 'Info Session',
-  date: '2021-11-17',
-  numCredits: '1',
+const defaultTeamEvent: TeamEvent = {
+  name: '',
+  date: '',
+  numCredits: '',
   hasHours: false,
   requests: [],
   attendees: [],
-  uuid: '1'
+  uuid: ''
 };
 
-const TeamEventDetails: React.FC = () => (
+const TeamEventDetails: React.FC = () => {
   // use query.uuid to fetch the team event from firebase
-  // const { query } = useRouter();
+  const location = useRouter();
+  const uuid = location.query.uuid as string;
+  const [teamEvent, setTeamEvent] = useState<TeamEvent>(defaultTeamEvent);
 
-  <div className={styles.container}>
-    <div className={styles.arrowAndButtons}>
-      <Link href="/admin/team-events">
-        <span className={styles.arrow}>&#8592;</span>
-      </Link>
+  useEffect(() => {
+    TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => setTeamEvent(teamEvent));
+  });
 
-      <div>
-        <EditTeamEvent teamEvent={mockTeamEvent}></EditTeamEvent>
-        <Modal
-          trigger={<Button color="red">Delete Event</Button>}
-          header="Delete Team Event"
-          content="Are you sure that you want to delete this event?"
-          actions={['Cancel', { key: 'deleteEvent', content: 'Delete Event', color: 'red' }]}
-        />
+  return (
+    <div className={styles.container}>
+      <div className={styles.arrowAndButtons}>
+        <Link href="/admin/team-events">
+          <span className={styles.arrow}>&#8592;</span>
+        </Link>
+        <div>
+          <EditTeamEvent teamEvent={teamEvent}></EditTeamEvent>
+          <Modal
+            trigger={<Button color="red">Delete Event</Button>}
+            header="Delete Team Event"
+            content="Are you sure that you want to delete this event?"
+            actions={['Cancel', { key: 'deleteEvent', content: 'Delete Event', color: 'red' }]}
+          />
+        </div>
+      </div>
+
+      <h1 className={styles.eventName}>{teamEvent.name}</h1>
+      <h2 className={styles.eventDate}>{teamEvent.date}</h2>
+
+      <div className={styles.listsContainer}>
+        <div className={styles.listContainer}>
+          <h2 className={styles.memberTitle}>Members Pending</h2>
+
+          {teamEvent.requests.length > 0 ? (
+            <Card.Group>
+              {teamEvent.requests.map((req) => (
+                <Card key={req.member.netid}>
+                  <Card.Content>
+                    <Card.Header>
+                      {req.member.firstName} {req.member.lastName}
+                    </Card.Header>
+                    <Card.Meta>{req.member.email}</Card.Meta>
+                  </Card.Content>
+                </Card>
+              ))}
+            </Card.Group>
+          ) : (
+            <Message>There are currently no pending members for this event.</Message>
+          )}
+        </div>
+
+        <div className={styles.listContainer}>
+          <h2 className={styles.memberTitle}>Members Approved</h2>
+
+          {teamEvent.attendees.length > 0 ? (
+            <Card.Group>
+              {teamEvent.attendees.map((req) => (
+                <Card key={req.member.netid}>
+                  <Card.Content>
+                    <Card.Header>
+                      {req.member.firstName} {req.member.lastName}
+                    </Card.Header>
+                    <Card.Meta>{req.member.email}</Card.Meta>
+                  </Card.Content>
+                </Card>
+              ))}
+            </Card.Group>
+          ) : (
+            <Message>There are currently no approved members for this event.</Message>
+          )}
+        </div>
       </div>
     </div>
-
-    <h1 className={styles.eventName}>{mockTeamEvent.name}</h1>
-    <h2 className={styles.eventDate}>{mockTeamEvent.date}</h2>
-
-    <div className={styles.listsContainer}>
-      <div className={styles.listContainer}>
-        <h2 className={styles.memberTitle}>Members Pending</h2>
-
-        {mockTeamEvent.requests.length > 0 ? (
-          <Card.Group>
-            {mockTeamEvent.requests.map((req) => (
-              <Card key={req.member.netid}>
-                <Card.Content>
-                  <Card.Header>
-                    {req.member.firstName} {req.member.lastName}
-                  </Card.Header>
-                  <Card.Meta>{req.member.email}</Card.Meta>
-                </Card.Content>
-              </Card>
-            ))}
-          </Card.Group>
-        ) : (
-          <Message>There are currently no pending members for this event.</Message>
-        )}
-      </div>
-
-      <div className={styles.listContainer}>
-        <h2 className={styles.memberTitle}>Members Approved</h2>
-
-        {mockTeamEvent.attendees.length > 0 ? (
-          <Card.Group>
-            {mockTeamEvent.attendees.map((req) => (
-              <Card key={req.member.netid}>
-                <Card.Content>
-                  <Card.Header>
-                    {req.member.firstName} {req.member.lastName}
-                  </Card.Header>
-                  <Card.Meta>{req.member.email}</Card.Meta>
-                </Card.Content>
-              </Card>
-            ))}
-          </Card.Group>
-        ) : (
-          <Message>There are currently no approved members for this event.</Message>
-        )}
-      </div>
-    </div>
-  </div>
-);
+  );
+};
 export default TeamEventDetails;

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -21,10 +21,29 @@ const TeamEventDetails: React.FC = () => {
   const location = useRouter();
   const uuid = location.query.uuid as string;
   const [teamEvent, setTeamEvent] = useState<TeamEvent>(defaultTeamEvent);
+  const [isLoading, setLoading] = useState(true);
+
+  const fullReset = () => {
+    setLoading(true);
+    setTeamEvent(defaultTeamEvent);
+  };
 
   useEffect(() => {
-    TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => setTeamEvent(teamEvent));
-  }, []);
+    const cb = () => {
+      fullReset();
+    };
+    Emitters.teamEventsUpdated.subscribe(cb);
+    return () => {
+      Emitters.teamEventsUpdated.unsubscribe(cb);
+    };
+  });
+
+  useEffect(() => {
+    if(isLoading) {
+      TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => setTeamEvent(teamEvent));
+      setLoading(false);
+    }
+  }, [isLoading]);
 
   const deleteTeamEvent = () => {
     TeamEventsAPI.deleteTeamEventForm(teamEvent).then(() => {

--- a/frontend/src/components/Admin/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEventDetails.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import EditTeamEvent from './EditTeamEvent';
 import styles from './TeamEventDetails.module.css';
 import { TeamEventsAPI } from '../../API/TeamEventsAPI';
+import { Emitters } from '../../utils';
 
 const defaultTeamEvent: TeamEvent = {
   name: '',
@@ -25,6 +26,16 @@ const TeamEventDetails: React.FC = () => {
     TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => setTeamEvent(teamEvent));
   }, []);
 
+  const deleteTeamEvent = () => {
+    TeamEventsAPI.deleteTeamEventForm(teamEvent).then(() => {
+        Emitters.generalSuccess.emit({
+          headerMsg: 'Team Event Deleted!',
+          contentMsg: 'The team event was successfully deleted!'
+        });
+    });
+    location.push('/admin/team-events');
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.arrowAndButtons}>
@@ -37,7 +48,7 @@ const TeamEventDetails: React.FC = () => {
             trigger={<Button color="red">Delete Event</Button>}
             header="Delete Team Event"
             content="Are you sure that you want to delete this event?"
-            actions={['Cancel', { key: 'deleteEvent', content: 'Delete Event', color: 'red' }]}
+            actions={['Cancel', { key: 'deleteEvent', content: 'Delete Event', color: 'red', onClick: deleteTeamEvent}]}
           />
         </div>
       </div>

--- a/frontend/src/components/Admin/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEventForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Form, Radio, Button } from 'semantic-ui-react';
+import { TeamEventsAPI } from '../../API/TeamEventsAPI';
 import { Emitters } from '../../utils';
 import styles from './TeamEventForm.module.css';
 
@@ -17,10 +18,6 @@ const TeamEventForm = (props: Props): JSX.Element => {
   const [teamEventDate, setTeamEventDate] = useState(teamEvent?.date || '');
   const [teamEventCreditNum, setTeamEventCreditNum] = useState(teamEvent?.numCredits || '');
   const [teamEventHasHours, setTeamEventHasHours] = useState(teamEvent?.hasHours || false);
-
-  const createTeamEvent = (teamEvent: TeamEvent) => {
-    // send new event to backend
-  };
 
   const submitTeamEvent = () => {
     if (!teamEventName) {
@@ -66,10 +63,18 @@ const TeamEventForm = (props: Props): JSX.Element => {
         requests: [],
         attendees: []
       };
-      createTeamEvent(newTeamEvent);
-      Emitters.generalSuccess.emit({
-        headerMsg: 'Team Event Created!',
-        contentMsg: 'The team event was successfully created!'
+      TeamEventsAPI.createTeamEventForm(newTeamEvent).then((val) => {
+        if (val.error) {
+          Emitters.generalError.emit({
+            headerMsg: "Couldn't create the team event!",
+            contentMsg: val.error
+          });
+        } else {
+          Emitters.generalSuccess.emit({
+            headerMsg: 'Team Event Created!',
+            contentMsg: 'The team event was successfully created!'
+          });
+        }
       });
     }
   };

--- a/frontend/src/components/Admin/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEventForm.tsx
@@ -74,6 +74,7 @@ const TeamEventForm = (props: Props): JSX.Element => {
             headerMsg: 'Team Event Created!',
             contentMsg: 'The team event was successfully created!'
           });
+          Emitters.teamEventsUpdated.emit();
         }
       });
     }

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -29,18 +29,22 @@ const TeamEvents: React.FC = () => {
       </div>
       <div className={styles.wrapper}>
         <h2>View All Team Events</h2>
-        <Card.Group>
-          {teamEvents.map((teamEvent) => (
-            <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
-              <Card>
-                <Card.Content>
-                  <Card.Header>{teamEvent.name} </Card.Header>
-                  <Card.Meta>{teamEvent.date}</Card.Meta>
-                </Card.Content>
-              </Card>
-            </Link>
-          ))}
-        </Card.Group>
+        {teamEvents.length !== 0 ? (
+          <Card.Group>
+            {teamEvents.map((teamEvent) => (
+              <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
+                <Card>
+                  <Card.Content>
+                    <Card.Header>{teamEvent.name} </Card.Header>
+                    <Card.Meta>{teamEvent.date}</Card.Meta>
+                  </Card.Content>
+                </Card>
+              </Link>
+            ))}
+          </Card.Group>
+        ) : (
+          <Message>There are currently no team event forms.</Message>
+        )}
       </div>
       <div className={styles.wrapper}>
         <h2>Approve Pending Credit Requests</h2>

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -5,13 +5,35 @@ import TeamEventForm from './TeamEventForm';
 import styles from './TeamEvents.module.css';
 import AramHeadshot from '../../static/images/aram-headshot.jpg';
 import { TeamEventsAPI } from '../../API/TeamEventsAPI';
+import { Emitters } from '../../utils';
 
 const TeamEvents: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
+  const [isLoading, setLoading] = useState(true);
+
+  const fullReset = () => {
+    setLoading(true);
+    setTeamEvents([]);
+  };
 
   useEffect(() => {
-    TeamEventsAPI.getAllTeamEvents().then((teamEvents) => setTeamEvents(teamEvents));
-  }, []);
+    const cb = () => {
+      fullReset();
+    };
+    Emitters.teamEventsUpdated.subscribe(cb);
+    return () => {
+      Emitters.teamEventsUpdated.unsubscribe(cb);
+    };
+  });
+
+  useEffect(() => {
+    if (isLoading) {
+      TeamEventsAPI.getAllTeamEvents().then((teamEvents) => {
+        setTeamEvents(teamEvents);
+        setLoading(false);
+      });
+    }
+  }, [isLoading]);
 
   const pendingRequests: TeamEventAttendance[] = [];
 

--- a/frontend/src/components/Admin/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvents.tsx
@@ -1,31 +1,17 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, Button, Message, Image } from 'semantic-ui-react';
 import Link from 'next/link';
 import TeamEventForm from './TeamEventForm';
 import styles from './TeamEvents.module.css';
 import AramHeadshot from '../../static/images/aram-headshot.jpg';
+import { TeamEventsAPI } from '../../API/TeamEventsAPI';
 
 const TeamEvents: React.FC = () => {
-  const teamEvents: TeamEvent[] = [
-    {
-      name: 'Coffee Chat',
-      date: '2021-11-17',
-      numCredits: '0.5',
-      hasHours: false,
-      requests: [],
-      attendees: [],
-      uuid: '1'
-    },
-    {
-      uuid: '2',
-      name: 'Club Fest',
-      date: '2021-11-17',
-      numCredits: '0.5',
-      hasHours: true,
-      requests: [],
-      attendees: []
-    }
-  ];
+  const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
+
+  useEffect(() => {
+    TeamEventsAPI.getAllTeamEvents().then((teamEvents) => setTeamEvents(teamEvents));
+  }, []);
 
   const pendingRequests: TeamEventAttendance[] = [];
 

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 export const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = false;
+export const useProdDb = true;
 
 /** Switch to false to test IDOL as a non-admin user. Change back to true before committing. */
 export const allowAdmin = true;

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 export const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = true;
+export const useProdDb = false;
 
 /** Switch to false to test IDOL as a non-admin user. Change back to true before committing. */
 export const allowAdmin = true;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -77,4 +77,7 @@ export class Emitters {
     headerMsg: string;
     contentMsg: string;
   }> = new EventEmitter();
+
+  // Team Events
+  static teamEventsUpdated: EventEmitter<void> = new EventEmitter();
 }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request connects the admin forms for the team event credit to the api to create new events and display their details. The backend endpoints were updated to support the following.

- [x] create team event and update firebase
- [x] fetch and display all team events
- [x] fetch and display team event details
- [x] edit team events
- [x] delete team events

next pr:
- [ ] admin approval of members

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
tested the endpoints and above functionality locally; data collection was updated as expected and was displayed on frontend

**Creation of Team Event and Fetching all Team Events**
![image](https://user-images.githubusercontent.com/55467524/156418141-0d3469ff-a8c4-4bbb-ba83-a03c3e6ec2fe.png)

**Team Event Details**
![image](https://user-images.githubusercontent.com/55467524/156418045-35763412-39b2-4c66-9bf4-fa53ef2ddd53.png)

