### PR TITLE
Increase GitHub API Rate Limit

### DIFF
--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -144,7 +144,9 @@ const filterComments = (
   let eligibleComments: Comment[] = [];
 
   // comments made by user
-  eligibleComments = comments.filter((comment) => comment.createdBy === username);
+  eligibleComments = comments.filter(
+    (comment) => comment.createdBy.toLowerCase() === username.toLowerCase()
+  );
   if (!eligibleComments || !eligibleComments.length) {
     throw new Error(`No review comments made by user ${username} in this PR.`);
   }
@@ -223,7 +225,7 @@ const validateReview = async (
     const review = await getReviewedPR(parseGithubUrl(reviewUrl));
 
     // cannot review own PR
-    if (review.createdBy === username) {
+    if (review.createdBy.toLowerCase() === username.toLowerCase()) {
       throw new Error(`Cannot use PR ${review.url} opened by user for review requirement.`);
     }
 
@@ -269,7 +271,8 @@ const validateOpen = async (
     // get open object
     const open = await getOpenedPR(parseGithubUrl(openUrl));
 
-    if (open.createdBy !== username) {
+    // case-insensitive compare in case URL removes capitalization
+    if (open.createdBy.toLowerCase() !== username.toLowerCase()) {
       throw new Error(`User ${username} did not open the pull request ${open.url}.`);
     }
 

--- a/dti-website/src/data/all-members.json
+++ b/dti-website/src/data/all-members.json
@@ -825,7 +825,7 @@
     "roleDescription": "Technical PM",
     "formerSubteams": [],
     "linkedin": "https://linkedin.com/in/jacksonstaniec",
-    "github": "https://github.com/jacksonstaniec"
+    "github": "https://github.com/JacksonStaniec"
   },
   {
     "netid": "jlc497",

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -66,6 +66,16 @@ const DevPortfolioForm: React.FC = () => {
         headerMsg: 'Invalid PR link',
         contentMsg: 'One or more links to PRs are not valid links.'
       });
+    } else if (new Date(devPortfolio.deadline) < new Date()) {
+      Emitters.generalError.emit({
+        headerMsg: 'The deadline for this dev portfolio has passed',
+        contentMsg: 'Please select another dev portfolio.'
+      });
+    } else if (new Date(devPortfolio.earliestValidDate) > new Date()) {
+      Emitters.generalError.emit({
+        headerMsg: 'This dev portfolio is not open yet',
+        contentMsg: 'Please select another dev portfolio.'
+      });
     } else {
       const newDevPortfolioSubmission: DevPortfolioSubmission = {
         member: userInfo,
@@ -110,7 +120,9 @@ const DevPortfolioForm: React.FC = () => {
                 selection
                 options={devPortfolios.map((assignment) => ({
                   key: assignment.uuid,
-                  text: assignment.name,
+                  text: `${assignment.name} (Due:  ${new Date(
+                    assignment.deadline
+                  ).toDateString()})`,
                   value: assignment.uuid
                 }))}
                 onChange={(_, data) => {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR uses a GitHub access token to authenticate API calls during made during dev portfolio validation, increasing the rate limit from 60 calls per hour to 5000 calls per hour. 

We can estimate that each dev portfolio submission has 2 opened PR links and 2 reviewed PR links (even though only 1 of each is required by the assignment). It costs 1 API call to validate an opened PR, and 4 API calls to validate a reviewed PR. So, this new rate limit allows the dev portfolio to validate up to 500 submissions per hour. 

<!-- Optional: If adding/updating endpoints, update the backend api specification (openapi.yaml) -->



### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->
[Notion](https://www.notion.so/cornelldti/Idol-FA22-5a158866a8a1472c98b1f3c042b480f8?p=2e4df035eb8d41c98fde53062e110baa&pm=s)

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Check the API rate limit by running:
```typescript
octokit.rest.rateLimit.get().then((res) => console.log(res.data.rate));
```
with `octokit` initialized using the token stored as an environment variable. (You can do this at the end of `githubUtil.ts` for example). You should see that:
```typescript
limit: 5000
```

Then, make a dev portfolio submission.

Checking the API limit again, the `limit` should still be 5000, and the `used` field should have incremented by however many API calls it took to validate the submission.
