### PR TITLE
Add regrade submissions functionality for dev portfolios

### DIFF
--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -77,3 +77,25 @@ export const makeDevPortfolioSubmission = async (
     await validateSubmission(devPortfolio, submission)
   );
 };
+
+export const regradeSubmissions = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {
+  const canRequestRegrade = await PermissionsManager.isLeadOrAdmin(user);
+  if (!canRequestRegrade)
+    throw new PermissionError(
+      `User with email ${user.email} does not have permission to regrade dev portfolio submissions`
+    );
+
+  const devPortfolio = await DevPortfolioDao.getInstance(uuid);
+  if (!devPortfolio) {
+    throw new BadRequestError(`Dev portfolio with uuid: ${uuid} does not exist`);
+  }
+
+  const updatedDP = {
+    ...devPortfolio,
+    submissions: await Promise.all(
+      devPortfolio.submissions.map((submission) => validateSubmission(devPortfolio, submission))
+    )
+  };
+  await DevPortfolioDao.updateInstance(updatedDP);
+  return updatedDP;
+};

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -59,7 +59,8 @@ import {
   createNewDevPortfolio,
   deleteDevPortfolio,
   makeDevPortfolioSubmission,
-  getDevPortfolio
+  getDevPortfolio,
+  regradeSubmissions
 } from './API/devPortfolioAPI';
 import DPSubmissionRequestLogDao from './dao/DPSubmissionRequestLogDao';
 
@@ -309,6 +310,9 @@ loginCheckedPost('/makeDevPortfolioSubmission', async (req, user) => {
     submission: await makeDevPortfolioSubmission(req.body.uuid, req.body.submission)
   };
 });
+loginCheckedPost('/regradeDevPortfolioSubmissions', async (req, user) => ({
+  portfolio: await regradeSubmissions(req.body.uuid, user)
+}));
 
 app.use('/.netlify/functions/api', router);
 

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -69,8 +69,9 @@ export default class DevPortfolioDao {
     return submission;
   }
 
