### PR TITLE
Refactor `SignInFormDAO` and `signinformAPI`

### DIFF
--- a/backend/src/signinformAPI.ts
+++ b/backend/src/signinformAPI.ts
@@ -1,6 +1,6 @@
 import SignInFormDao from './dao/SignInFormDao';
-import { PermissionError, BadRequestError } from './errors';
-import { signInFormCollection } from './firebase';
+import { PermissionError, BadRequestError, NotFoundError } from './errors';
+import { signInFormCollection, memberCollection } from './firebase';
 import PermissionsManager from './permissions';
 
 const checkIfDocExists = async (id: string): Promise<boolean> =>
@@ -21,19 +21,29 @@ export const createSignInForm = async (
   expireAt: number,
   user: IdolMember
 ): Promise<{ id: string; createdAt: number; expireAt: number }> => {
-  if (!PermissionsManager.canEditSignIn(user)) {
+  const canEdit = await PermissionsManager.canEditSignIn(user);
+  if (!canEdit) {
     throw new PermissionError("You don't have permission to create a sign-in form!");
   }
   if (expireAt <= Date.now()) {
     throw new BadRequestError('Invalid Date: Expiry Date cannot be in the past!');
+  }
+  const formExists = await signInFormExists(id);
+  if (formExists) {
+    throw new NotFoundError(`A form with id '${id}' already exists!`);
   }
   await SignInFormDao.createSignIn(id, expireAt);
   return { id, createdAt: Date.now(), expireAt };
 };
 
 export const deleteSignInForm = async (id: string, user: IdolMember): Promise<void> => {
-  if (!PermissionsManager.canEditSignIn(user)) {
+  const canEdit = await PermissionsManager.canEditSignIn(user);
+  if (!canEdit) {
     throw new PermissionError("You don't have permission to delete a sign-in form!");
+  }
+  const formExists = await signInFormExists(id);
+  if (!formExists) {
+    throw new NotFoundError(`No form with id '${id}' found.`);
   }
   await SignInFormDao.deleteSignIn(id);
 };
@@ -41,7 +51,8 @@ export const deleteSignInForm = async (id: string, user: IdolMember): Promise<vo
 export const allSignInForms = async (
   user: IdolMember
 ): Promise<{ readonly forms: SignInForm[] }> => {
-  if (!PermissionsManager.canEditSignIn(user)) {
+  const canEdit = await PermissionsManager.canEditSignIn(user);
+  if (!canEdit) {
     return { forms: [] };
   }
   return { forms: await SignInFormDao.allSignInForms() };
@@ -51,6 +62,20 @@ export const signIn = async (
   id: string,
   user: IdolMember
 ): Promise<{ signedInAt: number; id: string }> => {
+  const formExists = await signInFormExists(id);
+  if (!formExists) {
+    throw new NotFoundError(`No form with id '${id}' found.`);
+  }
+  const formExpired = await signInFormExpired(id);
+  if (formExpired) {
+    throw new BadRequestError(`User is not allowed to sign into expired form with id '${id}.`);
+  }
+  const userDoc = memberCollection.doc(user.email);
+  const userRef = await userDoc.get();
+  if (!userRef.exists) {
+    throw new NotFoundError(`No user with email '${user.email}' found.`);
+  }
+
   const signedInAt = await SignInFormDao.signIn(id, user.email);
   return { id, signedInAt };
 };

--- a/backend/tests/SignInFormDao.test.ts
+++ b/backend/tests/SignInFormDao.test.ts
@@ -43,12 +43,6 @@ test('Sign in into an open form', async () => {
   expect(userData.users).toContainEqual(expect.objectContaining({ user: users.mu1 }));
 });
 
-test('Sign in attempted for an expired form', async () => {
-  const expiredForm = mockForms.expiredSignin as SignInForm;
-  await SignInFormDao.createSignIn(expiredForm.id, expiredForm.expireAt);
-  await expect(() => SignInFormDao.signIn(expiredForm.id, users.mu1.email)).rejects.toThrow();
-});
-
 test('Sign in attempted for an invalid id', async () => {
   const invalidId = 'invalid-id';
   await expect(() => SignInFormDao.signIn(invalidId, users.mu1.email)).rejects.toThrow();


### PR DESCRIPTION
### Summary <!-- Required -->

This PR moves validation logic from the sign-in form DAO to its API. 
- [x] checking if the user exists
- [x] checking if the form exists
- [x] checking if the form is expired

There is also a bug fix with boolean Promises that resulted in always-true or always-false values (explanation [here](https://www.aleksandrhovhannisyan.com/blog/async-functions-that-return-booleans/)).

### Test Plan <!-- Required -->

Revised unit test suite to account for removed validation from DAO. Manually tested API for edge and typical cases:

<img width="569" alt="image" src="https://user-images.githubusercontent.com/81320443/161129079-647bd55c-96c0-48eb-96e8-b386ebfc7241.png">


