### PR TITLE
PR links open new tabs 

### DIFF
--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -229,7 +229,9 @@ const PullRequestDisplay: React.FC<PullRequestDisplayProps> = ({ prSubmission, i
   const isValid = prSubmission.status === 'valid';
   return (
     <>
-      <a href={prSubmission.url}>{prSubmission.url}</a>
+      <a href={prSubmission.url} target="_blank" rel="noreferrer noopener">
+        {prSubmission.url}
+      </a>
       {isAdminView ? (
         <>
           <Icon color={isValid ? 'green' : 'red'} name={isValid ? 'checkmark' : 'x'} />


### PR DESCRIPTION
### Summary <!-- Required -->
Changes PR link behavior to open in a new tab instead of in the current tab. 

### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Admin-DP-dashboard-links-should-open-new-tab-2238d09419a845b2ba4bd8c67f6154c4)

### Test Plan <!-- Required -->
Clicking on a PR link should open the link in a new tab 