### PR TITLE
Fixed Anonymous Bug in Shoutouts Page

### DIFF
--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -30,7 +30,7 @@ export default class ShoutoutsDao {
         const { giver, receiver, message, isAnon } = shoutoutRef.data();
         return isAnon
           ? {
-              receiver: await getMemberFromDocumentReference(giver),
+              receiver: await getMemberFromDocumentReference(receiver),
               message,
               isAnon
             }

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,13 +1,35 @@
 import React, { useState, useEffect } from 'react';
 import { Item, Card } from 'semantic-ui-react';
+import { Member } from '../../../API/MembersAPI';
 import { ShoutoutsAPI, Shoutout } from '../../../API/ShoutoutsAPI';
 import styles from './AdminShoutouts.module.css';
+
+type Props =
+  | {
+      readonly giver: Member;
+      readonly receiver: Member;
+      readonly message: string;
+      readonly isAnon: false;
+    }
+  | {
+      readonly receiver: Member;
+      readonly message: string;
+      readonly isAnon: true;
+    };
 
 const AdminShoutouts: React.FC = () => {
   const [shoutouts, setShoutouts] = useState<Shoutout[]>([]);
   useEffect(() => {
     ShoutoutsAPI.getAllShoutouts().then((shoutouts) => setShoutouts(shoutouts));
   }, []);
+
+  const fromString = (shoutout: Shoutout): string => {
+    if (!shoutout.isAnon) {
+      const { giver } = shoutout;
+      return `From: ${giver?.firstName} ${giver?.lastName} (${giver.email})`;
+    }
+    return 'From: Anonymous';
+  };
 
   return (
     <div className={styles.shoutoutsContainer}>
@@ -25,21 +47,7 @@ const AdminShoutouts: React.FC = () => {
                     ? `${shoutout.receiver.firstName} ${shoutout.receiver.lastName}`
                     : '(Former member)'}
                 </Item.Header>
-                <Item.Meta>
-                  From:{' '}
-                  {(() => {
-                    switch (shoutout.isAnon) {
-                      case true:
-                        return 'Anonymous';
-                      case false:
-                        return shoutout.giver
-                          ? `${shoutout.giver.firstName} ${shoutout.giver.lastName}`
-                          : '(Former member)';
-                      default:
-                        return 'Anonymous';
-                    }
-                  })()}
-                </Item.Meta>
+                <Item.Meta>{fromString(shoutout)}</Item.Meta>
                 <Item.Description>{shoutout.message}</Item.Description>
               </Item.Content>
             </Item>

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -27,9 +27,18 @@ const AdminShoutouts: React.FC = () => {
                 </Item.Header>
                 <Item.Meta>
                   From:{' '}
-                  {shoutout.giver
-                    ? `${shoutout.giver.firstName} ${shoutout.giver.lastName}`
-                    : '(Former member)'}
+                  {(() => {
+                    switch (shoutout.isAnon) {
+                      case true:
+                        return 'Anonymous';
+                      case false:
+                        return shoutout.giver
+                          ? `${shoutout.giver.firstName} ${shoutout.giver.lastName}`
+                          : '(Former member)';
+                      default:
+                        return 'Anonymous';
+                    }
+                  })()}
                 </Item.Meta>
                 <Item.Description>{shoutout.message}</Item.Description>
               </Item.Content>

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,21 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Item, Card } from 'semantic-ui-react';
-import { Member } from '../../../API/MembersAPI';
 import { ShoutoutsAPI, Shoutout } from '../../../API/ShoutoutsAPI';
 import styles from './AdminShoutouts.module.css';
-
-type Props =
-  | {
-      readonly giver: Member;
-      readonly receiver: Member;
-      readonly message: string;
-      readonly isAnon: false;
-    }
-  | {
-      readonly receiver: Member;
-      readonly message: string;
-      readonly isAnon: true;
-    };
 
 const AdminShoutouts: React.FC = () => {
   const [shoutouts, setShoutouts] = useState<Shoutout[]>([]);

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
@@ -17,7 +17,7 @@ const ShoutoutsPage: React.FC = () => {
       .then((given) => setGivenShoutouts(given))
       .catch((error) => {
         Emitters.generalError.emit({
-          headerMsg: `Couldn't get received shoutouts!`,
+          headerMsg: `Couldn't get given shoutouts!`,
           contentMsg: `Error was: ${error}`
         });
       });


### PR DESCRIPTION
### Summary <!-- Required -->
Fixed bug in Shoutouts page so that shoutouts marked as anonymous show up as "From: Anonymous" in the admin Shoutouts page and the member's Shoutout page. 

### Test Plan <!-- Required -->
Manually tested that shoutouts were showing up with correct and matching information in member's view and admin view.

Here is the member view:
<img width="671" alt="Screen Shot 2022-10-19 at 5 50 06 PM" src="https://user-images.githubusercontent.com/70241445/196812142-3966518a-938a-4a15-90a9-6efb055a0163.png">

Here is the admin view:
<img width="243" alt="Screen Shot 2022-10-19 at 5 51 33 PM" src="https://user-images.githubusercontent.com/70241445/196812218-818cb704-79c1-4e04-a631-8e60523f31c5.png">

