### PR TITLE
[QOL] Add type references for backend tests 

### DIFF
--- a/backend/tests/types.d.ts
+++ b/backend/tests/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="common-types" />


### PR DESCRIPTION
### Summary <!-- Required -->

This PR is a QOL change that adds a `types.d.ts` to `backend/tests/` so that the backend tests can reference `common-types`. This should remove the type not found errors in VSCode. 

### Test Plan <!-- Required -->
No changes in functionality -- all existing tests should pass. 