### PR TITLE
Add Google Anaytics to DTI website 

### DIFF
--- a/dti-website/src/pages/_app.tsx
+++ b/dti-website/src/pages/_app.tsx
@@ -73,7 +73,7 @@ const App = (props: AppProps): ReactElement => {
         <meta name="application-name" content="Cornell DTI" />
         <meta name="msapplication-TileColor" content="#b91d47" />
         <meta name="theme-color" content="#ffffff" />
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-JMY9HNQ6WK" />
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-B49CN5ZE3H" />
 
         <script
           dangerouslySetInnerHTML={{
@@ -81,7 +81,7 @@ const App = (props: AppProps): ReactElement => {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-              gtag('config', 'G-JMY9HNQ6WK', { page_path: window.location.pathname });
+              gtag('config', 'G-B49CN5ZE3H', { page_path: window.location.pathname });
             `
           }}
         />

--- a/dti-website/src/pages/_app.tsx
+++ b/dti-website/src/pages/_app.tsx
@@ -42,7 +42,7 @@ const App = (props: AppProps): ReactElement => {
   const router = useRouter();
 
   const handleRouteChange = (url: string) => {
-    window.gtag('config', 'G-B49CN5ZE3H', {
+    window.gtag('config', 'G-JMY9HNQ6WK', {
       page_path: url
     });
   };
@@ -73,7 +73,7 @@ const App = (props: AppProps): ReactElement => {
         <meta name="application-name" content="Cornell DTI" />
         <meta name="msapplication-TileColor" content="#b91d47" />
         <meta name="theme-color" content="#ffffff" />
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-B49CN5ZE3H" />
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-JMY9HNQ6WK" />
 
         <script
           dangerouslySetInnerHTML={{

--- a/dti-website/src/pages/_app.tsx
+++ b/dti-website/src/pages/_app.tsx
@@ -81,7 +81,7 @@ const App = (props: AppProps): ReactElement => {
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-              gtag('config', '[Tracking ID]', { page_path: window.location.pathname });
+              gtag('config', 'G-JMY9HNQ6WK', { page_path: window.location.pathname });
             `
           }}
         />

--- a/dti-website/src/pages/_app.tsx
+++ b/dti-website/src/pages/_app.tsx
@@ -1,7 +1,8 @@
-import { ReactElement } from 'react';
+import { ReactElement, useEffect } from 'react';
 
 import { AppProps } from 'next/app';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 import '../scss/index.scss';
 import '../components/CircleProgressIndicator.scss';
@@ -30,8 +31,28 @@ import './projects.scss';
 import './sponsor.scss';
 import './team.scss';
 
+declare global {
+  interface Window {
+    gtag: any;
+  }
+}
+
 const App = (props: AppProps): ReactElement => {
   const { Component, pageProps } = props;
+  const router = useRouter();
+
+  const handleRouteChange = (url: string) => {
+    window.gtag('config', 'G-B49CN5ZE3H', {
+      page_path: url
+    });
+  };
+
+  useEffect(() => {
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
 
   return (
     <>
@@ -52,6 +73,18 @@ const App = (props: AppProps): ReactElement => {
         <meta name="application-name" content="Cornell DTI" />
         <meta name="msapplication-TileColor" content="#b91d47" />
         <meta name="theme-color" content="#ffffff" />
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-B49CN5ZE3H" />
+
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '[Tracking ID]', { page_path: window.location.pathname });
+            `
+          }}
+        />
       </Head>
       <Component {...pageProps} />
     </>


### PR DESCRIPTION
### Summary <!-- Required -->

This PR attempts to add Google Analytics to the DTI website. 
### Test Plan <!-- Required -->

No functionality changes but ensure that the entire website looks good (I will check the Google Analytics page to make sure tracking is working) 
