### PR TITLE
Set hours/minutes/seconds for deadline and earliest valid dates

### DIFF
--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -45,7 +45,15 @@ export const createNewDevPortfolio = async (
       `User with email: ${user.email} does not have permission to create dev portfolio!`
     );
   }
-  return DevPortfolioDao.createNewInstance(instance);
+
+  const updatedDeadline = new Date(instance.deadline);
+  const updatedEarliestValidDate = new Date(instance.earliestValidDate);
+  const modifiedInstance = {
+    ...instance,
+    deadline: updatedDeadline.setHours(23, 59, 59),
+    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0)
+  };
+  return DevPortfolioDao.createNewInstance(modifiedInstance);
 };
 
 export const deleteDevPortfolio = async (uuid: string, user: IdolMember): Promise<void> => {

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -78,9 +78,15 @@ describe('User is lead or admin', () => {
   });
 
   test('createDevPortfolio should be successful', async () => {
+    const expectedDeadline = new Date(devPortfolio.deadline).setHours(23, 59, 59);
+    const expectedEarliestValidDate = new Date(devPortfolio.earliestValidDate).setHours(0, 0, 0);
     await createNewDevPortfolio(devPortfolio, user);
     expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
     expect(DevPortfolioDao.createNewInstance).toBeCalled();
+    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].deadline).toEqual(expectedDeadline);
+    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].earliestValidDate).toEqual(
+      expectedEarliestValidDate
+    );
   });
 
   test('deleteDevPortfolio should be successful', async () => {


### PR DESCRIPTION
### Summary <!-- Required -->

The date from the date picker component wasn't specifying the hours/minutes/seconds of the dates enough so users could be unable to make submissions even before the deadline hadn't actually passed. This PR makes code changes on the backend to specify the hours/minutes/seconds for these dates. For DP deadline, set the time of the deadline to 23:59:59 on that date. For DP earliest valid date, set the time on that date to 00:00:00. 

### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/DP-Deadline-and-earliest-valid-dates-should-be-start-and-end-of-day-7aa220f353d446d98d7c0d8d1d9557d1)
### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Added unit testing to ensure that dev portfolio is created with correct dates.

Test by creating a dev portfolio with the deadline being today and ensuring that you can make submissions. 