### PR TITLE
Change Dev Portfolio validation to be case-insensitive

### DIFF
--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -144,7 +144,9 @@ const filterComments = (
   let eligibleComments: Comment[] = [];
 
   // comments made by user
-  eligibleComments = comments.filter((comment) => comment.createdBy === username);
+  eligibleComments = comments.filter(
+    (comment) => comment.createdBy.toLowerCase() === username.toLowerCase()
+  );
   if (!eligibleComments || !eligibleComments.length) {
     throw new Error(`No review comments made by user ${username} in this PR.`);
   }
@@ -223,7 +225,7 @@ const validateReview = async (
     const review = await getReviewedPR(parseGithubUrl(reviewUrl));
 
     // cannot review own PR
-    if (review.createdBy === username) {
+    if (review.createdBy.toLowerCase() === username.toLowerCase()) {
       throw new Error(`Cannot use PR ${review.url} opened by user for review requirement.`);
     }
 
@@ -269,7 +271,8 @@ const validateOpen = async (
     // get open object
     const open = await getOpenedPR(parseGithubUrl(openUrl));
 
-    if (open.createdBy !== username) {
+    // case-insensitive compare in case URL removes capitalization
+    if (open.createdBy.toLowerCase() !== username.toLowerCase()) {
       throw new Error(`User ${username} did not open the pull request ${open.url}.`);
     }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR fixes a bug in the validation where member's usernames must exactly match the case of their username on GitHub, otherwise their comments and PRs are filtered out as if it was a different user.

For example, the username derived from profile page github.com/jacksonstaniec is `jacksonstaniec`, and will now match comments and PRs opened by user `JacksonStaniec` on GitHub.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->
[Notion](https://www.notion.so/cornelldti/Idol-FA22-5a158866a8a1472c98b1f3c042b480f8?p=8bafac625b944c7198d93fc3c3a938ed&pm=s)

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Tests for this functionality will be included in the `githubUtil.ts` test suite ([Notion task](https://www.notion.so/cornelldti/Idol-FA22-5a158866a8a1472c98b1f3c042b480f8?p=c88bce9db3d043c29a9bb42166fec4a7&pm=s)).

For now, submissions from users that previously failed should work as expected now:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/81320443/192660327-99afe110-27b7-4f97-b53d-04efc0bd66ac.png">
(PR #315 is now invalid for the correct reason for the Reviewed PRs)

