### PR TITLE
[QOL] Allow Pull from IDOL to be triggered manually 

### DIFF
--- a/.github/workflows/pull-from-idol.yml
+++ b/.github/workflows/pull-from-idol.yml
@@ -2,6 +2,7 @@ name: Pull from IDOL
 on:
   repository_dispatch:
     types: pull-idol-changes
+  workflow_dispatch:
   schedule:
     # Run the script at 0AM in UTC every day, which is 7PM or 8PM in ET.
     - cron: '0 0 * * *'


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds config to the `Pull from IDOL` workflow to allow the workflow to be triggered manually from the GitHub UI. 

### Test Plan <!-- Required -->

N/A