### PR TITLE
Increase GitHub API Rate Limit

### DIFF
--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -1,6 +1,5 @@
 import { Octokit } from '@octokit/rest';
 
-require('dotenv').config();
 // authenticated with PAT so rate limit increased
 const octokit = new Octokit({
   auth: process.env.GITHUB_VALIDATION_TOKEN


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR uses a GitHub access token to authenticate API calls during made during dev portfolio validation, increasing the rate limit from 60 calls per hour to 5000 calls per hour. 

We can estimate that each dev portfolio submission has 2 opened PR links and 2 reviewed PR links (even though only 1 of each is required by the assignment). It costs 1 API call to validate an opened PR, and 4 API calls to validate a reviewed PR. So, this new rate limit allows the dev portfolio to validate up to 500 submissions per hour. 

<!-- Optional: If adding/updating endpoints, update the backend api specification (openapi.yaml) -->



### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->
[Notion](https://www.notion.so/cornelldti/Idol-FA22-5a158866a8a1472c98b1f3c042b480f8?p=2e4df035eb8d41c98fde53062e110baa&pm=s)

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Check the API rate limit by running:
```typescript
octokit.rest.rateLimit.get().then((res) => console.log(res.data.rate));
```
with `octokit` initialized using the token stored as an environment variable. (You can do this at the end of `githubUtil.ts` for example). You should see that:
```typescript
limit: 5000
```

Then, make a dev portfolio submission.

Checking the API limit again, the `limit` should still be 5000, and the `used` field should have incremented by however many API calls it took to validate the submission.
