### PR TITLE
Add late deadline feature 

### DIFF
--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -48,11 +48,16 @@ export const createNewDevPortfolio = async (
 
   const updatedDeadline = new Date(instance.deadline);
   const updatedEarliestValidDate = new Date(instance.earliestValidDate);
+<<<<<<< HEAD
   const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : null;
+=======
+  const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : undefined;
+>>>>>>> 286cb9a (add late deadline support)
   const modifiedInstance = {
     ...instance,
     deadline: updatedDeadline.setHours(23, 59, 59),
-    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0)
+    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0),
+    lateDeadline: updatedLateDeadline ? updatedLateDeadline.setHours(23, 59, 59) : undefined
   };
   if (updatedLateDeadline) {
     modifiedInstance.lateDeadline = updatedLateDeadline.setHours(23, 59, 59);

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -48,10 +48,12 @@ export const createNewDevPortfolio = async (
 
   const updatedDeadline = new Date(instance.deadline);
   const updatedEarliestValidDate = new Date(instance.earliestValidDate);
+  const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : undefined;
   const modifiedInstance = {
     ...instance,
     deadline: updatedDeadline.setHours(23, 59, 59),
-    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0)
+    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0),
+    lateDeadline: updatedLateDeadline ? updatedLateDeadline.setHours(23, 59, 59) : undefined
   };
   return DevPortfolioDao.createNewInstance(modifiedInstance);
 };
@@ -73,17 +75,22 @@ export const makeDevPortfolioSubmission = async (
   const devPortfolio = await DevPortfolioDao.getDevPortfolio(uuid, true, submission.member);
   if (!devPortfolio) throw new BadRequestError(`Dev portfolio with uuid ${uuid} does not exist.`);
 
-  if (!isWithinDates(Date.now(), devPortfolio.earliestValidDate, devPortfolio.deadline)) {
+  const latestDeadline = devPortfolio.lateDeadline
+    ? devPortfolio.lateDeadline
+    : devPortfolio.deadline;
+
+  if (!isWithinDates(Date.now(), devPortfolio.earliestValidDate, latestDeadline)) {
     const startDate = new Date(devPortfolio.earliestValidDate).toDateString();
-    const endDate = new Date(devPortfolio.deadline).toDateString();
+    const endDate = new Date(latestDeadline).toDateString();
     throw new BadRequestError(
       `This dev portfolio must be created between ${startDate} and ${endDate}.`
     );
   }
-  return DevPortfolioDao.makeDevPortfolioSubmission(
-    uuid,
-    await validateSubmission(devPortfolio, submission)
-  );
+  const validatedSubmission = await validateSubmission(devPortfolio, submission);
+  return DevPortfolioDao.makeDevPortfolioSubmission(uuid, {
+    ...validatedSubmission,
+    isLate: devPortfolio.lateDeadline && Date.now() > devPortfolio.deadline
+  });
 };
 
 export const regradeSubmissions = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -89,7 +89,7 @@ export const makeDevPortfolioSubmission = async (
   const validatedSubmission = await validateSubmission(devPortfolio, submission);
   return DevPortfolioDao.makeDevPortfolioSubmission(uuid, {
     ...validatedSubmission,
-    isLate: devPortfolio.lateDeadline && Date.now() > devPortfolio.deadline
+    isLate: Boolean(devPortfolio.lateDeadline && Date.now() > devPortfolio.deadline)
   });
 };
 

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -48,16 +48,11 @@ export const createNewDevPortfolio = async (
 
   const updatedDeadline = new Date(instance.deadline);
   const updatedEarliestValidDate = new Date(instance.earliestValidDate);
-<<<<<<< HEAD
   const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : null;
-=======
-  const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : undefined;
->>>>>>> 286cb9a (add late deadline support)
   const modifiedInstance = {
     ...instance,
     deadline: updatedDeadline.setHours(23, 59, 59),
-    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0),
-    lateDeadline: updatedLateDeadline ? updatedLateDeadline.setHours(23, 59, 59) : undefined
+    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0)
   };
   if (updatedLateDeadline) {
     modifiedInstance.lateDeadline = updatedLateDeadline.setHours(23, 59, 59);

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -48,13 +48,15 @@ export const createNewDevPortfolio = async (
 
   const updatedDeadline = new Date(instance.deadline);
   const updatedEarliestValidDate = new Date(instance.earliestValidDate);
-  const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : undefined;
+  const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : null;
   const modifiedInstance = {
     ...instance,
     deadline: updatedDeadline.setHours(23, 59, 59),
-    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0),
-    lateDeadline: updatedLateDeadline ? updatedLateDeadline.setHours(23, 59, 59) : undefined
+    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0)
   };
