### PR TITLE
Center navigation cards on small screen

### DIFF
--- a/frontend/src/components/Common/NavigationCard/NavigationCard.module.css
+++ b/frontend/src/components/Common/NavigationCard/NavigationCard.module.css
@@ -3,3 +3,11 @@
   margin-right: 2rem;
   padding-top: 2rem;
 }
+
+@media (max-width: 900px) {
+  .cardsContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+}

--- a/frontend/src/components/Common/NavigationCard/NavigationCard.tsx
+++ b/frontend/src/components/Common/NavigationCard/NavigationCard.tsx
@@ -20,7 +20,7 @@ export default function NavigationCard({ testID, items }: Props): JSX.Element {
   return (
     <div data-testid={testID}>
       <div className={styles.content}>
-        <Card.Group>
+        <Card.Group className={styles.cardsContainer}>
           {items.map(
             ({ header, description, link, adminOnly }) =>
               (!isProduction || !adminOnly || hasAdminPermission) && (


### PR DESCRIPTION
### Summary <!-- Required -->

Centers navigation cards on a smaller screen 

Currently, navigation cards look like this on a smaller screen which doesn't look great. 
![image](https://user-images.githubusercontent.com/65922473/191775237-8a8a632c-fcad-4b36-8ed6-e424847cce43.png)

Updated navigation cards:
![image](https://user-images.githubusercontent.com/65922473/191775400-7f3189a9-437d-457a-a171-583a0e03ec27.png)



### Notion/Figma Link <!-- Optional -->
[Larger project](https://www.notion.so/cornelldti/Make-IDOL-more-mobile-friendly-a86a30e44322432ca848aa8e835e67e7)
[Specific issue](https://www.notion.so/cornelldti/Admin-forms-games-card-pages-4a681a37beaf4b869a8796cef0d7feef)

### Test Plan <!-- Required -->

Navigation cards for `Forms`, `Admin`, and `Games` pages should be centered on a smaller screen. 