### PR TITLE
[RFC] Rename and move siteIntegration.ts

### DIFF
--- a/backend/src/API/siteIntegrationAPI.ts
+++ b/backend/src/API/siteIntegrationAPI.ts
@@ -1,7 +1,7 @@
 import { Octokit } from '@octokit/rest';
-import { PRResponse } from './GithubTypes';
-import PermissionsManager from './utils/permissionsManager';
-import { PermissionError, BadRequestError } from './utils/errors';
+import { PRResponse } from '../GithubTypes';
+import PermissionsManager from '../utils/permissionsManager';
+import { PermissionError, BadRequestError } from '../utils/errors';
 
 require('dotenv').config();
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -8,7 +8,7 @@ import {
   getIDOLChangesPR,
   rejectIDOLChanges,
   requestIDOLPullDispatch
-} from './siteIntegration';
+} from './API/siteIntegrationAPI';
 import PermissionsManager from './utils/permissionsManager';
 import { HandlerError } from './utils/errors';
 import MembersDao from './dao/MembersDao';


### PR DESCRIPTION
### Summary <!-- Required -->

This PR renames `siteIntegration.ts` to `siteIntegrationAPI.ts` in the initiative to standard BE file names 

### Test Plan <!-- Required -->
N/A - No functionality changes 