### PR TITLE
Add text field for TPM dev portfolio submission.

### DIFF
--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -150,4 +150,5 @@ interface DevPortfolioSubmission {
   member: IdolMember;
   openedPRs: PullRequestSubmission[];
   reviewedPRs: PullRequestSubmission[];
+  text?: string;
 }

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import { Button, Container, Header, Icon, Table, Modal } from 'semantic-ui-react';
+import { Button, Container, Header, Icon, Table } from 'semantic-ui-react';
 import { ExportToCsv, Options } from 'export-to-csv';
+import DevPortfolioTextModal from '../../Modals/DevPortfolioTextModal';
 import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
 import { Emitters } from '../../../utils';
 import styles from './DevPortfolioDetails.module.css';
@@ -158,8 +159,6 @@ type SubmissionDetailsProps = {
 };
 
 const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdminView }) => {
-  const [viewText, setViewText] = useState(false);
-
   const numRows = Math.max(submission.openedPRs.length, submission.reviewedPRs.length);
   const isValid =
     submission.openedPRs.some((pr) => pr.status === 'valid') &&
@@ -196,26 +195,10 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
       )}
       {submission.text ? (
         <Table.Cell rowSpan={`${numRows}`}>
-          <Modal
-            onClose={() => setViewText(false)}
-            onOpen={() => setViewText(true)}
-            open={viewText}
-            trigger={<Button>Show Text</Button>}
-          >
-            <Modal.Header>
-              Paragraph Response for {submission.member.firstName} {submission.member.lastName}
-            </Modal.Header>
-            <Modal.Content image>
-              <Modal.Description>
-                <p>{submission.text}</p>
-              </Modal.Description>
-            </Modal.Content>
-            <Modal.Actions>
-              <Button color="red" onClick={() => setViewText(false)}>
-                Close
-              </Button>
-            </Modal.Actions>
-          </Modal>
+          <DevPortfolioTextModal
+            title={`${submission.member.firstName} ${submission.member.lastName}`}
+            text={submission.text}
+          ></DevPortfolioTextModal>
         </Table.Cell>
       ) : (
         <div></div>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -248,7 +248,7 @@ type PullRequestDisplayProps = {
 };
 
 const PullRequestDisplay: React.FC<PullRequestDisplayProps> = ({ prSubmission, isAdminView }) => {
-  if (prSubmission === undefined) return <></>;
+  if (prSubmission === undefined || !prSubmission.url) return <></>;
   const isValid = prSubmission.status === 'valid';
   return (
     <>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Button, Container, Header, Icon, Table } from 'semantic-ui-react';
+import { Button, Container, Header, Icon, Table, Modal } from 'semantic-ui-react';
 import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
 import { Emitters } from '../../../utils';
 import styles from './DevPortfolioDetails.module.css';
@@ -80,6 +80,11 @@ const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio, isAd
         <Table.HeaderCell rowSpan="2">Opened PRs</Table.HeaderCell>
         <Table.HeaderCell rowSpan="2">Reviewed PRs</Table.HeaderCell>
         {isAdminView ? <Table.HeaderCell rowSpan="2">Status</Table.HeaderCell> : <></>}
+        {sortedSubmissions.some((submission) => submission.text) ? (
+          <Table.HeaderCell rowSpan="2"></Table.HeaderCell>
+        ) : (
+          <></>
+        )}
       </Table.Header>
       <Table.Body>
         {sortedSubmissions.map((submission, i) => (
@@ -96,6 +101,8 @@ type SubmissionDetailsProps = {
 };
 
 const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdminView }) => {
+  const [viewText, setViewText] = useState(false);
+
   const numRows = Math.max(submission.openedPRs.length, submission.reviewedPRs.length);
   const isValid =
     submission.openedPRs.some((pr) => pr.status === 'valid') &&
@@ -119,9 +126,35 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
         />
       </Table.Cell>
       {isAdminView ? (
-        <Table.Cell rowSpan={`${numRows}`}>{isValid ? 'Valid' : 'Invalid'}</Table.Cell>
+        <Table.Cell rowSpan={`${numRows}`}>{<div>{isValid ? 'Valid' : 'Invalid'}</div>}</Table.Cell>
       ) : (
         <></>
+      )}
+      {submission.text ? (
+        <Table.Cell rowSpan={`${numRows}`}>
+          <Modal
+            onClose={() => setViewText(false)}
+            onOpen={() => setViewText(true)}
+            open={viewText}
+            trigger={<Button>Show Text</Button>}
+          >
+            <Modal.Header>
+              Paragraph Response for {submission.member.firstName} {submission.member.lastName}
+            </Modal.Header>
+            <Modal.Content image>
+              <Modal.Description>
+                <p>{submission.text}</p>
+              </Modal.Description>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button color="red" onClick={() => setViewText(false)}>
+                Close
+              </Button>
+            </Modal.Actions>
+          </Modal>
+        </Table.Cell>
+      ) : (
+        <div></div>
       )}
     </Table.Row>
   );

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -107,9 +107,14 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
   const isValid =
     submission.openedPRs.some((pr) => pr.status === 'valid') &&
     submission.reviewedPRs.some((pr) => pr.status === 'valid');
+  const hasText = Boolean(submission.text);
 
   const FirstRow = () => (
-    <Table.Row positive={isAdminView && isValid} negative={isAdminView && !isValid}>
+    <Table.Row
+      positive={isAdminView && isValid}
+      negative={isAdminView && !isValid}
+      warning={isAdminView && hasText}
+    >
       <Table.Cell
         rowSpan={`${numRows}`}
       >{`${submission.member.firstName} ${submission.member.lastName} (${submission.member.netid})`}</Table.Cell>
@@ -126,7 +131,9 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({ submission, isAdm
         />
       </Table.Cell>
       {isAdminView ? (
-        <Table.Cell rowSpan={`${numRows}`}>{<div>{isValid ? 'Valid' : 'Invalid'}</div>}</Table.Cell>
+        <Table.Cell rowSpan={`${numRows}`}>
+          {<div>{(hasText && 'Pending') || (isValid ? 'Valid' : 'Invalid')}</div>}
+        </Table.Cell>
       ) : (
         <></>
       )}

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -115,6 +115,8 @@ const DevPortfolioForm: React.FC = () => {
     }
   };
 
+  const isTpm = userInfo.role === 'tpm';
+
   return (
     <div>
       <Form className={styles.form_style}>
@@ -149,6 +151,34 @@ const DevPortfolioForm: React.FC = () => {
               />
             ) : undefined}
           </div>
+
+          {isTpm ? (
+            <div className={styles.inline}>
+              <label className={styles.bold}>
+                Paragraph Response: <span className={styles.red_color}>*</span>
+              </label>
+              <p>
+                Since you are a technical project manager, your portfolio needs to include 1-2
+                paragraphs with the following information: <br />
+                1. What did you personally do these past two weeks?
+                <br />
+                2. What did the team do the past two weeks?
+              </p>
+
+              <TextArea
+                value={text || undefined}
+                onInput={(e) => setText(e.currentTarget.value)}
+              ></TextArea>
+
+              <p>
+                In addition, if you have created and/or reviewed pull requests, please include those
+                links. There is no required minimum or maximum but please do include them when you
+                do them.
+              </p>
+            </div>
+          ) : (
+            <></>
+          )}
 
           <div className={styles.inline}>
             <label className={styles.bold}>
@@ -239,25 +269,6 @@ const DevPortfolioForm: React.FC = () => {
               </div>
             </div>
           </div>
-
-          {userInfo.role === 'tpm' ? (
-            <div>
-              <label className={styles.bold}>Paragraph Response:</label>
-              <p>
-                Since you are a technical project manager, you also need to include 1-2 paragraphs
-                with the following information: <br />
-                1. What did you personally do these past two weeks?
-                <br />
-                2. What did the team do the past two weeks?
-              </p>
-              <TextArea
-                value={text || undefined}
-                onInput={(e) => setText(e.currentTarget.value)}
-              ></TextArea>
-            </div>
-          ) : (
-            <></>
-          )}
         </div>
 
         <Form.Button floated="right" onClick={submitDevPortfolio}>

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -56,27 +56,32 @@ const DevPortfolioForm: React.FC = () => {
   };
 
   const submitDevPortfolio = () => {
+    const openedEmpty = !openPRs[0] || openPRs[0].length === 0;
+    const reviewedEmpty = !reviewPRs[0] || reviewPRs[0].length === 0;
+    const textEmpty = !text;
+
     if (!devPortfolio) {
       Emitters.generalError.emit({
         headerMsg: 'No Dev Portfolio selected',
         contentMsg: 'Please select a dev portfolio assignment!'
       });
-    } else if (
-      !isTpm &&
-      (!openPRs[0] || openPRs[0].length === 0 || !reviewPRs[0] || reviewPRs[0].length === 0)
-    ) {
+    } else if (!isTpm && (openedEmpty || reviewedEmpty)) {
       Emitters.generalError.emit({
         headerMsg: 'No opened or reviewed PR url submitted',
         contentMsg: 'Please paste a link to a opened and reviewed PR!'
       });
     } else if (
-      !isTpm &&
-      (openPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null) ||
-        reviewPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null))
+      (!openedEmpty && openPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null)) ||
+      (!reviewedEmpty && reviewPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null))
     ) {
       Emitters.generalError.emit({
         headerMsg: 'Invalid PR link',
         contentMsg: 'One or more links to PRs are not valid links.'
+      });
+    } else if (isTpm && textEmpty) {
+      Emitters.generalError.emit({
+        headerMsg: 'Paragraph Submission Empty',
+        contentMsg: 'Please write something for the paragraph section of the assignment.'
       });
     } else if (new Date(devPortfolio.deadline) < new Date()) {
       Emitters.generalError.emit({

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -12,6 +12,7 @@ const DevPortfolioForm: React.FC = () => {
   // When the user is logged in, `useSelf` always return non-null data.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const userInfo = useSelf()!;
+  const isTpm = userInfo.role === 'tpm';
 
   const [devPortfolio, setDevPortfolio] = useState<DevPortfolio | undefined>(undefined);
   const [devPortfolios, setDevPortfolios] = useState<DevPortfolio[]>([]);
@@ -61,18 +62,17 @@ const DevPortfolioForm: React.FC = () => {
         contentMsg: 'Please select a dev portfolio assignment!'
       });
     } else if (
-      !openPRs[0] ||
-      openPRs[0].length === 0 ||
-      !reviewPRs[0] ||
-      reviewPRs[0].length === 0
+      !isTpm &&
+      (!openPRs[0] || openPRs[0].length === 0 || !reviewPRs[0] || reviewPRs[0].length === 0)
     ) {
       Emitters.generalError.emit({
         headerMsg: 'No opened or reviewed PR url submitted',
         contentMsg: 'Please paste a link to a opened and reviewed PR!'
       });
     } else if (
-      openPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null) ||
-      reviewPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null)
+      !isTpm &&
+      (openPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null) ||
+        reviewPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null))
     ) {
       Emitters.generalError.emit({
         headerMsg: 'Invalid PR link',
@@ -114,8 +114,6 @@ const DevPortfolioForm: React.FC = () => {
       event.preventDefault();
     }
   };
-
-  const isTpm = userInfo.role === 'tpm';
 
   return (
     <div>
@@ -182,7 +180,8 @@ const DevPortfolioForm: React.FC = () => {
 
           <div className={styles.inline}>
             <label className={styles.bold}>
-              Opened Pull Request Github Link: <span className={styles.red_color}>*</span>
+              Opened Pull Request Github Link:{' '}
+              {!isTpm && <span className={styles.red_color}>*</span>}
             </label>
             {openPRs.map((openPR, index) => (
               <div className={styles.prInputContainer} key={index}>
@@ -227,7 +226,8 @@ const DevPortfolioForm: React.FC = () => {
 
           <div className={styles.inline}>
             <label className={styles.bold}>
-              Reviewed Pull Request Github Link: <span className={styles.red_color}>*</span>
+              Reviewed Pull Request Github Link:{' '}
+              {!isTpm && <span className={styles.red_color}>*</span>}
             </label>
             {reviewPRs.map((reviewPR, index) => (
               <div className={styles.prInputContainer} key={index}>

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Form, Dropdown, Button, Icon, Divider } from 'semantic-ui-react';
+import { Form, Dropdown, Button, Icon, Divider, TextArea } from 'semantic-ui-react';
 import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
 import { Emitters } from '../../../utils';
 import { DevPortfolioDashboard } from '../../Admin/DevPortfolio/AdminDevPortfolio';
@@ -18,6 +18,7 @@ const DevPortfolioForm: React.FC = () => {
   const [openPRs, setOpenPRs] = useState(['']);
   const [reviewPRs, setReviewedPRs] = useState(['']);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [text, setText] = useState<string | null>(null);
 
   useEffect(() => {
     refreshDevPortfolios();
@@ -97,12 +98,14 @@ const DevPortfolioForm: React.FC = () => {
         reviewedPRs: reviewPRs.map((pr) => ({
           url: pr,
           status: 'pending'
-        }))
+        })),
+        ...(text && { text })
       };
       sendSubmissionRequest(newDevPortfolioSubmission, devPortfolio);
       setDevPortfolio(undefined);
       setOpenPRs(['']);
       setReviewedPRs(['']);
+      setText(null);
     }
   };
 
@@ -236,6 +239,25 @@ const DevPortfolioForm: React.FC = () => {
               </div>
             </div>
           </div>
+
+          {userInfo.role === 'tpm' ? (
+            <div>
+              <label className={styles.bold}>Paragraph Response:</label>
+              <p>
+                Since you are a technical project manager, you also need to include 1-2 paragraphs
+                with the following information: <br />
+                1. What did you personally do these past two weeks?
+                <br />
+                2. What did the team do the past two weeks?
+              </p>
+              <TextArea
+                value={text || undefined}
+                onInput={(e) => setText(e.currentTarget.value)}
+              ></TextArea>
+            </div>
+          ) : (
+            <></>
+          )}
         </div>
 
         <Form.Button floated="right" onClick={submitDevPortfolio}>

--- a/frontend/src/components/Modals/DevPortfolioTextModal.tsx
+++ b/frontend/src/components/Modals/DevPortfolioTextModal.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Modal, Button } from 'semantic-ui-react';
+
+type Props = {
+  title: string;
+  text: string;
+};
+
+const DevPortfolioTextModal: React.FC<Props> = ({ title, text }) => {
+  const [viewText, setViewText] = useState(false);
+  return (
+    <Modal
+      onClose={() => setViewText(false)}
+      onOpen={() => setViewText(true)}
+      open={viewText}
+      trigger={<Button>Show Text</Button>}
+    >
+      <Modal.Header>{title}</Modal.Header>
+      <Modal.Content image>
+        <Modal.Description>
+          <p>{text}</p>
+        </Modal.Description>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button color="red" onClick={() => setViewText(false)}>
+          Close
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default DevPortfolioTextModal;


### PR DESCRIPTION
### Summary <!-- Required -->

This PR is the first step to be able to associate text with a dev portfolio submission. Just for the TPM paragraph requirement:
- [ ] added a text box and prompt area under the PR links on the submission form
- [ ] added button to view text response associated with a submission, if any


<!-- Optional: If adding/updating endpoints, update the backend api specification (openapi.yaml) -->


### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->
[Notion](https://www.notion.so/cornelldti/Idol-FA22-5a158866a8a1472c98b1f3c042b480f8?p=224afb83e4274d219f257c43d2f4786e&pm=s)

### Test Plan <!-- Required -->

- text area should not show for non-TPMs
- details view should not change if no submissions have text fields
<!-- Provide screenshots or point out the additional unit tests -->
Text area on submission form:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/81320443/196322133-52581795-f5df-4204-bd95-7d7374d1ce4f.png">

View from admin details:
<img width="743" alt="image" src="https://user-images.githubusercontent.com/81320443/196322150-29a54ccb-8c3f-434d-ac5a-881a6ffb3411.png">

View from user details:
<img width="764" alt="image" src="https://user-images.githubusercontent.com/81320443/196094605-d4210d3e-365e-4891-b946-2956d38da39a.png">

Clicking "Show Text"
<img width="775" alt="image" src="https://user-images.githubusercontent.com/81320443/196094690-b811e528-2408-4ba9-bee8-de92d468594b.png">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
This text field format may be able to be reused for non-TPMs as an area to explain why they were granted an exception from certain PR requirements ([Notion task](https://www.notion.so/cornelldti/DP-Add-Other-Category-to-Allow-Exceptions-1f4c5b41c7cd48c488ac2b22b668f62d)).
