### PR TITLE
Shoutouts page refactor 

### DIFF
--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.module.css
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.module.css
@@ -38,3 +38,7 @@
 .reasonInput {
   min-height: 25vh;
 }
+
+.requiredIcon {
+  color: #db2828;
+}

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.module.css
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.module.css
@@ -1,0 +1,40 @@
+.shoutoutForm {
+  width: 100%;
+  align-self: center;
+  margin: auto;
+}
+
+.formTitle {
+  margin-bottom: 2vh;
+}
+
+.formLabel {
+  font-weight: bold;
+}
+
+.formContainer {
+  display: flex;
+  align-items: center;
+}
+
+.recipientNameDisplayContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
+
+.recipientNameDisplay {
+  padding-right: 1.5em;
+}
+
+.isAnonCheckbox {
+  padding-left: 2em;
+}
+
+.reasonContainer {
+  padding: 0.8em 0;
+}
+
+.reasonInput {
+  min-height: 25vh;
+}

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -5,8 +5,13 @@ import { MemberSearch } from '../../Common/Search/Search';
 import { Emitters } from '../../../utils';
 import { Shoutout, ShoutoutsAPI } from '../../../API/ShoutoutsAPI';
 import { useMembers } from '../../Common/FirestoreDataProvider';
+import styles from './ShoutoutForm.module.css';
 
-const ShoutoutForm: React.FC = () => {
+type ShoutoutFormProps = {
+  getGivenShoutouts: () => void;
+};
+
+const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
   const userEmail = useUserEmail();
   const members = useMembers();
   const user = members.find((it) => it.email === userEmail);
@@ -45,36 +50,25 @@ const ShoutoutForm: React.FC = () => {
           });
           setRecipient(undefined);
           setMessage('');
