### PR TITLE
Implement image uploading for team events

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -217,8 +217,8 @@ loginCheckedPost('/deleteTeamEvent', async (req, user) => ({
 }));
 
 // Team Events Proof Image
-loginCheckedGet('/getEventProofImageSignedURL', async (req, user) => ({
-  url: await setEventProofImage(req.body, user)
+loginCheckedGet('/getEventProofImageSignedURL/:name', async (req, user) => ({
+  url: await setEventProofImage(req.params.name, user)
 }));
 loginCheckedGet('/getEventProofImage', async (req, user) => ({
   url: await getEventProofImage(req.body, user)

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -45,6 +45,7 @@ import {
   toggleCandidateDeciderInstance,
   deleteCandidateDeciderInstance
 } from './candidateDeciderAPI';
+import { getEventProofImage, setEventProofImage } from './team-events-imageAPI';
 
 // Constants and configurations
 const app = express();
@@ -213,6 +214,14 @@ loginCheckedPost('/updateTeamEvent', async (req, user) => ({
 }));
 loginCheckedPost('/deleteTeamEvent', async (req, user) => ({
   team: await deleteTeamEvent(req.body, user)
+}));
+
+// Team Events Proof Image
+loginCheckedGet('/getEventProofImageSignedURL', async (req, user) => ({
+  url: await setEventProofImage(req.body, user)
+}));
+loginCheckedGet('/getEventProofImage', async (req, user) => ({
+  url: await getEventProofImage(req.body, user)
 }));
 
 // Candidate Decider

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -225,7 +225,7 @@ loginCheckedPost('/deleteTeamEvent', async (req, user) => {
 });
 
 // Team Events Proof Image
-loginCheckedGet('/getEventProofImageSignedURL/:name', async (req, user) => ({
+loginCheckedGet('/getEventProofImageSignedURL/:name(*)', async (req, user) => ({
   url: await setEventProofImage(req.params.name, user)
 }));
 loginCheckedGet('/getEventProofImage', async (req, user) => ({

--- a/backend/src/team-events-imageAPI.ts
+++ b/backend/src/team-events-imageAPI.ts
@@ -13,18 +13,20 @@ export const setEventProofImage = async (name: string, user: IdolMember): Promis
   return signedURL[0];
 };
 
-export const getEventProofImage = async (name: string, user: IdolMember): Promise<string> => {
+export const getEventProofImage = async (user: IdolMember): Promise<{signedUrl: string, imageName: string}> => {
   const netId: string = getNetIDFromEmail(user.email);
-  const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
+  const date: string = (new Date()).toISOString()
+  const file = bucket.file(`eventProofs/${netId}/${date}.jpg`);
   const fileExists = await file.exists().then((result) => result[0]);
   if (!fileExists) {
-    throw new NotFoundError(`The requested image (${netId}/${name}.jpg) does not exist`);
+    throw new NotFoundError(`The requested image (${netId}/${date}.jpg) does not exist`);
   }
   const signedUrl = await file.getSignedUrl({
     action: 'read',
     expires: Date.now() + 15 * 60000
   });
-  return signedUrl[0];
+  return {
+    signedUrl: signedUrl[0], imageName: `${netId}/${date}`};
 };
 
 export const allEventProofImagesForMember = async (

--- a/backend/src/team-events-imageAPI.ts
+++ b/backend/src/team-events-imageAPI.ts
@@ -3,9 +3,7 @@ import { getNetIDFromEmail } from './util';
 import { NotFoundError } from './errors';
 
 export const setEventProofImage = async (name: string, user: IdolMember): Promise<string> => {
-  const netId: string = getNetIDFromEmail(user.email);
-  console.log(name);
-  const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
+  const file = bucket.file(`${name}`);
   const signedURL = await file.getSignedUrl({
     action: 'write',
     version: 'v4',
@@ -15,11 +13,10 @@ export const setEventProofImage = async (name: string, user: IdolMember): Promis
 };
 
 export const getEventProofImage = async (name: string, user: IdolMember): Promise<string> => {
-  const netId: string = getNetIDFromEmail(user.email);
-  const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
+  const file = bucket.file(`${name}.jpg`);
   const fileExists = await file.exists().then((result) => result[0]);
   if (!fileExists) {
-    throw new NotFoundError(`The requested image (${netId}/${name}.jpg) does not exist`);
+    throw new NotFoundError(`The requested image (${name}) does not exist`);
   }
   const signedUrl = await file.getSignedUrl({
     action: 'read',
@@ -58,8 +55,7 @@ export const allEventProofImagesForMember = async (
 };
 
 export const deleteEventProofImage = async (name: string, user: IdolMember): Promise<void> => {
-  const netId: string = getNetIDFromEmail(user.email);
-  const imageFile = bucket.file(`eventProofs/${netId}/${name}.jpg`);
+  const imageFile = bucket.file(`${name}.jpg`);
   await imageFile.delete();
 };
 

--- a/backend/src/team-events-imageAPI.ts
+++ b/backend/src/team-events-imageAPI.ts
@@ -2,7 +2,7 @@ import { bucket } from './firebase';
 import { getNetIDFromEmail } from './util';
 import { NotFoundError } from './errors';
 
-export const setProofImage = async (user: IdolMember, name: string): Promise<string> => {
+export const setEventProofImage = async (name:string, user: IdolMember): Promise<string> => {
   const netId: string = getNetIDFromEmail(user.email);
   const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
   const signedURL = await file.getSignedUrl({
@@ -13,7 +13,7 @@ export const setProofImage = async (user: IdolMember, name: string): Promise<str
   return signedURL[0];
 };
 
-export const getProofImage = async (user: IdolMember, name: string): Promise<string> => {
+export const getEventProofImage = async (name: string, user: IdolMember): Promise<string> => {
   const netId: string = getNetIDFromEmail(user.email);
   const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
   const fileExists = await file.exists().then((result) => result[0]);
@@ -27,7 +27,7 @@ export const getProofImage = async (user: IdolMember, name: string): Promise<str
   return signedUrl[0];
 };
 
-export const allProofImagesForMember = async (
+export const allEventProofImagesForMember = async (
   user: IdolMember
 ): Promise<readonly EventProofImage[]> => {
   const netId: string = getNetIDFromEmail(user.email);
@@ -56,13 +56,13 @@ export const allProofImagesForMember = async (
   return images;
 };
 
-export const deleteProofImage = async (user: IdolMember, name: string): Promise<void> => {
+export const deleteEventProofImage = async (name: string, user: IdolMember): Promise<void> => {
   const netId: string = getNetIDFromEmail(user.email);
   const imageFile = bucket.file(`eventProofs/${netId}/${name}.jpg`);
   await imageFile.delete();
 };
 
-export const deleteProofImagesForMember = async (user: IdolMember): Promise<void> => {
+export const deleteEventProofImagesForMember = async (user: IdolMember): Promise<void> => {
   const netId: string = getNetIDFromEmail(user.email);
   const files = await bucket.getFiles({ prefix: `eventProofs/${netId}` });
   Promise.all(

--- a/backend/src/team-events-imageAPI.ts
+++ b/backend/src/team-events-imageAPI.ts
@@ -13,20 +13,18 @@ export const setEventProofImage = async (name: string, user: IdolMember): Promis
   return signedURL[0];
 };
 
-export const getEventProofImage = async (user: IdolMember): Promise<{signedUrl: string, imageName: string}> => {
+export const getEventProofImage = async (name: string, user: IdolMember): Promise<string> => {
   const netId: string = getNetIDFromEmail(user.email);
-  const date: string = (new Date()).toISOString()
-  const file = bucket.file(`eventProofs/${netId}/${date}.jpg`);
+  const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
   const fileExists = await file.exists().then((result) => result[0]);
   if (!fileExists) {
-    throw new NotFoundError(`The requested image (${netId}/${date}.jpg) does not exist`);
+    throw new NotFoundError(`The requested image (${netId}/${name}.jpg) does not exist`);
   }
   const signedUrl = await file.getSignedUrl({
     action: 'read',
     expires: Date.now() + 15 * 60000
   });
-  return {
-    signedUrl: signedUrl[0], imageName: `${netId}/${date}`};
+  return signedUrl[0];
 };
 
 export const allEventProofImagesForMember = async (

--- a/backend/src/team-events-imageAPI.ts
+++ b/backend/src/team-events-imageAPI.ts
@@ -4,7 +4,7 @@ import { NotFoundError } from './errors';
 
 export const setEventProofImage = async (name: string, user: IdolMember): Promise<string> => {
   const netId: string = getNetIDFromEmail(user.email);
-  console.log(name)
+  console.log(name);
   const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
   const signedURL = await file.getSignedUrl({
     action: 'write',

--- a/backend/src/team-events-imageAPI.ts
+++ b/backend/src/team-events-imageAPI.ts
@@ -4,6 +4,7 @@ import { NotFoundError } from './errors';
 
 export const setEventProofImage = async (name: string, user: IdolMember): Promise<string> => {
   const netId: string = getNetIDFromEmail(user.email);
+  console.log(name)
   const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
   const signedURL = await file.getSignedUrl({
     action: 'write',

--- a/backend/src/team-events-imageAPI.ts
+++ b/backend/src/team-events-imageAPI.ts
@@ -2,7 +2,7 @@ import { bucket } from './firebase';
 import { getNetIDFromEmail } from './util';
 import { NotFoundError } from './errors';
 
-export const setEventProofImage = async (name:string, user: IdolMember): Promise<string> => {
+export const setEventProofImage = async (name: string, user: IdolMember): Promise<string> => {
   const netId: string = getNetIDFromEmail(user.email);
   const file = bucket.file(`eventProofs/${netId}/${name}.jpg`);
   const signedURL = await file.getSignedUrl({

--- a/frontend/src/API/APIWrapper.ts
+++ b/frontend/src/API/APIWrapper.ts
@@ -39,7 +39,7 @@ export default class APIWrapper {
   public static async put(url: string, body: unknown, config: any): Promise<APIProcessedResponse> {
     const idToken = await getUserIDTokenNonNull();
     return axios
-      .put(url, body, { headers: {...config, 'auth-token': idToken } })
+      .put(url, body, { headers: { ...config, 'auth-token': idToken } })
       .catch((err: AxiosError) => err)
       .then((resOrErr) => this.responseMiddleware(resOrErr));
   }

--- a/frontend/src/API/APIWrapper.ts
+++ b/frontend/src/API/APIWrapper.ts
@@ -36,10 +36,10 @@ export default class APIWrapper {
       .then((resOrErr) => this.responseMiddleware(resOrErr));
   }
 
-  public static async put(url: string, body: unknown): Promise<APIProcessedResponse> {
+  public static async put(url: string, body: unknown, config: any): Promise<APIProcessedResponse> {
     const idToken = await getUserIDTokenNonNull();
     return axios
-      .put(url, body, { headers: { 'auth-token': idToken } })
+      .put(url, body, { headers: {...config, 'auth-token': idToken } })
       .catch((err: AxiosError) => err)
       .then((resOrErr) => this.responseMiddleware(resOrErr));
   }

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -3,6 +3,7 @@ import APIWrapper from './APIWrapper';
 import HeadshotPlaceholder from '../static/images/headshot-placeholder.png';
 
 export default class ImagesAPI {
+  // Member profile images
   public static getMemberImage(): Promise<string> {
     const responseProm = APIWrapper.get(`${backendURL}/getMemberImage`).then((res) => res.data);
 
@@ -26,22 +27,24 @@ export default class ImagesAPI {
     });
   }
 
+  // Event proof images
   public static getEventProofImage(): Promise<string> {
     const responseProm = APIWrapper.get(`${backendURL}/getEventProofImage`).then((res) => res.data);
     return responseProm.then((val) => val.url);
   }
 
-  private static getEventProofImageSignedURL(): Promise<string> {
+  private static getEventProofImageSignedURL(): Promise<{ signedUrl: string, imageName: string }> {
     const responseProm = APIWrapper.get(`${backendURL}/getEventProofImageSignedURL`).then(
       (res) => res.data
     );
     return responseProm.then((val) => val.url);
   }
 
-  public static uploadEventProofImage(body: Blob): Promise<void> {
+  public static uploadEventProofImage(body: Blob): Promise<string> {
     return this.getEventProofImageSignedURL().then((url) => {
       const headers = { "contentType": 'image/jpeg'}
-      APIWrapper.put(url, body, headers).then((res) => res.data);
+      APIWrapper.put(url.signedUrl, body, headers).then((res) => res.data);
+      return url.imageName;
     });
   }
 }

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -21,7 +21,8 @@ export default class ImagesAPI {
 
   public static uploadMemberImage(body: Blob): Promise<void> {
     return this.getSignedURL().then((url) => {
-      APIWrapper.put(url, body).then((res) => res.data);
+      const headers = { "contentType": 'image/jpeg' }
+      APIWrapper.put(url, body, headers).then((res) => res.data);
     });
   }
 
@@ -39,7 +40,8 @@ export default class ImagesAPI {
 
   public static uploadEventProofImage(body: Blob): Promise<void> {
     return this.getEventProofImageSignedURL().then((url) => {
-      APIWrapper.put(url, body).then((res) => res.data);
+      const headers = { "contentType": 'image/jpeg'}
+      APIWrapper.put(url, body, headers).then((res) => res.data);
     });
   }
 }

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -31,15 +31,15 @@ export default class ImagesAPI {
     return responseProm.then((val) => val.url);
   }
 
-  private static getEventProofImageSignedURL(): Promise<string> {
-    const responseProm = APIWrapper.get(`${backendURL}/getEventProofImageSignedURL`).then(
+  private static getEventProofImageSignedURL(name: string): Promise<string> {
+    const responseProm = APIWrapper.get(`${backendURL}/getEventProofImageSignedURL/${name}`).then(
       (res) => res.data
     );
     return responseProm.then((val) => val.url);
   }
 
-  public static uploadEventProofImage(body: Blob): Promise<void> {
-    return this.getEventProofImageSignedURL().then((url) => {
+  public static uploadEventProofImage(body: Blob, name: string): Promise<void> {
+    return this.getEventProofImageSignedURL(name).then((url) => {
       const headers = { "contentType": 'image/jpeg'}
       APIWrapper.put(url, body, headers).then((res) => res.data);
     });

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -31,7 +31,9 @@ export default class ImagesAPI {
   }
 
   private static getEventProofImageSignedURL(): Promise<string> {
-    const responseProm = APIWrapper.get(`${backendURL}/getEventProofImageSignedURL`).then((res) => res.data);
+    const responseProm = APIWrapper.get(`${backendURL}/getEventProofImageSignedURL`).then(
+      (res) => res.data
+    );
     return responseProm.then((val) => val.url);
   }
 

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -3,6 +3,7 @@ import APIWrapper from './APIWrapper';
 import HeadshotPlaceholder from '../static/images/headshot-placeholder.png';
 
 export default class ImagesAPI {
+  // member images
   public static getMemberImage(): Promise<string> {
     const responseProm = APIWrapper.get(`${backendURL}/getMemberImage`).then((res) => res.data);
 
@@ -21,11 +22,12 @@ export default class ImagesAPI {
 
   public static uploadMemberImage(body: Blob): Promise<void> {
     return this.getSignedURL().then((url) => {
-      const headers = { contentType: 'image/jpeg' };
+      const headers = { 'content-type': 'image/jpeg' };
       APIWrapper.put(url, body, headers).then((res) => res.data);
     });
   }
 
+  // Event proof images
   public static getEventProofImage(): Promise<string> {
     const responseProm = APIWrapper.get(`${backendURL}/getEventProofImage`).then((res) => res.data);
     return responseProm.then((val) => val.url);
@@ -40,7 +42,7 @@ export default class ImagesAPI {
 
   public static uploadEventProofImage(body: Blob, name: string): Promise<void> {
     return this.getEventProofImageSignedURL(name).then((url) => {
-      const headers = { contentType: 'image/jpeg' };
+      const headers = { 'content-type': 'image/jpeg' };
       APIWrapper.put(url, body, headers).then((res) => res.data);
     });
   }

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -21,7 +21,7 @@ export default class ImagesAPI {
 
   public static uploadMemberImage(body: Blob): Promise<void> {
     return this.getSignedURL().then((url) => {
-      const headers = { "contentType": 'image/jpeg' }
+      const headers = { contentType: 'image/jpeg' };
       APIWrapper.put(url, body, headers).then((res) => res.data);
     });
   }
@@ -40,7 +40,7 @@ export default class ImagesAPI {
 
   public static uploadEventProofImage(body: Blob, name: string): Promise<void> {
     return this.getEventProofImageSignedURL(name).then((url) => {
-      const headers = { "contentType": 'image/jpeg'}
+      const headers = { contentType: 'image/jpeg' };
       APIWrapper.put(url, body, headers).then((res) => res.data);
     });
   }

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -24,4 +24,20 @@ export default class ImagesAPI {
       APIWrapper.put(url, body).then((res) => res.data);
     });
   }
+
+  public static getEventProofImage(): Promise<string> {
+    const responseProm = APIWrapper.get(`${backendURL}/getEventProofImage`).then((res) => res.data);
+    return responseProm.then((val) => val.url);
+  }
+
+  private static getEventProofImageSignedURL(): Promise<string> {
+    const responseProm = APIWrapper.get(`${backendURL}/getEventProofImageSignedURL`).then((res) => res.data);
+    return responseProm.then((val) => val.url);
+  }
+
+  public static uploadEventProofImage(body: Blob): Promise<void> {
+    return this.getEventProofImageSignedURL().then((url) => {
+      APIWrapper.put(url, body).then((res) => res.data);
+    });
+  }
 }

--- a/frontend/src/API/ImagesAPI.ts
+++ b/frontend/src/API/ImagesAPI.ts
@@ -3,7 +3,6 @@ import APIWrapper from './APIWrapper';
 import HeadshotPlaceholder from '../static/images/headshot-placeholder.png';
 
 export default class ImagesAPI {
-  // Member profile images
   public static getMemberImage(): Promise<string> {
     const responseProm = APIWrapper.get(`${backendURL}/getMemberImage`).then((res) => res.data);
 
@@ -27,24 +26,22 @@ export default class ImagesAPI {
     });
   }
 
-  // Event proof images
   public static getEventProofImage(): Promise<string> {
     const responseProm = APIWrapper.get(`${backendURL}/getEventProofImage`).then((res) => res.data);
     return responseProm.then((val) => val.url);
   }
 
-  private static getEventProofImageSignedURL(): Promise<{ signedUrl: string, imageName: string }> {
+  private static getEventProofImageSignedURL(): Promise<string> {
     const responseProm = APIWrapper.get(`${backendURL}/getEventProofImageSignedURL`).then(
       (res) => res.data
     );
     return responseProm.then((val) => val.url);
   }
 
-  public static uploadEventProofImage(body: Blob): Promise<string> {
+  public static uploadEventProofImage(body: Blob): Promise<void> {
     return this.getEventProofImageSignedURL().then((url) => {
       const headers = { "contentType": 'image/jpeg'}
-      APIWrapper.put(url.signedUrl, body, headers).then((res) => res.data);
-      return url.imageName;
+      APIWrapper.put(url, body, headers).then((res) => res.data);
     });
   }
 }

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Form, Segment, Label, Button } from 'semantic-ui-react';
-import { Emitters } from '../../../utils';
+import { Emitters, getNetIDFromEmail } from '../../../utils';
 import CustomSearch from '../../Common/Search';
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
@@ -39,7 +39,6 @@ const TeamEventCreditForm: React.FC = () => {
         const imageURL: string = window.URL.createObjectURL(blob);
         ImagesAPI.uploadEventProofImage(blob, eventCreditRequest.image);
         setImage(imageURL);
-        console.log('inside handle new image');
       });
   };
 
@@ -63,7 +62,7 @@ const TeamEventCreditForm: React.FC = () => {
       const newTeamEventAttendance: TeamEventAttendance = {
         member: userInfo,
         hoursAttended: Number(hours),
-        image: new Date().toISOString()
+        image: `eventProofs/${getNetIDFromEmail(userInfo.email)}/${new Date().toISOString()}`
       };
       requestTeamEventCredit(newTeamEventAttendance, teamEvent);
       Emitters.generalSuccess.emit({

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -4,11 +4,10 @@ import { Emitters } from '../../../utils';
 import CustomSearch from '../../Common/Search';
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
+import ImagesAPI from '../../../API/ImagesAPI';
 
 const TeamEventCreditForm: React.FC = () => {
-  // When the user is logged in, `useSelf` always return non-null data.
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const userInfo = useSelf()!;
+  const userInfo = useSelf();
 
   const [teamEvent, setTeamEvent] = useState<TeamEvent | undefined>(undefined);
   const [image, setImage] = useState('');
@@ -31,6 +30,13 @@ const TeamEventCreditForm: React.FC = () => {
   ) => {
     teamEvent?.requests.push(eventCreditRequest);
     TeamEventsAPI.requestTeamEventCredit(teamEvent);
+    // upload image
+    fetch(image).then((res) => res.blob()).then((blob) => {
+      const imageURL: string = window.URL.createObjectURL(blob);
+      ImagesAPI.uploadEventProofImage(blob);
+      setImage(imageURL);
+      console.log("inside handle new image");
+    });
   };
 
   const submitTeamEventCredit = () => {

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -61,7 +61,7 @@ const TeamEventCreditForm: React.FC = () => {
       const newTeamEventAttendance: TeamEventAttendance = {
         member: userInfo,
         hoursAttended: Number(hours),
-        image: (new Date()).toISOString()
+        image: new Date().toISOString()
       };
       requestTeamEventCredit(newTeamEventAttendance, teamEvent);
       Emitters.generalSuccess.emit({

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -31,12 +31,14 @@ const TeamEventCreditForm: React.FC = () => {
     teamEvent?.requests.push(eventCreditRequest);
     TeamEventsAPI.requestTeamEventCredit(teamEvent);
     // upload image
-    fetch(image).then((res) => res.blob()).then((blob) => {
-      const imageURL: string = window.URL.createObjectURL(blob);
-      ImagesAPI.uploadEventProofImage(blob);
-      setImage(imageURL);
-      console.log("inside handle new image");
-    });
+    fetch(image)
+      .then((res) => res.blob())
+      .then((blob) => {
+        const imageURL: string = window.URL.createObjectURL(blob);
+        ImagesAPI.uploadEventProofImage(blob);
+        setImage(imageURL);
+        console.log('inside handle new image');
+      });
   };
 
   const submitTeamEventCredit = () => {

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -7,11 +7,10 @@ import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import ImagesAPI from '../../../API/ImagesAPI';
 
 const TeamEventCreditForm: React.FC = () => {
-  const userInfo = useSelf()!;
+  const userInfo = useSelf();
 
   const [teamEvent, setTeamEvent] = useState<TeamEvent | undefined>(undefined);
   const [image, setImage] = useState('');
-  const [imageName, setImageName] = useState('');
   const [hours, setHours] = useState('');
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
 
@@ -29,18 +28,17 @@ const TeamEventCreditForm: React.FC = () => {
     eventCreditRequest: TeamEventAttendance,
     teamEvent: TeamEvent
   ) => {
+    teamEvent?.requests.push(eventCreditRequest);
+    TeamEventsAPI.requestTeamEventCredit(teamEvent);
     // upload image
     fetch(image)
       .then((res) => res.blob())
       .then((blob) => {
         const imageURL: string = window.URL.createObjectURL(blob);
-        ImagesAPI.uploadEventProofImage(blob).then((val) => setImageName(val));
+        ImagesAPI.uploadEventProofImage(blob);
         setImage(imageURL);
         console.log('inside handle new image');
-        console.log(`image name: ${imageName}`)
       });
-    teamEvent?.requests.push({ ...eventCreditRequest, image: imageName });
-    TeamEventsAPI.requestTeamEventCredit(teamEvent);
   };
 
   const submitTeamEventCredit = () => {

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -35,7 +35,7 @@ const TeamEventCreditForm: React.FC = () => {
       .then((res) => res.blob())
       .then((blob) => {
         const imageURL: string = window.URL.createObjectURL(blob);
-        ImagesAPI.uploadEventProofImage(blob);
+        ImagesAPI.uploadEventProofImage(blob, eventCreditRequest.image);
         setImage(imageURL);
         console.log('inside handle new image');
       });
@@ -61,7 +61,7 @@ const TeamEventCreditForm: React.FC = () => {
       const newTeamEventAttendance: TeamEventAttendance = {
         member: userInfo,
         hoursAttended: Number(hours),
-        image
+        image: (new Date()).toISOString()
       };
       requestTeamEventCredit(newTeamEventAttendance, teamEvent);
       Emitters.generalSuccess.emit({

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -7,10 +7,11 @@ import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import ImagesAPI from '../../../API/ImagesAPI';
 
 const TeamEventCreditForm: React.FC = () => {
-  const userInfo = useSelf();
+  const userInfo = useSelf()!;
 
   const [teamEvent, setTeamEvent] = useState<TeamEvent | undefined>(undefined);
   const [image, setImage] = useState('');
+  const [imageName, setImageName] = useState('');
   const [hours, setHours] = useState('');
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
 
@@ -28,17 +29,18 @@ const TeamEventCreditForm: React.FC = () => {
     eventCreditRequest: TeamEventAttendance,
     teamEvent: TeamEvent
   ) => {
-    teamEvent?.requests.push(eventCreditRequest);
-    TeamEventsAPI.requestTeamEventCredit(teamEvent);
     // upload image
     fetch(image)
       .then((res) => res.blob())
       .then((blob) => {
         const imageURL: string = window.URL.createObjectURL(blob);
-        ImagesAPI.uploadEventProofImage(blob);
+        ImagesAPI.uploadEventProofImage(blob).then((val) => setImageName(val));
         setImage(imageURL);
         console.log('inside handle new image');
+        console.log(`image name: ${imageName}`)
       });
+    teamEvent?.requests.push({ ...eventCreditRequest, image: imageName });
+    TeamEventsAPI.requestTeamEventCredit(teamEvent);
   };
 
   const submitTeamEventCredit = () => {

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -7,7 +7,9 @@ import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import ImagesAPI from '../../../API/ImagesAPI';
 
 const TeamEventCreditForm: React.FC = () => {
-  const userInfo = useSelf();
+  // When the user is logged in, `useSelf` always return non-null data.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const userInfo = useSelf()!;
 
   const [teamEvent, setTeamEvent] = useState<TeamEvent | undefined>(undefined);
   const [image, setImage] = useState('');


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements image uploading for the team event credit form. The image name (eventProofs/[netid]/[timestamp]) is saved as part of the `TeamEventAttendance`.  

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

- [x] image is in the firebase storage
- [x] image name is updated in the team event data