-  static async getInstance(uuid: string): Promise<DevPortfolio> {
+  static async getInstance(uuid: string): Promise<DevPortfolio | null> {
     const doc = await devPortfolioCollection.doc(uuid).get();
+    if (!doc) return null;
 
     const data = doc.data() as DBDevPortfolio;
 

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -5,7 +5,8 @@ import {
   getDevPortfolio,
   deleteDevPortfolio,
   createNewDevPortfolio,
-  makeDevPortfolioSubmission
+  makeDevPortfolioSubmission,
+  regradeSubmissions
 } from '../src/API/devPortfolioAPI';
 import { PermissionError, BadRequestError } from '../src/utils/errors';
 import * as githubUtils from '../src/utils/githubUtil';
@@ -22,11 +23,6 @@ describe('User is not lead or admin', () => {
 
   const user = fakeIdolMember();
   const devPortfolio = fakeDevPortfolio();
-
-  test('test', async () => {
-    const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
-    expect(isLeadOrAdmin).toBeDefined();
-  });
 
   test('getDevPortfolio should throw permission error', async () => {
     await expect(getDevPortfolio('fake-uuid', user, true)).rejects.toThrow(
@@ -51,6 +47,14 @@ describe('User is not lead or admin', () => {
       )
     );
   });
+
+  test('regradeSubmissions should throw permission error', async () => {
+    await expect(regradeSubmissions('<kewl-uuid>', user)).rejects.toThrow(
+      new PermissionError(
+        `User with email ${user.email} does not have permission to regrade dev portfolio submissions`
+      )
+    );
+  });
 });
 
 describe('User is lead or admin', () => {
@@ -68,6 +72,32 @@ describe('User is lead or admin', () => {
     DevPortfolioDao.createNewInstance = mockCreateInstance;
     DevPortfolioDao.getDevPortfolio = mockGetInstance;
     DevPortfolioDao.deleteInstance = mockDeleteInstance;
+  });
+
+  describe('regradeSubmissions tests', () => {
+    test("regradeSubmissions should fail if uuid isn't valid", async () => {
+      const mockGetInstance = jest.fn().mockResolvedValue(null);
+      DevPortfolioDao.getInstance = mockGetInstance;
+      expect(regradeSubmissions('<fake-uuid>', user)).rejects.toThrow(
+        new BadRequestError('Dev portfolio with uuid: <kewl-uuid> does not exist')
+      );
+    });
+
+    test('validateSubmission is called for every submission', async () => {
+      const mockValidateSubmission = jest.spyOn(githubUtils, 'validateSubmission');
+      const dp = {
+        ...devPortfolio,
+        submissions: [fakeDevPortfolioSubmission(), fakeDevPortfolioSubmission()]
+      };
+      const mockGetInstance = jest.fn().mockResolvedValue(dp);
+      const mockUpdateInstance = jest.fn();
+      DevPortfolioDao.getInstance = mockGetInstance;
+      DevPortfolioDao.updateInstance = mockUpdateInstance;
+
+      await regradeSubmissions('<kewl-uuid>', user);
+      expect(mockValidateSubmission.mock.calls.length).toBeGreaterThan(1);
+      expect(mockUpdateInstance.mock.calls.length).toEqual(1);
+    });
   });
 
   test('getDevPortfolio should be successful', async () => {

--- a/frontend/src/API/DevPortfolioAPI.ts
+++ b/frontend/src/API/DevPortfolioAPI.ts
@@ -38,4 +38,10 @@ export default class DevPortfolioAPI {
       `${backendURL}/getDevPortfolio${isAdminReq ? '' : 'NonAdmin'}/${uuid}`
     ).then((res) => res.data.portfolio);
   }
+
+  public static async regradeSubmissions(uuid: string): Promise<DevPortfolio> {
+    return APIWrapper.post(`${backendURL}/regradeDevPortfolioSubmissions`, { uuid }).then(
+      (res) => res.data.portfolio
+    );
+  }
 }

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.module.css
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.module.css
@@ -1,4 +1,3 @@
 .container {
   padding: 1%;
-  text-align: center;
 }

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.module.css
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.module.css
@@ -1,3 +1,4 @@
 .container {
   padding: 1%;
+  text-align: center;
 }

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -42,7 +42,7 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
             );
         }}
       >
-        Regrade Latest Submissions
+        Regrade All Submissions
       </Button>
       <DetailsTable portfolio={portfolio} isAdminView={isAdminView} />
     </Container>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -11,6 +11,7 @@ type Props = {
 
 const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
   const [portfolio, setPortfolio] = useState<DevPortfolio | null>(null);
+  const [isRegrading, setIsRegrading] = useState<boolean>(false);
 
   useEffect(() => {
     DevPortfolioAPI.getDevPortfolio(uuid, isAdminView).then((portfolio) => setPortfolio(portfolio));
@@ -32,8 +33,16 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
       </Header>
       <Button
         onClick={() => {
+          setIsRegrading(true);
           DevPortfolioAPI.regradeSubmissions(portfolio.uuid)
-            .then((portfolio) => setPortfolio(portfolio))
+            .then((portfolio) => {
+              setPortfolio(portfolio);
+              setIsRegrading(false);
+              Emitters.generalSuccess.emit({
+                headerMsg: 'Success!',
+                contentMsg: 'Submissions successfully regraded.'
+              });
+            })
             .catch((e) =>
               Emitters.generalError.emit({
                 headerMsg: 'Failed to regrade all submissions',
@@ -41,6 +50,7 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
               })
             );
         }}
+        loading={isRegrading}
       >
         Regrade All Submissions
       </Button>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import { Container, Header, Icon, Table } from 'semantic-ui-react';
+import { Button, Container, Header, Icon, Table } from 'semantic-ui-react';
 import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
+import { Emitters } from '../../../utils';
 import styles from './DevPortfolioDetails.module.css';
 
 type Props = {
@@ -29,6 +30,20 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
       <Header textAlign="center" as="h3">
         Deadline: {new Date(portfolio.deadline).toDateString()}
       </Header>
+      <Button
+        onClick={() => {
+          DevPortfolioAPI.regradeSubmissions(portfolio.uuid)
+            .then((portfolio) => setPortfolio(portfolio))
+            .catch((e) =>
+              Emitters.generalError.emit({
+                headerMsg: 'Failed to regrade all submissions',
+                contentMsg: 'Please try again or contact the IDOL team'
+              })
+            );
+        }}
+      >
+        Regrade Latest Submissions
+      </Button>
       <DetailsTable portfolio={portfolio} isAdminView={isAdminView} />
     </Container>
   );
@@ -53,8 +68,8 @@ const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio, isAd
         {isAdminView ? <Table.HeaderCell rowSpan="2">Status</Table.HeaderCell> : <></>}
       </Table.Header>
       <Table.Body>
-        {sortedSubmissions.map((submission) => (
-          <SubmissionDetails submission={submission} isAdminView={isAdminView} />
+        {sortedSubmissions.map((submission, i) => (
+          <SubmissionDetails submission={submission} isAdminView={isAdminView} key={i} />
         ))}
       </Table.Body>
     </Table>
@@ -107,7 +122,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
       ? remainingOpenedPRs
       : remainingReviewedPRs
   ).map((_, i) => () => (
-    <Table.Row positive={isAdminView && isValid} negative={isAdminView && !isValid}>
+    <Table.Row positive={isAdminView && isValid} negative={isAdminView && !isValid} key={i}>
       <Table.Cell>
         <PullRequestDisplay
           prSubmission={i >= remainingOpenedPRs.length ? undefined : remainingOpenedPRs[i]}
@@ -126,8 +141,8 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
   return (
     <>
       <FirstRow />
-      {remainingRows.map((Row) => (
-        <Row />
+      {remainingRows.map((Row, i) => (
+        <Row key={i} />
       ))}
     </>
   );


### PR DESCRIPTION
### Summary <!-- Required -->
Adds the ability for leads/admins to request a regrade of all submission for a dev portfolio 

### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/DP-View-Manually-Trigger-Regrade-6e5e2e4eda1044758e129ebecba93078)

### Test Plan <!-- Required -->

Added unit testing for `devPortfolioAPI.regradeSubmissions`.

### Notes <!-- Optional -->