+  if (updatedLateDeadline) {
+    modifiedInstance.lateDeadline = updatedLateDeadline.setHours(23, 59, 59);
+  }
   return DevPortfolioDao.createNewInstance(modifiedInstance);
 };
 

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -100,6 +100,7 @@ export type DBDevPortfolio = {
   deadline: number;
   earliestValidDate: number;
   submissions: DBDevPortfolioSubmission[];
+  lateDeadline: number | null;
   readonly uuid: string;
 };
 

--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -67,7 +67,7 @@ const parseGithubUsername = (url: string): string => {
  *  Raises an error if the Idol member from `submission` does not have a github username. */
 const parsePortfolioSubmission = (portfolio: DevPortfolio, submission: DevPortfolioSubmission) => {
   const start = portfolio.earliestValidDate;
-  const end = portfolio.deadline;
+  const end = portfolio.lateDeadline ? portfolio.lateDeadline : portfolio.deadline;
   const usernameUrl = submission.member.github;
 
   // check github user

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -110,12 +110,16 @@ describe('User is lead or admin', () => {
   test('createDevPortfolio should be successful', async () => {
     const expectedDeadline = new Date(devPortfolio.deadline).setHours(23, 59, 59);
     const expectedEarliestValidDate = new Date(devPortfolio.earliestValidDate).setHours(0, 0, 0);
+    const expectedLateDeadline = new Date(devPortfolio.lateDeadline).setHours(23, 59, 59);
     await createNewDevPortfolio(devPortfolio, user);
     expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
     expect(DevPortfolioDao.createNewInstance).toBeCalled();
     expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].deadline).toEqual(expectedDeadline);
     expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].earliestValidDate).toEqual(
       expectedEarliestValidDate
+    );
+    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].lateDeadline).toEqual(
+      expectedLateDeadline
     );
   });
 
