### PR TITLE
Clear fields of admin forms after each submission

### DIFF
--- a/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
@@ -87,13 +87,15 @@ const CandidateDeciderInstanceCreator = ({
     };
     CandidateDeciderAPI.createNewInstance(instance)
       .then((newInstance) => setInstances((instances) => [...instances, newInstance]))
-      .then(() => setSuccess(true));
-    setName('');
-    setHeaders([]);
-    setResponses([[]]);
-    setAuthorizedMembers([]);
-    setAuthorizedRoles([]);
-    setFileInKey(Date.now().toString());
+      .then(() => setSuccess(true))
+      .then(() => {
+        setName('');
+        setHeaders([]);
+        setResponses([[]]);
+        setAuthorizedMembers([]);
+        setAuthorizedRoles([]);
+        setFileInKey(Date.now().toString());
+      });
   };
 
   return (

--- a/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
@@ -53,6 +53,7 @@ const CandidateDeciderInstanceCreator = ({
   const [responses, setResponses] = useState<string[][]>([[]]);
   const [authorizedMembers, setAuthorizedMembers] = useState<IdolMember[]>([]);
   const [authorizedRoles, setAuthorizedRoles] = useState<Role[]>([]);
+  const [, setFileInKey] = useState('0');
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
@@ -87,6 +88,12 @@ const CandidateDeciderInstanceCreator = ({
     CandidateDeciderAPI.createNewInstance(instance)
       .then((newInstance) => setInstances((instances) => [...instances, newInstance]))
       .then(() => setSuccess(true));
+    setName('');
+    setHeaders([]);
+    setResponses([[]]);
+    setAuthorizedMembers([]);
+    setAuthorizedRoles([]);
+    setFileInKey(Date.now().toString());
   };
 
   return (

--- a/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
@@ -53,7 +53,7 @@ const CandidateDeciderInstanceCreator = ({
   const [responses, setResponses] = useState<string[][]>([[]]);
   const [authorizedMembers, setAuthorizedMembers] = useState<IdolMember[]>([]);
   const [authorizedRoles, setAuthorizedRoles] = useState<Role[]>([]);
-  const [, setFileInKey] = useState('0');
+  const [fileInKey, setFileInKey] = useState('0');
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
@@ -101,7 +101,7 @@ const CandidateDeciderInstanceCreator = ({
       <Header as="h2">Create a new Candidate Decider instance</Header>
       <Form success={success}>
         <Form.Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
-        <input type="file" accept=".csv" onChange={handleFileUpload} />
+        <input type="file" accept=".csv" onChange={handleFileUpload} key={fileInKey || ''} />
         <Message>
           All leads and IDOL admins have permission to all Candidate Decider instances
         </Message>

--- a/frontend/src/components/Admin/SignInForm/SignInFormCreator.tsx
+++ b/frontend/src/components/Admin/SignInForm/SignInFormCreator.tsx
@@ -68,6 +68,7 @@ const CodeForm: React.FC<{
       onClick={() => {
         setShowCopied(false);
         onClick && onClick();
+        setInputVal('');
       }}
       type="submit"
     >


### PR DESCRIPTION
### Summary <!-- Required -->

On the admin side, there are forms to make a sign-in link and to create a candidate decider instance. Previously, after the form is submitted, the input in each field remains there, so the user would have to manually delete the input to submit new data. This PR clears the form fields by simply clearing the different states upon clicking the submit button.

### Test Plan <!-- Required -->

1a
![image](https://user-images.githubusercontent.com/69334328/167724621-28a87f6d-57a6-4d82-9244-cd40a7a3de21.png)

1b
![image](https://user-images.githubusercontent.com/69334328/167724720-13b57165-4a9b-4989-bad9-83850616698d.png)

2a
![image](https://user-images.githubusercontent.com/69334328/167724772-e67814c1-774d-470f-97c3-4a0e5e59a5ec.png)

2b
![image](https://user-images.githubusercontent.com/69334328/167724803-50cf55da-3c45-413a-b7a5-26c9cba2450d.png)