### PR TITLE
Determine whether PR or review is trivial for dev portfolio automation

### DIFF
--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -233,9 +233,19 @@ const validateReview = async (
     }
   });
 
+/** Returns `comments` with duplicate content from quote replies removed. */
+const removeQuoted = (comments: Comment[]): Comment[] => {
+  // quote replies are of the form "> (original comment)\r\n(new comment)"
+  const quotePattern = />(.*?)\r\n/gs;
+  return comments.map((comment) => ({
+    ...comment,
+    content: comment.content.replace(quotePattern, '').trim()
+  }));
+};
+
 /** ="this collection of comments constitutes a trivial review" */
 const reviewIsTrivial = (comments: Comment[]): boolean => {
-  const totalWordCount = comments.reduce((count, comment) => {
+  const totalWordCount = removeQuoted(comments).reduce((count, comment) => {
     // get alphanumeric words
     const words = comment.content.split(' ').filter((s) => s.replace(/[\W_-]/g, ''));
     return count + words.length;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->
This PR revises the placeholder logic for determining whether a PR or review is trivial. 
- There is no way that an opened PR can be trivial. This allowed for some unnecessary API calls for validating an opened PR to be removed 
- A review can be trivial if it has less than 10 words. This is as opposed to a minimum character count so that things like [Henry's beautiful artworks](https://github.com/cornell-dti/idol/pull/267#pullrequestreview-929767102) dont count.
- Determining whether a collection of comments is trivial was factored out in to a separate function to allow for easier modification later if course policy changes


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
No changes to functionality.

