### PR TITLE
Members Can View Past DP Submissions

### DIFF
--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -5,7 +5,7 @@ import { validateSubmission, isWithinDates } from '../utils/githubUtil';
 
 export const getAllDevPortfolios = async (
   user: IdolMember,
-  isAdminRequest
+  isAdminRequest: boolean
 ): Promise<DevPortfolio[]> => {
   if (!isAdminRequest) {
     return DevPortfolioDao.getAllInstances(false, user);

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -3,14 +3,36 @@ import PermissionsManager from '../utils/permissionsManager';
 import { PermissionError, BadRequestError } from '../utils/errors';
 import { validateSubmission, isWithinDates } from '../utils/githubUtil';
 
-export const getAllDevPortfolios = async (user: IdolMember): Promise<DevPortfolio[]> =>{
-  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
-  return DevPortfolioDao.getAllInstances(false, user);
-}
+export const getAllDevPortfolios = async (
+  user: IdolMember,
+  isAdminRequest
+): Promise<DevPortfolio[]> => {
+  if (!isAdminRequest) {
+    return DevPortfolioDao.getAllInstances(false, user);
+  }
 
-export const getDevPortfolio = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
-  return DevPortfolioDao.getDevPortfolio(uuid, false, user);
+  if (!isLeadOrAdmin)
+    throw new PermissionError(
+      `User with email ${user.email} does not have permission to view dev portfolios!`
+    );
+  return DevPortfolioDao.getAllInstances(isLeadOrAdmin, user);
+};
+
+export const getDevPortfolio = async (
+  uuid: string,
+  user: IdolMember,
+  isAdminRequest: boolean
+): Promise<DevPortfolio> => {
+  if (!isAdminRequest) {
+    return DevPortfolioDao.getDevPortfolio(uuid, false, user);
+  }
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  if (!isLeadOrAdmin)
+    throw new PermissionError(
+      `User with email ${user.email} does not have permission to view dev portfolios!`
+    );
+  return DevPortfolioDao.getDevPortfolio(uuid, isLeadOrAdmin, user);
 };
 
 export const createNewDevPortfolio = async (

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -3,16 +3,14 @@ import PermissionsManager from '../utils/permissionsManager';
 import { PermissionError, BadRequestError } from '../utils/errors';
 import { validateSubmission, isWithinDates } from '../utils/githubUtil';
 
-export const getAllDevPortfolios = async (): Promise<DevPortfolio[]> =>
-  DevPortfolioDao.getAllInstances();
+export const getAllDevPortfolios = async (user: IdolMember): Promise<DevPortfolio[]> =>{
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  return DevPortfolioDao.getAllInstances(isLeadOrAdmin, user);
+}
 
 export const getDevPortfolio = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
-  if (!isLeadOrAdmin)
-    throw new PermissionError(
-      `User with email ${user.email} does not have permission to view dev portfolios!`
-    );
-  return DevPortfolioDao.getDevPortfolio(uuid);
+  return DevPortfolioDao.getDevPortfolio(uuid, false, user);
 };
 
 export const createNewDevPortfolio = async (
@@ -42,7 +40,7 @@ export const makeDevPortfolioSubmission = async (
   uuid: string,
   submission: DevPortfolioSubmission
 ): Promise<DevPortfolioSubmission> => {
-  const devPortfolio = await DevPortfolioDao.getInstance(uuid);
+  const devPortfolio = await DevPortfolioDao.getDevPortfolio(uuid, true, submission.member);
   if (!devPortfolio) throw new BadRequestError(`Dev portfolio with uuid ${uuid} does not exist.`);
 
   if (!isWithinDates(Date.now(), devPortfolio.earliestValidDate, devPortfolio.deadline)) {

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -5,7 +5,7 @@ import { validateSubmission, isWithinDates } from '../utils/githubUtil';
 
 export const getAllDevPortfolios = async (user: IdolMember): Promise<DevPortfolio[]> =>{
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
-  return DevPortfolioDao.getAllInstances(isLeadOrAdmin, user);
+  return DevPortfolioDao.getAllInstances(false, user);
 }
 
 export const getDevPortfolio = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -285,7 +285,7 @@ loginCheckedPost('/sendMail', async (req, user) => ({
 
 // Dev Portfolios
 loginCheckedGet('/getAllDevPortfolios', async (req, user) => ({
-  portfolios: await getAllDevPortfolios()
+  portfolios: await getAllDevPortfolios(user)
 }));
 loginCheckedGet('/getDevPortfolio/:uuid', async (req, user) => ({
   portfolio: await getDevPortfolio(req.params.uuid, user)

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -285,10 +285,16 @@ loginCheckedPost('/sendMail', async (req, user) => ({
 
 // Dev Portfolios
 loginCheckedGet('/getAllDevPortfolios', async (req, user) => ({
-  portfolios: await getAllDevPortfolios(user)
+  portfolios: await getAllDevPortfolios(user, true)
 }));
 loginCheckedGet('/getDevPortfolio/:uuid', async (req, user) => ({
-  portfolio: await getDevPortfolio(req.params.uuid, user)
+  portfolio: await getDevPortfolio(req.params.uuid, user, true)
+}));
+loginCheckedGet('/getAllDevPortfoliosNonAdmin', async (req, user) => ({
+  portfolios: await getAllDevPortfolios(user, false)
+}));
+loginCheckedGet('/getDevPortfolioNonAdmin/:uuid', async (req, user) => ({
+  portfolio: await getDevPortfolio(req.params.uuid, user, false)
 }));
 loginCheckedPost('/createNewDevPortfolio', async (req, user) => ({
   portfolio: await createNewDevPortfolio(req.body, user)

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -4,19 +4,25 @@ import { DBDevPortfolio } from '../types/DataTypes';
 import { getMemberFromDocumentReference } from '../utils/memberUtil';
 
 export default class DevPortfolioDao {
-  private static async DBDevPortfolioToDevPortfolio(data: DBDevPortfolio, isLeadOrAdminOrIgnorePerms: boolean, user: IdolMember | null): Promise<DevPortfolio> {
+  private static async DBDevPortfolioToDevPortfolio(
+    data: DBDevPortfolio,
+    isLeadOrAdminOrIgnorePerms: boolean,
+    user: IdolMember | null
+  ): Promise<DevPortfolio> {
     const submissions = await Promise.all(
       data.submissions.map(async (submission) => ({
         ...submission,
         member: await getMemberFromDocumentReference(submission.member)
       }))
-    )
-    // console.log(user.email)
-    // console.log(submissions.forEach((submission) => console.log(submission.member.email)))
+    );
+
     return {
       ...data,
-      submissions: isLeadOrAdminOrIgnorePerms ? submissions : submissions.filter((submission) => user ? submission.member.email === user.email : false)
-      // submissions: submissions
+      submissions: isLeadOrAdminOrIgnorePerms
+        ? submissions
+        : submissions.filter((submission) =>
+            user ? submission.member.email === user.email : false
+          )
     };
   }
 
@@ -31,7 +37,11 @@ export default class DevPortfolioDao {
     };
   }
 
-  public static async getDevPortfolio(uuid: string, isLeadOrAdmin: boolean, user: IdolMember): Promise<DevPortfolio> {
+  public static async getDevPortfolio(
+    uuid: string,
+    isLeadOrAdmin: boolean,
+    user: IdolMember
+  ): Promise<DevPortfolio> {
     const doc = await devPortfolioCollection.doc(uuid).get();
     return this.DBDevPortfolioToDevPortfolio(doc.data() as DBDevPortfolio, isLeadOrAdmin, user);
   }
@@ -61,12 +71,19 @@ export default class DevPortfolioDao {
     return DevPortfolioDao.DBDevPortfolioToDevPortfolio(data, true, null);
   }
 
-  static async getAllInstances(isLeadOrAdmin: boolean, user: IdolMember | null): Promise<DevPortfolio[]> {
+  static async getAllInstances(
+    isLeadOrAdmin: boolean,
+    user: IdolMember | null
+  ): Promise<DevPortfolio[]> {
     const instanceRefs = await devPortfolioCollection.get();
 
     return Promise.all(
       instanceRefs.docs.map(async (instanceRefs) =>
-        DevPortfolioDao.DBDevPortfolioToDevPortfolio(instanceRefs.data() as DBDevPortfolio, isLeadOrAdmin,user)
+        DevPortfolioDao.DBDevPortfolioToDevPortfolio(
+          instanceRefs.data() as DBDevPortfolio,
+          isLeadOrAdmin,
+          user
+        )
       )
     );
   }

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -68,7 +68,7 @@ export default class DevPortfolioDao {
 
     return submission;
   }
-  
+
   static async getInstance(uuid: string): Promise<DevPortfolio> {
     const doc = await devPortfolioCollection.doc(uuid).get();
 

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -6,7 +6,7 @@ import { getMemberFromDocumentReference } from '../utils/memberUtil';
 export default class DevPortfolioDao {
   private static async DBDevPortfolioToDevPortfolio(
     data: DBDevPortfolio,
-    isLeadOrAdminOrIgnorePerms: boolean,
+    isAdminReq: boolean,
     user: IdolMember | null
   ): Promise<DevPortfolio> {
     const submissions = await Promise.all(
@@ -18,7 +18,7 @@ export default class DevPortfolioDao {
 
     return {
       ...data,
-      submissions: isLeadOrAdminOrIgnorePerms
+      submissions: isAdminReq
         ? submissions
         : submissions.filter((submission) =>
             user ? submission.member.email === user.email : false
@@ -39,11 +39,11 @@ export default class DevPortfolioDao {
 
   public static async getDevPortfolio(
     uuid: string,
-    isLeadOrAdmin: boolean,
+    isAdminReq: boolean,
     user: IdolMember
   ): Promise<DevPortfolio> {
     const doc = await devPortfolioCollection.doc(uuid).get();
-    return this.DBDevPortfolioToDevPortfolio(doc.data() as DBDevPortfolio, isLeadOrAdmin, user);
+    return this.DBDevPortfolioToDevPortfolio(doc.data() as DBDevPortfolio, isAdminReq, user);
   }
 
   static async makeDevPortfolioSubmission(
@@ -72,7 +72,7 @@ export default class DevPortfolioDao {
   }
 
   static async getAllInstances(
-    isLeadOrAdmin: boolean,
+    isAdminReq: boolean,
     user: IdolMember | null
   ): Promise<DevPortfolio[]> {
     const instanceRefs = await devPortfolioCollection.get();
@@ -81,7 +81,7 @@ export default class DevPortfolioDao {
       instanceRefs.docs.map(async (instanceRefs) =>
         DevPortfolioDao.DBDevPortfolioToDevPortfolio(
           instanceRefs.data() as DBDevPortfolio,
-          isLeadOrAdmin,
+          isAdminReq,
           user
         )
       )

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -68,6 +68,7 @@ export default class DevPortfolioDao {
 
     return submission;
   }
+  
   static async getInstance(uuid: string): Promise<DevPortfolio> {
     const doc = await devPortfolioCollection.doc(uuid).get();
 

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -28,14 +28,6 @@ describe('User is not lead or admin', () => {
     expect(isLeadOrAdmin).toBeDefined();
   });
 
-  test('getDevPortfolio should throw permission error', async () => {
-    await expect(getDevPortfolio('fake-uuid', user)).rejects.toThrow(
-      new PermissionError(
-        `User with email ${user.email} does not have permission to view dev portfolios!`
-      )
-    );
-  });
-
   test('createDevPortfolio should throw permission error', async () => {
     await expect(createNewDevPortfolio(devPortfolio, user)).rejects.toThrow(
       new PermissionError(

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -28,6 +28,14 @@ describe('User is not lead or admin', () => {
     expect(isLeadOrAdmin).toBeDefined();
   });
 
+  test('getDevPortfolio should throw permission error', async () => {
+    await expect(getDevPortfolio('fake-uuid', user, true)).rejects.toThrow(
+      new PermissionError(
+        `User with email ${user.email} does not have permission to view dev portfolios!`
+      )
+    );
+  });
+
   test('createDevPortfolio should throw permission error', async () => {
     await expect(createNewDevPortfolio(devPortfolio, user)).rejects.toThrow(
       new PermissionError(
@@ -63,7 +71,7 @@ describe('User is lead or admin', () => {
   });
 
   test('getDevPortfolio should be successful', async () => {
-    const dp = await getDevPortfolio(devPortfolio.uuid, user);
+    const dp = await getDevPortfolio(devPortfolio.uuid, user, true);
     expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
     expect(DevPortfolioDao.getDevPortfolio).toBeCalled();
     expect(dp.uuid).toEqual(devPortfolio.uuid);

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -100,8 +100,8 @@ describe('makeDevPortfolioSubmission tests', () => {
   });
 
   it('should throw BadRequestError', async () => {
-    const mockGetInstance = jest.fn().mockResolvedValue(null);
-    DevPortfolioDao.getInstance = mockGetInstance;
+    const mockGetDevPortfolio = jest.fn().mockResolvedValue(null);
+    DevPortfolioDao.getDevPortfolio = mockGetDevPortfolio;
     expect(makeDevPortfolioSubmission(devPortfolio.uuid, dpSubmission)).rejects.toThrow(
       new BadRequestError(`Dev portfolio with uuid ${devPortfolio.uuid} does not exist.`)
     );
@@ -111,8 +111,8 @@ describe('makeDevPortfolioSubmission tests', () => {
     const mockIsWithinDates = jest.spyOn(githubUtils, 'isWithinDates');
 
     beforeAll(() => {
-      const mockGetInstance = jest.fn().mockResolvedValue(devPortfolio);
-      DevPortfolioDao.getInstance = mockGetInstance;
+      const mockGetDevPortfolio = jest.fn().mockResolvedValue(devPortfolio);
+      DevPortfolioDao.getDevPortfolio = mockGetDevPortfolio;
     });
 
     afterEach(() => {

--- a/backend/tests/DevPortfolioDao.test.ts
+++ b/backend/tests/DevPortfolioDao.test.ts
@@ -27,7 +27,7 @@ afterAll(async () => {
 // });
 
 test('Get all instances', () =>
-  DevPortfolioDao.getAllInstances().then((allSubmissions) => {
+  DevPortfolioDao.getAllInstances(true, null).then((allSubmissions) => {
     expect(allSubmissions.some((submission) => submission === mockDP));
     expect(allSubmissions.some((submission) => submission === mockDP2));
     expect(allSubmissions.some((submission) => submission === mockDP3));

--- a/frontend/src/API/DevPortfolioAPI.ts
+++ b/frontend/src/API/DevPortfolioAPI.ts
@@ -6,8 +6,10 @@ type DevPortfolioSubmissionResponseObj = {
 };
 
 export default class DevPortfolioAPI {
-  static async getAllDevPortfolios(): Promise<DevPortfolio[]> {
-    const response = APIWrapper.get(`${backendURL}/getAllDevPortfolios`);
+  static async getAllDevPortfolios(isAdminReq: boolean): Promise<DevPortfolio[]> {
+    const response = APIWrapper.get(
+      `${backendURL}/getAllDevPortfolios${isAdminReq ? '' : 'NonAdmin'}`
+    );
     return response.then((val) => val.data.portfolios);
   }
 
@@ -31,9 +33,9 @@ export default class DevPortfolioAPI {
     APIWrapper.post(`${backendURL}/deleteDevPortfolio`, { uuid });
   }
 
-  public static async getDevPortfolio(uuid: string): Promise<DevPortfolio> {
-    return APIWrapper.get(`${backendURL}/getDevPortfolio/${uuid}`).then(
-      (res) => res.data.portfolio
-    );
+  public static async getDevPortfolio(uuid: string, isAdminReq: boolean): Promise<DevPortfolio> {
+    return APIWrapper.get(
+      `${backendURL}/getDevPortfolio${isAdminReq ? '' : 'NonAdmin'}/${uuid}`
+    ).then((res) => res.data.portfolio);
   }
 }

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
@@ -43,7 +43,7 @@ const AdminDevPortfolio: React.FC = () => {
         <AdminDevPortfolioForm setDevPortfolios={setDevPortfolios} />
       </Container>
       <Divider />
-      <AdminDevPortfolioDashboard
+      <DevPortfolioDashboard
         isLoading={isLoading}
         devPortfolios={devPortfolios}
         setDevPortfolios={setDevPortfolios}
@@ -53,14 +53,14 @@ const AdminDevPortfolio: React.FC = () => {
   );
 };
 
-type AdminDevPortfolioDashboardProps = {
+type DevPortfolioDashboardProps = {
   readonly devPortfolios: DevPortfolio[];
   readonly isLoading: boolean;
   readonly setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   readonly setDevPortfolios: React.Dispatch<React.SetStateAction<DevPortfolio[]>>;
 };
 
-const AdminDevPortfolioDashboard: React.FC<AdminDevPortfolioDashboardProps> = ({
+export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
   devPortfolios,
   setDevPortfolios,
   isLoading,

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
@@ -48,6 +48,7 @@ const AdminDevPortfolio: React.FC = () => {
         devPortfolios={devPortfolios}
         setDevPortfolios={setDevPortfolios}
         setIsLoading={setIsLoading}
+        isAdmin={true}
       />
     </Container>
   );
@@ -58,13 +59,15 @@ type DevPortfolioDashboardProps = {
   readonly isLoading: boolean;
   readonly setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   readonly setDevPortfolios: React.Dispatch<React.SetStateAction<DevPortfolio[]>>;
+  readonly isAdmin: boolean;
 };
 
 export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
   devPortfolios,
   setDevPortfolios,
   isLoading,
-  setIsLoading
+  setIsLoading,
+  isAdmin,
 }) => (
   <Container>
     {isLoading ? (
@@ -75,13 +78,15 @@ export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
           {devPortfolios.map((portfolio) => (
             <Card key={portfolio.uuid}>
               <Card.Content>
+                
+                {isAdmin ?
                 <DevPortfolioDeleteModal
                   uuid={portfolio.uuid}
                   name={portfolio.name}
                   setDevPortfolios={setDevPortfolios}
-                />
+                /> : <></>}
                 <Card.Header className={styles.cardHeader}>
-                  <a href={`/admin/dev-portfolio/${portfolio.uuid}`}>{portfolio.name}</a>
+                  <a href={`${isAdmin ? `/admin/dev-portfolio/` : `/forms/submissions/`}${portfolio.uuid}`}>{portfolio.name}</a>
                 </Card.Header>
                 <Card.Meta>{portfolio.submissions.length} submissions</Card.Meta>
                 <Card.Description>

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
@@ -27,7 +27,7 @@ const AdminDevPortfolio: React.FC = () => {
 
   const getAllDevPortfolios = () => {
     setIsLoading(true);
-    DevPortfolioAPI.getAllDevPortfolios().then((devPortfolios) => {
+    DevPortfolioAPI.getAllDevPortfolios(true).then((devPortfolios) => {
       setIsLoading(false);
       setDevPortfolios(devPortfolios);
     });
@@ -48,7 +48,7 @@ const AdminDevPortfolio: React.FC = () => {
         devPortfolios={devPortfolios}
         setDevPortfolios={setDevPortfolios}
         setIsLoading={setIsLoading}
-        isAdmin={true}
+        isAdminView={true}
       />
     </Container>
   );
@@ -59,7 +59,7 @@ type DevPortfolioDashboardProps = {
   readonly isLoading: boolean;
   readonly setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   readonly setDevPortfolios: React.Dispatch<React.SetStateAction<DevPortfolio[]>>;
-  readonly isAdmin: boolean;
+  readonly isAdminView: boolean;
 };
 
 export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
@@ -67,7 +67,7 @@ export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
   setDevPortfolios,
   isLoading,
   setIsLoading,
-  isAdmin,
+  isAdminView
 }) => (
   <Container>
     {isLoading ? (
@@ -78,15 +78,23 @@ export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
           {devPortfolios.map((portfolio) => (
             <Card key={portfolio.uuid}>
               <Card.Content>
-                
-                {isAdmin ?
-                <DevPortfolioDeleteModal
-                  uuid={portfolio.uuid}
-                  name={portfolio.name}
-                  setDevPortfolios={setDevPortfolios}
-                /> : <></>}
+                {isAdminView ? (
+                  <DevPortfolioDeleteModal
+                    uuid={portfolio.uuid}
+                    name={portfolio.name}
+                    setDevPortfolios={setDevPortfolios}
+                  />
+                ) : (
+                  <></>
+                )}
                 <Card.Header className={styles.cardHeader}>
-                  <a href={`${isAdmin ? `/admin/dev-portfolio/` : `/forms/submissions/`}${portfolio.uuid}`}>{portfolio.name}</a>
+                  <a
+                    href={`${
+                      isAdminView ? `/admin/dev-portfolio/` : `/forms/dev-portfolio-submissions/`
+                    }${portfolio.uuid}`}
+                  >
+                    {portfolio.name}
+                  </a>
                 </Card.Header>
                 <Card.Meta>{portfolio.submissions.length} submissions</Card.Meta>
                 <Card.Description>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -5,13 +5,14 @@ import styles from './DevPortfolioDetails.module.css';
 
 type Props = {
   uuid: string;
+  isAdminView: boolean;
 };
 
-const DevPortfolioDetails: React.FC<Props> = ({ uuid }) => {
+const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
   const [portfolio, setPortfolio] = useState<DevPortfolio | null>(null);
 
   useEffect(() => {
-    DevPortfolioAPI.getDevPortfolio(uuid).then((portfolio) => setPortfolio(portfolio));
+    DevPortfolioAPI.getDevPortfolio(uuid, isAdminView).then((portfolio) => setPortfolio(portfolio));
   }, [uuid]);
 
   return !portfolio ? (
@@ -28,16 +29,17 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid }) => {
       <Header textAlign="center" as="h3">
         Deadline: {new Date(portfolio.deadline).toDateString()}
       </Header>
-      <DetailsTable portfolio={portfolio} />
+      <DetailsTable portfolio={portfolio} isAdminView={isAdminView} />
     </Container>
   );
 };
 
 type DevPortfolioDetailsTableProps = {
   readonly portfolio: DevPortfolio;
+  readonly isAdminView: boolean;
 };
 
-const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio }) => {
+const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio, isAdminView }) => {
   const sortedSubmissions = [...portfolio.submissions].sort((s1, s2) =>
     s1.member.netid.localeCompare(s2.member.netid)
   );
@@ -48,11 +50,11 @@ const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio }) =>
         <Table.HeaderCell rowSpan="2">Name</Table.HeaderCell>
         <Table.HeaderCell rowSpan="2">Opened PRs</Table.HeaderCell>
         <Table.HeaderCell rowSpan="2">Reviewed PRs</Table.HeaderCell>
-        <Table.HeaderCell rowSpan="2">Status</Table.HeaderCell>
+        {isAdminView ? <Table.HeaderCell rowSpan="2">Status</Table.HeaderCell> : <></>}
       </Table.Header>
       <Table.Body>
         {sortedSubmissions.map((submission) => (
-          <SubmissionDetails submission={submission} />
+          <SubmissionDetails submission={submission} isAdminView={isAdminView} />
         ))}
       </Table.Body>
     </Table>
@@ -61,30 +63,37 @@ const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio }) =>
 
 type SubmissionDetailsProps = {
   submission: DevPortfolioSubmission;
+  isAdminView: boolean;
 };
 
-const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission }) => {
+const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdminView }) => {
   const numRows = Math.max(submission.openedPRs.length, submission.reviewedPRs.length);
   const isValid =
     submission.openedPRs.some((pr) => pr.status === 'valid') &&
     submission.reviewedPRs.some((pr) => pr.status === 'valid');
 
   const FirstRow = () => (
-    <Table.Row positive={isValid} negative={!isValid}>
+    <Table.Row positive={isAdminView && isValid} negative={isAdminView && !isValid}>
       <Table.Cell
         rowSpan={`${numRows}`}
       >{`${submission.member.firstName} ${submission.member.lastName} (${submission.member.netid})`}</Table.Cell>
       <Table.Cell>
         <PullRequestDisplay
           prSubmission={submission.openedPRs.length > 0 ? submission.openedPRs[0] : undefined}
+          isAdminView={isAdminView}
         />
       </Table.Cell>
       <Table.Cell>
         <PullRequestDisplay
           prSubmission={submission.reviewedPRs.length > 0 ? submission.reviewedPRs[0] : undefined}
+          isAdminView={isAdminView}
         />
       </Table.Cell>
-      <Table.Cell rowSpan={`${numRows}`}>{isValid ? 'Valid' : 'Invalid'}</Table.Cell>
+      {isAdminView ? (
+        <Table.Cell rowSpan={`${numRows}`}>{isValid ? 'Valid' : 'Invalid'}</Table.Cell>
+      ) : (
+        <></>
+      )}
     </Table.Row>
   );
 
@@ -98,15 +107,17 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission }) => 
       ? remainingOpenedPRs
       : remainingReviewedPRs
   ).map((_, i) => () => (
-    <Table.Row positive={isValid} negative={!isValid}>
+    <Table.Row positive={isAdminView && isValid} negative={isAdminView && !isValid}>
       <Table.Cell>
         <PullRequestDisplay
           prSubmission={i >= remainingOpenedPRs.length ? undefined : remainingOpenedPRs[i]}
+          isAdminView={isAdminView}
         />
       </Table.Cell>
       <Table.Cell>
         <PullRequestDisplay
           prSubmission={i >= remainingReviewedPRs.length ? undefined : remainingReviewedPRs[i]}
+          isAdminView={isAdminView}
         />
       </Table.Cell>
     </Table.Row>
@@ -124,19 +135,22 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission }) => 
 
 type PullRequestDisplayProps = {
   prSubmission: PullRequestSubmission | undefined;
+  isAdminView: boolean;
 };
 
-const PullRequestDisplay: React.FC<PullRequestDisplayProps> = ({ prSubmission }) => {
+const PullRequestDisplay: React.FC<PullRequestDisplayProps> = ({ prSubmission, isAdminView }) => {
   if (prSubmission === undefined) return <></>;
   return (
     <>
       <a href={prSubmission.url}>{prSubmission.url}</a>
-      {
+      {isAdminView ? (
         <Icon
           color={prSubmission.status === 'valid' ? 'green' : 'red'}
           name={prSubmission.status === 'valid' ? 'checkmark' : 'x'}
         />
-      }
+      ) : (
+        <></>
+      )}
     </>
   );
 };

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -13,7 +13,7 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
 
   useEffect(() => {
     DevPortfolioAPI.getDevPortfolio(uuid, isAdminView).then((portfolio) => setPortfolio(portfolio));
-  }, [uuid]);
+  }, [uuid, isAdminView]);
 
   return !portfolio ? (
     <></>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -145,11 +145,11 @@ const PullRequestDisplay: React.FC<PullRequestDisplayProps> = ({ prSubmission, i
       <a href={prSubmission.url}>{prSubmission.url}</a>
       {isAdminView ? (
         <>
-        <Icon
-          color={prSubmission.status === 'valid' ? 'green' : 'red'}
-          name={prSubmission.status === 'valid' ? 'checkmark' : 'x'}
-        />
-        <p>{prSubmission.reason ? `(${prSubmission.reason})` : ''}</p>
+          <Icon
+            color={prSubmission.status === 'valid' ? 'green' : 'red'}
+            name={prSubmission.status === 'valid' ? 'checkmark' : 'x'}
+          />
+          <p>{prSubmission.reason ? `(${prSubmission.reason})` : ''}</p>
         </>
       ) : (
         <></>

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Form, Dropdown, Button, Icon, Divider, Container } from 'semantic-ui-react';
+import { Form, Dropdown, Button, Icon, Divider } from 'semantic-ui-react';
 import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
 import { Emitters } from '../../../utils';
 import { DevPortfolioDashboard } from '../../Admin/DevPortfolio/AdminDevPortfolio';

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -51,7 +51,7 @@ const DevPortfolioForm: React.FC = () => {
       setIsLoading(false);
       setDevPortfolios(devPortfolios);
     });
-  }
+  };
 
   const submitDevPortfolio = () => {
     if (!devPortfolio) {

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { Form, Dropdown, Button, Icon } from 'semantic-ui-react';
+import { Form, Dropdown, Button, Icon, Divider, Container } from 'semantic-ui-react';
 import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
 import { Emitters } from '../../../utils';
+import { DevPortfolioDashboard } from '../../Admin/DevPortfolio/AdminDevPortfolio';
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import styles from './DevPortfolioForm.module.css';
 
@@ -16,9 +17,14 @@ const DevPortfolioForm: React.FC = () => {
   const [devPortfolios, setDevPortfolios] = useState<DevPortfolio[]>([]);
   const [openPRs, setOpenPRs] = useState(['']);
   const [reviewPRs, setReviewedPRs] = useState(['']);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    DevPortfolioAPI.getAllDevPortfolios().then((devPortfolios) => setDevPortfolios(devPortfolios));
+    setIsLoading(true);
+    DevPortfolioAPI.getAllDevPortfolios().then((devPortfolios) => {
+      setIsLoading(false);
+      setDevPortfolios(devPortfolios);
+    });
   }, []);
 
   const sendSubmissionRequest = (
@@ -228,6 +234,15 @@ const DevPortfolioForm: React.FC = () => {
         <Form.Button floated="right" onClick={submitDevPortfolio}>
           Submit
         </Form.Button>
+
+        <Divider />
+        <DevPortfolioDashboard
+        isLoading={isLoading}
+        devPortfolios={devPortfolios}
+        setDevPortfolios={setDevPortfolios}
+        setIsLoading={setIsLoading}
+        isAdmin={false}
+      />
       </Form>
     </div>
   );

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -20,11 +20,7 @@ const DevPortfolioForm: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    setIsLoading(true);
-    DevPortfolioAPI.getAllDevPortfolios(false).then((devPortfolios) => {
-      setIsLoading(false);
-      setDevPortfolios(devPortfolios);
-    });
+    refreshDevPortfolios();
   }, []);
 
   const sendSubmissionRequest = (
@@ -43,10 +39,19 @@ const DevPortfolioForm: React.FC = () => {
             headerMsg: 'Dev Portfolio Assignment submitted!',
             contentMsg: `The leads were notified of your submission and your submission will be graded soon!`
           });
+          refreshDevPortfolios();
         }
       }
     );
   };
+
+  const refreshDevPortfolios = () => {
+    setIsLoading(true);
+    DevPortfolioAPI.getAllDevPortfolios(false).then((devPortfolios) => {
+      setIsLoading(false);
+      setDevPortfolios(devPortfolios);
+    });
+  }
 
   const submitDevPortfolio = () => {
     if (!devPortfolio) {

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -21,7 +21,7 @@ const DevPortfolioForm: React.FC = () => {
 
   useEffect(() => {
     setIsLoading(true);
-    DevPortfolioAPI.getAllDevPortfolios().then((devPortfolios) => {
+    DevPortfolioAPI.getAllDevPortfolios(false).then((devPortfolios) => {
       setIsLoading(false);
       setDevPortfolios(devPortfolios);
     });
@@ -237,12 +237,12 @@ const DevPortfolioForm: React.FC = () => {
 
         <Divider />
         <DevPortfolioDashboard
-        isLoading={isLoading}
-        devPortfolios={devPortfolios}
-        setDevPortfolios={setDevPortfolios}
-        setIsLoading={setIsLoading}
-        isAdmin={false}
-      />
+          isLoading={isLoading}
+          devPortfolios={devPortfolios}
+          setDevPortfolios={setDevPortfolios}
+          setIsLoading={setIsLoading}
+          isAdminView={false}
+        />
       </Form>
     </div>
   );

--- a/frontend/src/pages/admin/dev-portfolio/[uuid].tsx
+++ b/frontend/src/pages/admin/dev-portfolio/[uuid].tsx
@@ -4,7 +4,7 @@ import DevPortfolioDetails from '../../../components/Admin/DevPortfolio/DevPortf
 const DevPortfolioDetailsPage: React.FC = () => {
   const router = useRouter();
   const { uuid } = router.query;
-  return <DevPortfolioDetails uuid={uuid as string} />;
+  return <DevPortfolioDetails uuid={uuid as string} isAdminView={true} />;
 };
 
 export default DevPortfolioDetailsPage;

--- a/frontend/src/pages/forms/dev-portfolio-submissions/[uuid].tsx
+++ b/frontend/src/pages/forms/dev-portfolio-submissions/[uuid].tsx
@@ -4,7 +4,7 @@ import DevPortfolioDetails from '../../../components/Admin/DevPortfolio/DevPortf
 const DevPortfolioDetailsPage: React.FC = () => {
   const router = useRouter();
   const { uuid } = router.query;
-  return <DevPortfolioDetails uuid={uuid as string} />;
+  return <DevPortfolioDetails uuid={uuid as string} isAdminView={false} />;
 };
 
 export default DevPortfolioDetailsPage;

--- a/frontend/src/pages/forms/submissions/[uuid].tsx
+++ b/frontend/src/pages/forms/submissions/[uuid].tsx
@@ -1,0 +1,10 @@
+import { useRouter } from 'next/router';
+import DevPortfolioDetails from '../../../components/Admin/DevPortfolio/DevPortfolioDetails';
+
+const DevPortfolioDetailsPage: React.FC = () => {
+  const router = useRouter();
+  const { uuid } = router.query;
+  return <DevPortfolioDetails uuid={uuid as string} />;
+};
+
+export default DevPortfolioDetailsPage;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

- Users were previously not able to see their previous submissions. Now, users can see dev portfolios that they’ve submitted to, and a table of their submissions, using analogous components to the admin dashboard.
- Users are not able to see the validation results, just the submissions. We've hidden their results for now. The results are only available from the admin side.
- Added getAllDevPortfoliosNonAdmin and getDevPortfolioNonAdmin routes, which only return information about the dev portfolios that are accessible to a non-admin (aka, deadline, earliest date, and that member's submissions ONLY). Trying to access the admin-only routes as a non-admin still throws a permissions error. Admins can call the nonAdmin route, which returns information only as if they were a non-admin.
- Architecturally, the admin dashboard and the non-admin form submission page now share their analogous components that display dev portfolios and the submission details


### Notion/Figma Link <!-- Optional -->

[https://www.notion.so/cornelldti/DP-Form-See-Past-Submissions-00067ed77b394c1ca8d552c37fd0df5a](https://www.notion.so/cornelldti/DP-Form-See-Past-Submissions-00067ed77b394c1ca8d552c37fd0df5a)

### Test Plan <!-- Required -->

- Manual testing, video attached

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
- As you can see in the video, the submit button is below the divider. I haven't been able to figure out how to get it to be above.

<!-- Keep items that apply: -->

https://user-images.githubusercontent.com/59291082/193474819-dc47d77d-ea03-40b5-8b44-eba0719d72e9.mov