@@ -163,7 +167,7 @@ describe('makeDevPortfolioSubmission tests', () => {
       it('should successfully submit', async () => {
         await makeDevPortfolioSubmission(devPortfolio.uuid, dpSubmission);
         expect(mockIsWithinDates.mock.calls[0][1]).toEqual(devPortfolio.earliestValidDate);
-        expect(mockIsWithinDates.mock.calls[0][2]).toEqual(devPortfolio.deadline);
+        expect(mockIsWithinDates.mock.calls[0][2]).toEqual(devPortfolio.lateDeadline);
         expect(DevPortfolioDao.makeDevPortfolioSubmission).toBeCalled();
       });
     });

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -115,7 +115,8 @@ export const fakeDevPortfolioSubmission = (): DevPortfolioSubmission => {
 export const fakeDevPortfolio = (): DevPortfolio => {
   const DP = {
     name: 'testdevportfolio',
-    deadline: Date.now() + 10 * 86400000, // 10 days in the future
+    deadline: Date.now() + 10 * 86400000,
+    lateDeadline: Date.now() + 15 * 86400000, // 10 days in the future
     earliestValidDate: Date.parse('01 May 2022 00:00:00 GMT'),
     submissions: [],
     uuid: faker.datatype.uuid()

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -144,10 +144,12 @@ interface DevPortfolio {
   earliestValidDate: number;
   submissions: DevPortfolioSubmission[];
   readonly uuid: string;
+  lateDeadline?: number;
 }
 
 interface DevPortfolioSubmission {
   member: IdolMember;
   openedPRs: PullRequestSubmission[];
   reviewedPRs: PullRequestSubmission[];
+  isLate?: boolean;
 }

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -144,7 +144,7 @@ interface DevPortfolio {
   earliestValidDate: number;
   submissions: DevPortfolioSubmission[];
   readonly uuid: string;
-  lateDeadline?: number;
+  lateDeadline: number | null;
 }
 
 interface DevPortfolioSubmission {

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.module.css
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.module.css
@@ -14,3 +14,8 @@
 .cardHeader a:hover {
   text-decoration: underline;
 }
+
+.cardDescription {
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
@@ -101,7 +101,14 @@ export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
                   {portfolio.submissions.length !== 1 ? 's' : ''}
                 </Card.Meta>
                 <Card.Description>
-                  Due: {new Date(portfolio.deadline).toDateString()}
+                  <Container className={styles.cardDescription}>
+                    <div>Due: {new Date(portfolio.deadline).toDateString()}</div>
+                    <div>
+                      {portfolio.lateDeadline
+                        ? `Late Deadline: ${new Date(portfolio.lateDeadline).toDateString()}`
+                        : ''}
+                    </div>
+                  </Container>
                 </Card.Description>
               </Card.Content>
             </Card>
@@ -123,6 +130,7 @@ const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({ setDevPor
   const [dateErrorMsg, setDateErrorMsg] = useState<string>('');
   const [deadline, setDeadline] = useState<Date>(new Date());
   const [earliestDate, setEarliestDate] = useState<Date>(new Date());
+  const [lateDeadline, setLateDeadline] = useState<Date | undefined>(undefined);
   const [success, setSuccess] = useState<boolean>(false);
 
   const handleSubmit = () => {
@@ -141,12 +149,18 @@ const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({ setDevPor
       setDateErrorMsg('Deadline cannot be before today.');
       return;
     }
+    if (lateDeadline && deadline > lateDeadline && !isSameDay(deadline, lateDeadline)) {
+      setDateError(true);
+      setDateErrorMsg('Late deadline cannot be before the regular deadline');
+      return;
+    }
     setNameError(false);
     setDateErrorMsg('');
     const portfolio = {
       name,
       deadline: deadline.getTime(),
       earliestValidDate: earliestDate.getTime(),
+      lateDeadline: lateDeadline ? lateDeadline.getTime() : undefined,
       submissions: [],
       uuid: ''
     };
@@ -171,6 +185,12 @@ const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({ setDevPor
         selected={deadline}
         dateFormat="MMMM do yyyy"
         onChange={(date: Date) => setDeadline(date)}
+      />
+      <Header as="h3">Late Deadline (optional)</Header>
+      <DatePicker
+        selected={lateDeadline}
+        dateFormat="MMMM do yyyy"
+        onChange={(date: Date) => setLateDeadline(date)}
       />
       {dateError ? (
         <Label

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
@@ -130,7 +130,7 @@ const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({ setDevPor
   const [dateErrorMsg, setDateErrorMsg] = useState<string>('');
   const [deadline, setDeadline] = useState<Date>(new Date());
   const [earliestDate, setEarliestDate] = useState<Date>(new Date());
-  const [lateDeadline, setLateDeadline] = useState<Date | undefined>(undefined);
+  const [lateDeadline, setLateDeadline] = useState<Date | null>(null);
   const [success, setSuccess] = useState<boolean>(false);
 
   const handleSubmit = () => {
@@ -160,7 +160,7 @@ const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({ setDevPor
       name,
       deadline: deadline.getTime(),
       earliestValidDate: earliestDate.getTime(),
-      lateDeadline: lateDeadline ? lateDeadline.getTime() : undefined,
+      lateDeadline: lateDeadline ? lateDeadline.getTime() : null,
       submissions: [],
       uuid: ''
     };

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -118,6 +118,9 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
         <> </>
       )}
       <DetailsTable portfolio={portfolio} isAdminView={isAdminView} />
+      <span>
+        <b>* = Late submission</b>
+      </span>
     </Container>
   );
 };
@@ -176,7 +179,9 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
         />
       </Table.Cell>
       {isAdminView ? (
-        <Table.Cell rowSpan={`${numRows}`}>{isValid ? 'Valid' : 'Invalid'}</Table.Cell>
+        <Table.Cell rowSpan={`${numRows}`}>
+          {`${isValid ? 'Valid' : 'Invalid'}${submission.isLate ? '*' : ''}`}
+        </Table.Cell>
       ) : (
         <></>
       )}

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -163,9 +163,9 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
 
   const FirstRow = () => (
     <Table.Row positive={isAdminView && isValid} negative={isAdminView && !isValid}>
-      <Table.Cell
-        rowSpan={`${numRows}`}
-      >{`${submission.member.firstName} ${submission.member.lastName} (${submission.member.netid})`}</Table.Cell>
+      <Table.Cell rowSpan={`${numRows}`}>{`${submission.member.firstName} ${
+        submission.member.lastName
+      } (${submission.member.netid})${submission.isLate ? '*' : ''}`}</Table.Cell>
       <Table.Cell>
         <PullRequestDisplay
           prSubmission={submission.openedPRs.length > 0 ? submission.openedPRs[0] : undefined}
@@ -179,9 +179,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
         />
       </Table.Cell>
       {isAdminView ? (
-        <Table.Cell rowSpan={`${numRows}`}>
-          {`${isValid ? 'Valid' : 'Invalid'}${submission.isLate ? '*' : ''}`}
-        </Table.Cell>
+        <Table.Cell rowSpan={`${numRows}`}>{`${isValid ? 'Valid' : 'Invalid'}`}</Table.Cell>
       ) : (
         <></>
       )}

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -170,7 +170,11 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
   const hasText = Boolean(submission.text);
 
   const FirstRow = () => (
-    <Table.Row positive={isAdminView && isValid} negative={isAdminView && !isValid} warning={isAdminView && hasText}>
+    <Table.Row
+      positive={isAdminView && isValid}
+      negative={isAdminView && !isValid}
+      warning={isAdminView && hasText}
+    >
       <Table.Cell rowSpan={`${numRows}`}>{`${submission.member.firstName} ${
         submission.member.lastName
       } (${submission.member.netid})${submission.isLate ? '*' : ''}`}</Table.Cell>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -53,7 +53,8 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
         netid: submission.member.netid,
         opened_score: open,
         reviewed_score: review,
-        total_score: open + review
+        total_score: open + review,
+        late: submission.isLate ? 1 : 0
       };
     });
 

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -70,7 +70,7 @@ const DevPortfolioForm: React.FC = () => {
     const latestDeadline = devPortfolio.lateDeadline
       ? devPortfolio.lateDeadline
       : devPortfolio?.deadline;
-    
+
     if (!isTpm && (openedEmpty || reviewedEmpty)) {
       Emitters.generalError.emit({
         headerMsg: 'No opened or reviewed PR url submitted',

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -77,12 +77,12 @@ const DevPortfolioForm: React.FC = () => {
         headerMsg: 'Invalid PR link',
         contentMsg: 'One or more links to PRs are not valid links.'
       });
-    } else if (new Date(devPortfolio.deadline) < new Date()) {
+    } else if (new Date(latestDeadline) < new Date()) {
       Emitters.generalError.emit({
         headerMsg: 'The deadline for this dev portfolio has passed',
         contentMsg: 'Please select another dev portfolio.'
       });
-    } else if (new Date(latestDeadline) > new Date()) {
+    } else if (new Date(devPortfolio.earliestValidDate) > new Date()) {
       Emitters.generalError.emit({
         headerMsg: 'This dev portfolio is not open yet',
         contentMsg: 'Please select another dev portfolio.'

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -82,7 +82,7 @@ const DevPortfolioForm: React.FC = () => {
         headerMsg: 'The deadline for this dev portfolio has passed',
         contentMsg: 'Please select another dev portfolio.'
       });
-    } else if (new Date(devPortfolio.earliestValidDate) > new Date()) {
+    } else if (new Date(latestDeadline) > new Date()) {
       Emitters.generalError.emit({
         headerMsg: 'This dev portfolio is not open yet',
         contentMsg: 'Please select another dev portfolio.'

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -82,7 +82,7 @@ const DevPortfolioForm: React.FC = () => {
         headerMsg: 'The deadline for this dev portfolio has passed',
         contentMsg: 'Please select another dev portfolio.'
       });
-    } else if (new Date(latestDeadline) > new Date()) {
+    } else if (new Date(devPortfolio.earliestValidDate) > new Date()) {
       Emitters.generalError.emit({
         headerMsg: 'This dev portfolio is not open yet',
         contentMsg: 'Please select another dev portfolio.'

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -59,12 +59,12 @@ const DevPortfolioForm: React.FC = () => {
         headerMsg: 'No Dev Portfolio selected',
         contentMsg: 'Please select a dev portfolio assignment!'
       });
-    } else if (
-      !openPRs[0] ||
-      openPRs[0].length === 0 ||
-      !reviewPRs[0] ||
-      reviewPRs[0].length === 0
-    ) {
+      return;
+    }
+    const latestDeadline = devPortfolio.lateDeadline
+      ? devPortfolio.lateDeadline
+      : devPortfolio?.deadline;
+    if (!openPRs[0] || openPRs[0].length === 0 || !reviewPRs[0] || reviewPRs[0].length === 0) {
       Emitters.generalError.emit({
         headerMsg: 'No opened or reviewed PR url submitted',
         contentMsg: 'Please paste a link to a opened and reviewed PR!'
@@ -82,7 +82,7 @@ const DevPortfolioForm: React.FC = () => {
         headerMsg: 'The deadline for this dev portfolio has passed',
         contentMsg: 'Please select another dev portfolio.'
       });
-    } else if (new Date(devPortfolio.earliestValidDate) > new Date()) {
+    } else if (new Date(latestDeadline) > new Date()) {
       Emitters.generalError.emit({
         headerMsg: 'This dev portfolio is not open yet',
         contentMsg: 'Please select another dev portfolio.'

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 export const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = false;
+export const useProdDb = true;
 
 /** Switch to false to test IDOL as a non-admin user. Change back to true before committing. */
 export const allowAdmin = true;

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 export const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = true;
+export const useProdDb = false;
 
 /** Switch to false to test IDOL as a non-admin user. Change back to true before committing. */
 export const allowAdmin = true;


### PR DESCRIPTION
### Summary <!-- Required -->
Added support for late deadline for dev portfolios. A late deadline is optional when creating a new dev portfolio.


### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Late-Submissions-for-Dev-Portfolios-30da8b9dbefb4f6298906f4023b6f38c)

### Test Plan <!-- Required -->
- Updated backend unit testing 
- Test validation for creating a new portfolio (i.e. late deadline is after the normal deadline, etc.) 
- Test that late submissions are marked as late (and that submission before the deadline isn't marked late)
- Test that late submissions have a `*` by the submission status 
- Test that a dev portfolio should behave normally if the late deadline wasn't set 
- Test that you can't submit a portfolio past the late deadline 
- Test that late deadline is used (only if it was set) as the "end date" for submission validation 

### Notes <!-- Optional -->
- ~~CSV exporting isn't implemented in this PR. This is currently blocked by #345.~~
- [This issue](https://www.notion.so/cornelldti/DP-Admin-Add-validation-for-creating-new-DP-assignment-66f97764abbc4bed89900ce5b8416e3b) should be addressed in a separate PR still 