### PR TITLE
Add tests for dev porfolio api layer

### DIFF
--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -7,7 +7,7 @@ export const getAllDevPortfolios = async (): Promise<DevPortfolio[]> =>
   DevPortfolioDao.getAllInstances();
 
 export const getDevPortfolio = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {
-  const isLeadOrAdmin = PermissionsManager.isLeadOrAdmin(user);
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
   if (!isLeadOrAdmin)
     throw new PermissionError(
       `User with email ${user.email} does not have permission to view dev portfolios!`
@@ -44,7 +44,6 @@ export const makeDevPortfolioSubmission = async (
 ): Promise<DevPortfolioSubmission> => {
   const devPortfolio = await DevPortfolioDao.getInstance(uuid);
   if (!devPortfolio) throw new BadRequestError(`Dev portfolio with uuid ${uuid} does not exist.`);
-
   if (!isWithinDates(Date.now(), devPortfolio.earliestValidDate, devPortfolio.deadline)) {
     const startDate = new Date(devPortfolio.earliestValidDate).toDateString();
     const endDate = new Date(devPortfolio.deadline).toDateString();

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -44,6 +44,7 @@ export const makeDevPortfolioSubmission = async (
 ): Promise<DevPortfolioSubmission> => {
   const devPortfolio = await DevPortfolioDao.getInstance(uuid);
   if (!devPortfolio) throw new BadRequestError(`Dev portfolio with uuid ${uuid} does not exist.`);
+
   if (!isWithinDates(Date.now(), devPortfolio.earliestValidDate, devPortfolio.deadline)) {
     const startDate = new Date(devPortfolio.earliestValidDate).toDateString();
     const endDate = new Date(devPortfolio.deadline).toDateString();

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -1,0 +1,152 @@
+import DevPortfolioDao from '../src/dao/DevPortfolioDao'; // eslint-disable-line  @typescript-eslint/no-unused-vars
+import PermissionsManager from '../src/utils/permissionsManager';
+import { fakeIdolMember, fakeDevPortfolio, fakeDevPortfolioSubmission } from './data/createData';
+import {
+  getDevPortfolio,
+  deleteDevPortfolio,
+  createNewDevPortfolio,
+  makeDevPortfolioSubmission
+} from '../src/API/devPortfolioAPI';
+import { PermissionError, BadRequestError } from '../src/utils/errors';
+import * as githubUtils from '../src/utils/githubUtil';
+
+describe('User is not lead or admin', () => {
+  beforeAll(() => {
+    const mockIsLeadOrAdmin = jest.fn().mockResolvedValue(false);
+    PermissionsManager.isLeadOrAdmin = mockIsLeadOrAdmin;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const user = fakeIdolMember();
+  const devPortfolio = fakeDevPortfolio();
+
+  test('test', async () => {
+    const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+    expect(isLeadOrAdmin).toBeDefined();
+  });
+
+  test('getDevPortfolio should throw permission error', async () => {
+    await expect(getDevPortfolio('fake-uuid', user)).rejects.toThrow(
+      new PermissionError(
+        `User with email ${user.email} does not have permission to view dev portfolios!`
+      )
+    );
+  });
+
+  test('createDevPortfolio should throw permission error', async () => {
+    await expect(createNewDevPortfolio(devPortfolio, user)).rejects.toThrow(
+      new PermissionError(
+        `User with email: ${user.email} does not have permission to create dev portfolio!`
+      )
+    );
+  });
+
+  test('deleteDevPortfolio shoudl throw permission error', async () => {
+    await expect(deleteDevPortfolio('fake-uuid', user)).rejects.toThrow(
+      new PermissionError(
+        `User with email: ${user.email} does not have permission to delete dev portfolio!`
+      )
+    );
+  });
+});
+
+describe('User is lead or admin', () => {
+  const devPortfolio = fakeDevPortfolio();
+  const user = fakeIdolMember();
+  user.email = 'hl738@cornell.edu';
+
+  beforeAll(() => {
+    const mockIsLeadOrAdmin = jest.fn().mockResolvedValue(true);
+    const mockGetInstance = jest.fn().mockResolvedValue(devPortfolio);
+    const mockCreateInstance = jest.fn().mockResolvedValue(devPortfolio);
+    const mockDeleteInstance = jest.fn().mockResolvedValue(undefined);
+
+    PermissionsManager.isLeadOrAdmin = mockIsLeadOrAdmin;
+    DevPortfolioDao.createNewInstance = mockCreateInstance;
+    DevPortfolioDao.getDevPortfolio = mockGetInstance;
+    DevPortfolioDao.deleteInstance = mockDeleteInstance;
+  });
+
+  test('getDevPortfolio should be successful', async () => {
+    const dp = await getDevPortfolio(devPortfolio.uuid, user);
+    expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
+    expect(DevPortfolioDao.getDevPortfolio).toBeCalled();
+    expect(dp.uuid).toEqual(devPortfolio.uuid);
+  });
+
+  test('createDevPortfolio should be successful', async () => {
+    await createNewDevPortfolio(devPortfolio, user);
+    expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
+    expect(DevPortfolioDao.createNewInstance).toBeCalled();
+  });
+
+  test('deleteDevPortfolio should be successful', async () => {
+    await deleteDevPortfolio(devPortfolio.uuid, user);
+    expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
+    expect(DevPortfolioDao.deleteInstance).toBeCalled();
+  });
+});
+
+describe('makeDevPortfolioSubmission tests', () => {
+  const dpSubmission = fakeDevPortfolioSubmission();
+  const devPortfolio = fakeDevPortfolio();
+
+  beforeAll(() => {
+    const mockMakeDevPortfolioSubmission = jest.fn().mockResolvedValue(dpSubmission);
+    DevPortfolioDao.makeDevPortfolioSubmission = mockMakeDevPortfolioSubmission;
+  });
+
+  it('should throw BadRequestError', async () => {
+    const mockGetInstance = jest.fn().mockResolvedValue(null);
+    DevPortfolioDao.getInstance = mockGetInstance;
+    expect(makeDevPortfolioSubmission(devPortfolio.uuid, dpSubmission)).rejects.toThrow(
+      new BadRequestError(`Dev portfolio with uuid ${devPortfolio.uuid} does not exist.`)
+    );
+  });
+
+  describe('Dev portfolio exists', () => {
+    const mockIsWithinDates = jest.spyOn(githubUtils, 'isWithinDates');
+
+    beforeAll(() => {
+      const mockGetInstance = jest.fn().mockResolvedValue(devPortfolio);
+      DevPortfolioDao.getInstance = mockGetInstance;
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('Submission is within dates', () => {
+      beforeAll(() => {
+        mockIsWithinDates.mockReturnValue(true);
+      });
+
+      it('should successfully submit', async () => {
+        await makeDevPortfolioSubmission(devPortfolio.uuid, dpSubmission);
+        expect(mockIsWithinDates.mock.calls[0][1]).toEqual(devPortfolio.earliestValidDate);
+        expect(mockIsWithinDates.mock.calls[0][2]).toEqual(devPortfolio.deadline);
+        expect(DevPortfolioDao.makeDevPortfolioSubmission).toBeCalled();
+      });
+    });
+
+    describe('Submission is not within dates', () => {
+      beforeAll(() => {
+        mockIsWithinDates.mockReturnValue(false);
+      });
+
+      it('should not successfully submit', async () => {
+        expect(makeDevPortfolioSubmission(devPortfolio.uuid, dpSubmission)).rejects.toThrow(
+          new BadRequestError(
+            `This dev portfolio must be created between ${new Date(
+              devPortfolio.earliestValidDate
+            ).toDateString()} and ${new Date(devPortfolio.deadline).toDateString()}.`
+          )
+        );
+        expect(DevPortfolioDao.makeDevPortfolioSubmission).not.toBeCalled();
+      });
+    });
+  });
+});

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -25,7 +25,7 @@ export default function AppTemplate(props: AppProps): JSX.Element {
         <meta charSet="utf-8" />
         <link rel="icon" href="/dti-logo.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="theme-color" content="#000000" />
+        <meta name="theme-color" content="#FFFFFF" />
         <meta name="description" content="Cornell DTI's Internal DTI Organization Logic (IDOL)" />
         <link rel="apple-touch-icon" href="/dti-logo.png" />
         <link rel="manifest" href="/manifest.json" />

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -25,7 +25,7 @@ export default function AppTemplate(props: AppProps): JSX.Element {
         <meta charSet="utf-8" />
         <link rel="icon" href="/dti-logo.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="theme-color" content="#FFFFFF" />
+        <meta name="theme-color" content="#000000" />
         <meta name="description" content="Cornell DTI's Internal DTI Organization Logic (IDOL)" />
         <link rel="apple-touch-icon" href="/dti-logo.png" />
         <link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION
### Summary <!-- Required -->

Adds testing for the API layer for dev portfolios

Tests:
- Permissions tests for getting, deleting, and creating new dev portfolios 
- Logic tests for whether or not a portfolio can submitted to a dev portfolio assignment (i.e. making sure that a submission can only be made to an assignment that is currently open) 



### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Backend-Test-dev-portfolio-API-ec5eb701160e4d5ba8256975e242f16f)

### Test Plan <!-- Required -->
All tests should pass. Tests should hopefully cover all the logic in the API layer for Dev Portfolios.  
