### PR TITLE
Bug fix: add . to regex

### DIFF
--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -39,7 +39,7 @@ type ValidationResult = {
  *  Raises an error if URL is malformed. */
 const parseGithubUrl = (url: string): PullRequest => {
   // of the form: https://github.com/cornell-dti/idol/pull/266
-  const pattern = /.*github.com\/([_a-zA-Z0-9-]+)\/([_a-zA-Z0-9-]+)\/pull\/([0-9]+)/;
+  const pattern = /.*github.com\/([._a-zA-Z0-9-]+)\/([._a-zA-Z0-9-]+)\/pull\/([0-9]+).*/;
 
   const match = url.match(pattern);
   if (match == null) {
@@ -53,7 +53,7 @@ const parseGithubUrl = (url: string): PullRequest => {
  *  Raises an error if URL is malformed. */
 const parseGithubUsername = (url: string): string => {
   // of the form: https://github.com/JacksonStaniec
-  const pattern = /.*github.com\/([_a-zA-Z0-9-]+).*/;
+  const pattern = /.*github.com\/([._a-zA-Z0-9-]+).*/;
 
   const match = url.match(pattern);
   if (match == null) {

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -6,7 +6,7 @@ import { DevPortfolioDashboard } from '../../Admin/DevPortfolio/AdminDevPortfoli
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import styles from './DevPortfolioForm.module.css';
 
-const GITHUB_PR_REGEX = /.*github.com\/([_a-zA-Z0-9-]+)\/([_a-zA-Z0-9-]+)\/pull\/([0-9]+)/;
+const GITHUB_PR_REGEX = /.*github.com\/([._a-zA-Z0-9-]+)\/([._a-zA-Z0-9-]+)\/pull\/([0-9]+).*/;
 
 const DevPortfolioForm: React.FC = () => {
   // When the user is logged in, `useSelf` always return non-null data.


### PR DESCRIPTION
### Summary <!-- Required -->

Bug fix

Regex currently doesn't support URLs that contain . (periods).

i.e. https://github.com/cornell-dti/course-reviews-react-2.0/pull/362 did not work.


### Test Plan <!-- Required -->

Manually tested and successfully submitted an example URL

### Notes <!-- Optional -->

We should probably look into adding other symbols eventually too, pushing this one for now because it's urgent.

### Breaking Changes <!-- Optional -->