+          getGivenShoutouts();
         }
       });
     }
   };
 
   return (
-    <Form
-      style={{
-        width: '100%',
-        alignSelf: 'center',
-        margin: 'auto'
-      }}
-    >
-      <h2 style={{ marginBottom: '2vh' }}>Give someone a shoutout! 📣</h2>
-      <label style={{ fontWeight: 'bold' }}>
+    <Form className={styles.shoutoutForm}>
+      <h2 className={styles.formTitle}>Give someone a shoutout! 📣</h2>
+      <label className={styles.formLabel}>
         Who is awesome? <span style={{ color: '#db2828' }}>*</span>
       </label>
 
-      <div style={{ display: 'flex', alignItems: 'center' }}>
+      <div className={styles.formContainer}>
         {!recipient ? <MemberSearch onSelect={setRecipient} /> : undefined}
 
         {recipient ? (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              alignItems: 'baseline'
-            }}
-          >
-            <p style={{ paddingRight: '1.5em' }}>
+          <div className={styles.recipientNameDisplayContainer}>
+            <p className={styles.recipientNameDisplay}>
               {recipient?.firstName} {recipient?.lastName}
             </p>
             <Button
@@ -90,24 +84,23 @@ const ShoutoutForm: React.FC = () => {
 
         <Checkbox
           label={{ children: 'Anonymous?' }}
-          style={{ paddingLeft: '2em' }}
+          className={styles.isAnonCheckbox}
           onChange={() => setIsAnon(!isAnon)}
         />
       </div>
 
-      <div style={{ padding: '0.8em 0' }}>
+      <div className={styles.reasonContainer}>
         <Form.Input
           label="Why are they awesome?"
           name="message"
           value={message}
           control={TextArea}
           onChange={(event) => setMessage(event.target.value)}
-          style={{ minHeight: '25vh' }}
           required
         />
       </div>
 
-      <Form.Button floated="right" onClick={giveShoutout}>
+      <Form.Button floated="right" onClick={giveShoutout} style={{ marginBottom: 0 }}>
         Send
       </Form.Button>
     </Form>

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -60,7 +60,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
     <Form className={styles.shoutoutForm}>
       <h2 className={styles.formTitle}>Give someone a shoutout! 📣</h2>
       <label className={styles.formLabel}>
-        Who is awesome? <span style={{ color: '#db2828' }}>*</span>
+        Who is awesome? <span className={styles.requiredIcon}>*</span>
       </label>
 
       <div className={styles.formContainer}>
@@ -100,7 +100,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
         />
       </div>
 
-      <Form.Button floated="right" onClick={giveShoutout} style={{ marginBottom: 0 }}>
+      <Form.Button floated="right" onClick={giveShoutout}>
         Send
       </Form.Button>
     </Form>

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
@@ -21,11 +21,18 @@
 }
 
 @media only screen and (max-width: 900px) {
+  .shoutoutFormContainer {
+    width: 90%;
+    height: 100%;
+    margin-bottom: 5%;
+  }
+
   .shoutoutTitle {
-    text-align: left;
+    text-align: center;
   }
 
   .listsContainer {
+    margin-top: 10%;
     flex-direction: column;
   }
 

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Message } from 'semantic-ui-react';
 import { useUserEmail } from '../../Common/UserProvider/UserProvider';
 import { Emitters } from '../../../utils';
@@ -12,18 +12,19 @@ const ShoutoutsPage: React.FC = () => {
   const [givenShoutouts, setGivenShoutouts] = useState<Shoutout[]>([]);
   const [receivedShoutouts, setReceivedShoutouts] = useState<Shoutout[]>([]);
 
-  useEffect(() => {
+  const getGivenShoutouts = useCallback(() => {
     ShoutoutsAPI.getShoutouts(userEmail, 'given')
-      .then((given) => {
-        setGivenShoutouts(given);
-      })
+      .then((given) => setGivenShoutouts(given))
       .catch((error) => {
         Emitters.generalError.emit({
-          headerMsg: `Couldn't get given shoutouts!`,
+          headerMsg: `Couldn't get received shoutouts!`,
           contentMsg: `Error was: ${error}`
         });
       });
+  }, [userEmail]);
 
+  useEffect(() => {
+    getGivenShoutouts();
     ShoutoutsAPI.getShoutouts(userEmail, 'received')
       .then((received) => {
         setReceivedShoutouts(received);
@@ -34,12 +35,12 @@ const ShoutoutsPage: React.FC = () => {
           contentMsg: `Error was: ${error}`
         });
       });
-  }, [userEmail]);
+  }, [userEmail, getGivenShoutouts]);
 
   return (
     <div>
       <div className={styles.shoutoutFormContainer}>
-        <ShoutoutForm />
+        <ShoutoutForm getGivenShoutouts={getGivenShoutouts} />
       </div>
 
       <div className={styles.listsContainer}>

--- a/frontend/src/components/Homepage/Homepage/Homepage.tsx
+++ b/frontend/src/components/Homepage/Homepage/Homepage.tsx
@@ -17,7 +17,7 @@ const Homepage: React.FC = () => (
         <Spotlight></Spotlight>
         <Card style={{ width: '50%', display: 'flex', justfiyContent: 'center' }} size="medium">
           <Card.Content style={{ height: '100%' }}>
-            <ShoutoutForm></ShoutoutForm>
+            <ShoutoutForm getGivenShoutouts={() => undefined} />
           </Card.Content>
         </Card>
       </div>


### PR DESCRIPTION
### Summary <!-- Required -->

This PR is the first step towards making the IDOL frontend more mobile-friendly. It addresses responsivity for the shoutouts page and contains some other general refactoring changes.

Changes:
- Made shoutouts form and shoutouts display responsive for mobile screens
- Created `.module.css` file for `ShoutoutForm` component and removed inline CSS 
- Changed `ShoutoutForm` component to update given shoutouts when a new shoutout is submitted  

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->
[Notion link](https://www.notion.so/cornelldti/Shoutouts-form-dbb163886d4e4704a88936e83aad411b)

### Test Plan <!-- Required -->
- Shoutout page should look the same on desktop 
- Shoutout page should be responsive for mobile 
![image](https://user-images.githubusercontent.com/65922473/191414042-09b815f8-4f10-4204-bdf2-123c56194ea0.png)
![image](https://user-images.githubusercontent.com/65922473/191414051-c550c66a-7afa-4a73-8dac-c2afa620ce80.png)

- Newly given shoutouts should appear automatically without needing to refresh the page 

<!-- Provide screenshots or point out the additional unit tests -->

### Note 
You can get a mobile sized version of the page by right click on page -> inspect -> toggle device toolbar. The `toggle device toolbar` icon is at the top left of the panel and looks like this: 
![image](https://user-images.githubusercontent.com/65922473/191550124-5343e40f-7a07-46d1-b6f2-1825d3b68e81.png)

