### PR TITLE
Export Dev Submissions to CSV

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "axios": "^0.22.0",
     "common-types": "1.0.0",
     "csvtojson": "^2.0.10",
+    "export-to-csv": "^0.2.1",
     "firebase": "^9.1.1",
     "moment": "^2.29.1",
     "next": "^12.0.1",

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -58,7 +58,7 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
       decimalSeparator: '.',
       showLabels: true,
       showTitle: true,
-      title: `${portfolio?.name}Submissions`,
+      title: `${portfolio?.name} Submissions`,
       useTextFile: false,
       useBom: true,
       useKeysAsHeaders: true

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -10,6 +10,9 @@ type Props = {
   isAdminView: boolean;
 };
 
+const sortSubmissions = (submissions: DevPortfolioSubmission[]) =>
+  submissions.sort((s1, s2) => s1.member.netid.localeCompare(s2.member.netid));
+
 const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
   const [portfolio, setPortfolio] = useState<DevPortfolio | null>(null);
 
@@ -25,7 +28,21 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
       });
       return;
     }
-    const csvData = portfolio?.submissions.map((submission) => ({
+
+    const uniqueIds: string[] = [];
+
+    const uniqueSubmissions = portfolio.submissions.filter((submission) => {
+      const isDuplicate = uniqueIds.includes(submission.member.netid);
+      if (!isDuplicate) {
+        uniqueIds.push(submission.member.netid);
+        return true;
+      }
+      return false;
+    });
+
+    const sortedSubmissions = sortSubmissions(uniqueSubmissions);
+
+    const csvData = sortedSubmissions.map((submission) => ({
       name: `${submission.member.firstName} ${submission.member.lastName}`,
       netid: submission.member.netid,
       opened_score: Number(submission.openedPRs.some((pr) => pr.status === 'valid')),
@@ -77,9 +94,7 @@ type DevPortfolioDetailsTableProps = {
 };
 
 const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio, isAdminView }) => {
-  const sortedSubmissions = [...portfolio.submissions].sort((s1, s2) =>
-    s1.member.netid.localeCompare(s2.member.netid)
-  );
+  const sortedSubmissions = sortSubmissions([...portfolio.submissions]);
 
   return (
     <Table celled>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -58,6 +58,7 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
     });
 
     const options: Options = {
+      filename: `${portfolio?.name}_Submissions`,
       fieldSeparator: ',',
       quoteStrings: '"',
       decimalSeparator: '.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7206,6 +7206,11 @@ expect@^27.2.4:
     jest-message-util "^27.2.4"
     jest-regex-util "^27.0.6"
 
+export-to-csv@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/export-to-csv/-/export-to-csv-0.2.1.tgz#8f997156feebc1cf995096da16341aa0100cce4e"
+  integrity sha512-KTbrd3CAZ0cFceJEZr1e5uiMasabeCpXq1/5uvVxDl53o4jXJHnltasQoj2NkzrxD8hU9kdwjnMhoir/7nNx/A==
+
 express-logging@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/express-logging/-/express-logging-1.1.1.tgz#62839618cbab5bb3610f1a1c1485352fe9d26c2a"


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request implemented "export to csv" functionality for dev leads to easily grade dev portfolio submissions. It includes the columns `name`, `netid`, `opened_score`, `reviewed_score`, and `total_score`. Submissions are sorted by netid and the csv only includes one submission from each member. 

If a dev portfolio assignment has no submissions, an error message will pop-up. 

<img width="900" alt="Screen Shot 2022-10-13 at 1 01 53 PM" src="https://user-images.githubusercontent.com/70241445/195683434-81fcabee-1883-4f0d-b0ea-f3b986e8369f.png">


### Test Plan <!-- Required -->

- Manually tested and checked that all submissions were present in CSV with correct values.
- All submissions were correctly sorted by netID.
- Tested dev portfolio with multiple submissions from one member. 
- Tested dev portfolio with no submissions. 

