### PR TITLE
New types for dev portfolio automation 

### DIFF
--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -131,3 +131,17 @@ interface CandidateDeciderInfo {
   readonly uuid: string;
   isOpen: boolean;
 }
+
+interface DevPortfolio {
+  name: string;
+  deadline: number;
+  earliestValidDate: number;
+  submissions: DevPortfolioSubmission[];
+}
+
+interface DevPortfolioSubmission {
+  member: IdolMember;
+  openedPR: string;
+  reviewedPR: string;
+  status: 'valid' | 'invalid' | 'pending';
+}

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -141,7 +141,7 @@ interface DevPortfolio {
 
 interface DevPortfolioSubmission {
   member: IdolMember;
-  openedPR: string;
-  reviewedPR: string;
+  openedPRs: string[];
+  reviewedPRs: string[];
   status: 'valid' | 'invalid' | 'pending';
 }


### PR DESCRIPTION
### Summary <!-- Required -->

Add types for [Dev Portfolio Automation feature ](https://www.notion.so/Dev-Portfolio-Automation-66804d95ee1d4e55b2d1426b268405cc)
```
interface DevPortfolio {
  name: string;
  deadline: number;
  earliestValidDate: number;
  submissions: DevPortfolioSubmission[];
}

interface DevPortfolioSubmission {
  member: IdolMember;
  openedPR: string;
  reviewedPR: string;
  status: 'valid' | 'invalid' | 'pending';
}
```

### Test Plan <!-- Required -->
Read dev portfolio automation feature proposal and confirm that type declarations are reasonable 

