### PR TITLE
[bug-fix] Fix admin shoutouts for former members 

### DIFF
--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -5,7 +5,6 @@ import styles from './AdminShoutouts.module.css';
 
 const AdminShoutouts: React.FC = () => {
   const [shoutouts, setShoutouts] = useState<Shoutout[]>([]);
-
   useEffect(() => {
     ShoutoutsAPI.getAllShoutouts().then((shoutouts) => setShoutouts(shoutouts));
   }, []);
@@ -22,9 +21,16 @@ const AdminShoutouts: React.FC = () => {
             <Item key={i}>
               <Item.Content>
                 <Item.Header>
-                  {`${shoutout.receiver.firstName} ${shoutout.receiver.lastName}`}
+                  {shoutout.receiver
+                    ? `${shoutout.receiver.firstName} ${shoutout.receiver.lastName}`
+                    : '(Former member)'}
                 </Item.Header>
-                <Item.Meta>{`From: ${shoutout.giver.firstName} ${shoutout.giver.lastName}`}</Item.Meta>
+                <Item.Meta>
+                  From:{' '}
+                  {shoutout.giver
+                    ? `${shoutout.giver.firstName} ${shoutout.giver.lastName}`
+                    : '(Former member)'}
+                </Item.Meta>
                 <Item.Description>{shoutout.message}</Item.Description>
               </Item.Content>
             </Item>


### PR DESCRIPTION
### Summary <!-- Required -->

This PR fixes the issue on the admin shoutouts page that @riyajaggi discovered. Since shoutouts use `DocumentReference` for the givers and receivers, we get an error for former members (i.e. members that are no longer n the `members` collection). 

The solution implemented in this PR is the replace the name of the giver/receiver with `(Former member)` if the giver/receiver is `undefined.`

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/65922473/163728464-5a190d7d-85f0-496a-a5f8-cc1bd77d6b39.png">

### Test Plan <!-- Required -->
Check deploy preview to ensure that the admin shoutouts page is loading 

### Notes
In the future, we should probably consider implementing a more robust system in the backend for dealing with document references to former members (possibly by looking through archived members). 