### PR TITLE
Unified Shoutouts type and removed requirement that recipient be IDOL user

### DIFF
--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -8,7 +8,7 @@ export const getAllShoutouts = (): Promise<Shoutout[]> => ShoutoutsDao.getAllSho
 export const giveShoutout = async (
   body: {
     giver: IdolMember;
-    receiver: IdolMember;
+    receiver: string;
     message: string;
     isAnon: boolean;
   },

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -9,11 +9,9 @@ export default class ShoutoutsDao {
         shoutoutRefs.docs.map(async (doc) => {
           const dbShoutout = doc.data() as DBShoutout;
           const giver = await getMemberFromDocumentReference(dbShoutout.giver);
-          const receiver = await getMemberFromDocumentReference(dbShoutout.receiver);
           return {
             ...dbShoutout,
-            giver,
-            receiver
+            giver
           };
         })
       )
@@ -28,32 +26,25 @@ export default class ShoutoutsDao {
     return Promise.all(
       shoutoutRefs.docs.map(async (shoutoutRef) => {
         const { giver, receiver, message, isAnon } = shoutoutRef.data();
-        return isAnon
-          ? {
-              receiver: await getMemberFromDocumentReference(receiver),
-              message,
-              isAnon
-            }
-          : {
-              giver: await getMemberFromDocumentReference(giver),
-              receiver: await getMemberFromDocumentReference(receiver),
-              message,
-              isAnon
-            };
+        return {
+          giver: await getMemberFromDocumentReference(giver),
+          receiver,
+          message,
+          isAnon
+        };
       })
     );
   }
 
   static async setShoutout(shoutout: {
     giver: IdolMember;
-    receiver: IdolMember;
+    receiver: string;
     message: string;
     isAnon: boolean;
   }): Promise<Shoutout> {
     const shoutoutRef: DBShoutout = {
       ...shoutout,
-      giver: memberCollection.doc(shoutout.giver.email),
-      receiver: memberCollection.doc(shoutout.receiver.email)
+      giver: memberCollection.doc(shoutout.giver.email)
     };
     await shoutoutCollection.doc().set(shoutoutRef);
     return shoutout;

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -10,23 +10,17 @@ export type Team = {
 
 export type DBShoutout = {
   giver: firestore.DocumentReference;
-  receiver: firestore.DocumentReference;
+  receiver: string;
   message: string;
   isAnon: boolean;
 };
 
-export type Shoutout =
-  | {
-      giver: IdolMember;
-      receiver: IdolMember;
-      message: string;
-      isAnon: false;
-    }
-  | {
-      receiver: IdolMember;
-      message: string;
-      isAnon: true;
-    };
+export type Shoutout = {
+  giver: IdolMember;
+  receiver: string;
+  message: string;
+  isAnon: boolean;
+};
 
 export type DBSignInForm = {
   users: { signedInAt: number; user: firestore.DocumentReference }[];

--- a/backend/tests/ShoutoutsDao.test.ts
+++ b/backend/tests/ShoutoutsDao.test.ts
@@ -4,13 +4,12 @@ import { db } from '../src/firebase';
 import { fakeIdolMember } from './data/createData';
 
 const shoutoutData = {
-  mu1: fakeIdolMember(),
-  mu2: fakeIdolMember()
+  mu1: fakeIdolMember()
 };
 
 const mockShoutout1 = {
   giver: shoutoutData.mu1,
-  receiver: shoutoutData.mu2,
+  receiver: 'Fake Idol Member',
   message: 'Mock Shoutout',
   isAnon: false
 };
@@ -18,7 +17,6 @@ const mockShoutout1 = {
 /* Adding mock users for testing sign-ins */
 beforeAll(async () => {
   await MembersDao.setMember(shoutoutData.mu1.email, shoutoutData.mu1);
-  await MembersDao.setMember(shoutoutData.mu2.email, shoutoutData.mu2);
 });
 
 /* Cleanup database after running tests */
@@ -42,11 +40,6 @@ test('Send shoutout', async () => {
   await ShoutoutsDao.setShoutout(mockShoutout1);
   const allShoutouts = await ShoutoutsDao.getAllShoutouts();
   expect(allShoutouts).toContainEqual(mockShoutout1);
-});
-
-test('Get received shoutouts', async () => {
-  const shoutoutsReceived = await ShoutoutsDao.getShoutouts(shoutoutData.mu2.email, 'received');
-  expect(shoutoutsReceived).toContainEqual(mockShoutout1);
 });
 
 test('Get sent shoutout', async () => {

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -5,7 +5,7 @@ import { Emitters } from '../utils';
 
 export type Shoutout = {
   giver: Member;
-  receiver: Member;
+  receiver: string;
   message: string;
   isAnon: boolean;
 };

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -28,11 +28,7 @@ const AdminShoutouts: React.FC = () => {
           {shoutouts.map((shoutout, i) => (
             <Item key={i}>
               <Item.Content>
-                <Item.Header>
-                  {shoutout.receiver
-                    ? `${shoutout.receiver.firstName} ${shoutout.receiver.lastName}`
-                    : '(Former member)'}
-                </Item.Header>
+                <Item.Header>{`To: ${shoutout.receiver}`}</Item.Header>
                 <Item.Meta>{fromString(shoutout)}</Item.Meta>
                 <Item.Description>{shoutout.message}</Item.Description>
               </Item.Content>

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutCard.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutCard.tsx
@@ -4,9 +4,7 @@ import { Shoutout } from '../../../API/ShoutoutsAPI';
 const ShoutoutCard = (props: Shoutout): JSX.Element => {
   const { giver, receiver, message, isAnon } = props;
 
-  let fromString = 'From: Anonymous';
-  if (!isAnon) {
-    fromString = `From: ${giver?.firstName} ${giver?.lastName} (${giver.email})`;
+  const fromString = isAnon ? 'From: Anonymous' :  `From: ${giver?.firstName} ${giver?.lastName} (${giver.email})` ;
   }
 
   return (

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutCard.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutCard.tsx
@@ -1,35 +1,17 @@
 import { Card } from 'semantic-ui-react';
-import { Member } from '../../../API/MembersAPI';
+import { Shoutout } from '../../../API/ShoutoutsAPI';
 
-type Props =
-  | {
-      readonly giver: Member;
-      readonly receiver: Member;
-      readonly message: string;
-      readonly isAnon: false;
-    }
-  | {
-      readonly receiver: Member;
-      readonly message: string;
-      readonly isAnon: true;
-    };
+const ShoutoutCard = (props: Shoutout): JSX.Element => {
+  const { giver, receiver, message, isAnon } = props;
 
-const ShoutoutCard = (props: Props): JSX.Element => {
-  const { receiver, message } = props;
-
-  let fromString;
-  if ('giver' in props) {
-    const { giver } = props;
+  let fromString = 'From: Anonymous';
+  if (!isAnon) {
     fromString = `From: ${giver?.firstName} ${giver?.lastName} (${giver.email})`;
-  } else {
-    fromString = 'From: Anonymous';
   }
 
   return (
     <Card style={{ width: '100%' }}>
-      <Card.Content
-        header={`To: ${receiver?.firstName} ${receiver?.lastName} (${receiver.email})`}
-      />
+      <Card.Content header={`To: ${receiver}`} />
       <Card.Meta style={{ paddingLeft: '1rem', paddingBottom: '1rem' }} content={fromString} />
       <Card.Content description={message} />
     </Card>

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutCard.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutCard.tsx
@@ -4,8 +4,9 @@ import { Shoutout } from '../../../API/ShoutoutsAPI';
 const ShoutoutCard = (props: Shoutout): JSX.Element => {
   const { giver, receiver, message, isAnon } = props;
 
-  const fromString = isAnon ? 'From: Anonymous' :  `From: ${giver?.firstName} ${giver?.lastName} (${giver.email})` ;
-  }
+  const fromString = isAnon
+    ? 'From: Anonymous'
+    : `From: ${giver?.firstName} ${giver?.lastName} (${giver.email})`;
 
   return (
     <Card style={{ width: '100%' }}>

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.module.css
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.module.css
@@ -8,35 +8,18 @@
   margin-bottom: 2vh;
 }
 
-.formLabel {
-  font-weight: bold;
-}
-
 .formContainer {
   display: flex;
-  align-items: center;
-}
-
-.recipientNameDisplayContainer {
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-}
-
-.recipientNameDisplay {
-  padding-right: 1.5em;
+  align-items: left;
 }
 
 .isAnonCheckbox {
-  padding-left: 2em;
+  padding-left: 5em;
+  align-self: center;
 }
 
 .reasonContainer {
   padding: 0.8em 0;
-}
-
-.reasonInput {
-  min-height: 25vh;
 }
 
 .requiredIcon {

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import { Form, TextArea, Button, Checkbox } from 'semantic-ui-react';
+import { Form, TextArea, Checkbox } from 'semantic-ui-react';
 import { useUserEmail } from '../../Common/UserProvider/UserProvider';
-import { MemberSearch } from '../../Common/Search/Search';
 import { Emitters } from '../../../utils';
 import { Shoutout, ShoutoutsAPI } from '../../../API/ShoutoutsAPI';
 import { useMembers } from '../../Common/FirestoreDataProvider';
@@ -15,25 +14,20 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
   const userEmail = useUserEmail();
   const members = useMembers();
   const user = members.find((it) => it.email === userEmail);
-  const [recipient, setRecipient] = useState<IdolMember | undefined>(undefined);
+  const [receiver, setReceiver] = useState('');
   const [message, setMessage] = useState('');
   const [isAnon, setIsAnon] = useState(false);
 
   const giveShoutout = () => {
-    if (!recipient) {
+    if (!receiver) {
       Emitters.generalError.emit({
         headerMsg: 'No Member Selected',
         contentMsg: 'Please select a member!'
       });
-    } else if (recipient.email === userEmail) {
-      Emitters.generalError.emit({
-        headerMsg: 'No Self Shoutouts',
-        contentMsg: "You can't give yourself a shoutout, please select a different member!"
-      });
-    } else if (user && recipient && message !== '') {
+    } else if (user && receiver && message !== '') {
       const shoutout: Shoutout = {
         giver: user,
-        receiver: recipient,
+        receiver,
         message,
         isAnon
       };
@@ -46,10 +40,11 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
         } else {
           Emitters.generalSuccess.emit({
             headerMsg: 'Shoutout submitted!',
-            contentMsg: `Thank you for recognizing ${recipient.firstName}'s awesomeness! 🙏`
+            contentMsg: `Thank you for recognizing ${receiver}'s awesomeness! 🙏`
           });
-          setRecipient(undefined);
+          setReceiver('');
           setMessage('');
+          setIsAnon(false);
           getGivenShoutouts();
         }
       });
@@ -59,29 +54,15 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
   return (
     <Form className={styles.shoutoutForm}>
       <h2 className={styles.formTitle}>Give someone a shoutout! 📣</h2>
-      <label className={styles.formLabel}>
-        Who is awesome? <span className={styles.requiredIcon}>*</span>
-      </label>
-
       <div className={styles.formContainer}>
-        {!recipient ? <MemberSearch onSelect={setRecipient} /> : undefined}
-
-        {recipient ? (
-          <div className={styles.recipientNameDisplayContainer}>
-            <p className={styles.recipientNameDisplay}>
-              {recipient?.firstName} {recipient?.lastName}
-            </p>
-            <Button
-              negative
-              onClick={() => {
-                setRecipient(undefined);
-              }}
-            >
-              Clear
-            </Button>
-          </div>
-        ) : undefined}
-
+        <Form.Input
+          label="Who is awesome?"
+          name="receiver"
+          value={receiver}
+          control={TextArea}
+          onChange={(event) => setReceiver(event.target.value)}
+          required
+        />
         <Checkbox
           label={{ children: 'Anonymous?' }}
           className={styles.isAnonCheckbox}

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -57,9 +57,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
       <div className={styles.formContainer}>
         <Form.Input
           label="Who is awesome?"
-          name="receiver"
           value={receiver}
-          control={TextArea}
           onChange={(event) => setReceiver(event.target.value)}
           required
         />

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
@@ -6,18 +6,11 @@
   height: calc(100vh - 80px - 25vh);
 }
 
-.shoutoutTitle {
-  text-align: center;
-}
-
-.listsContainer {
-  min-height: 50vh;
-  display: flex;
-}
-
-.listContainer {
-  padding: 2em;
+.shoutoutListContainer {
   width: 50%;
+  align-self: center;
+  margin: auto;
+  height: calc(100vh - 80px - 25vh);
 }
 
 @media only screen and (max-width: 900px) {
@@ -27,16 +20,9 @@
     margin-bottom: 5%;
   }
 
-  .shoutoutTitle {
-    text-align: center;
-  }
-
-  .listsContainer {
-    margin-top: 10%;
-    flex-direction: column;
-  }
-
-  .listContainer {
-    width: 100%;
+  .shoutoutListContainer {
+    width: 90%;
+    height: 100%;
+    margin-bottom: 5%;
   }
 }

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.module.css
@@ -3,14 +3,14 @@
   align-self: center;
   margin: auto;
   padding-top: 10vh;
-  height: calc(100vh - 80px - 25vh);
+  height: calc(100vh - 150px - 25vh);
 }
 
 .shoutoutListContainer {
   width: 50%;
   align-self: center;
   margin: auto;
-  height: calc(100vh - 80px - 25vh);
+  padding-bottom: 10vh;
 }
 
 @media only screen and (max-width: 900px) {

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
@@ -10,7 +10,6 @@ import { Shoutout, ShoutoutsAPI } from '../../../API/ShoutoutsAPI';
 const ShoutoutsPage: React.FC = () => {
   const userEmail = useUserEmail();
   const [givenShoutouts, setGivenShoutouts] = useState<Shoutout[]>([]);
-  const [receivedShoutouts, setReceivedShoutouts] = useState<Shoutout[]>([]);
 
   const getGivenShoutouts = useCallback(() => {
     ShoutoutsAPI.getShoutouts(userEmail, 'given')
@@ -25,16 +24,6 @@ const ShoutoutsPage: React.FC = () => {
 
   useEffect(() => {
     getGivenShoutouts();
-    ShoutoutsAPI.getShoutouts(userEmail, 'received')
-      .then((received) => {
-        setReceivedShoutouts(received);
-      })
-      .catch((error) => {
-        Emitters.generalError.emit({
-          headerMsg: `Couldn't get received shoutouts!`,
-          contentMsg: `Error was: ${error}`
-        });
-      });
   }, [userEmail, getGivenShoutouts]);
 
   return (
@@ -43,25 +32,13 @@ const ShoutoutsPage: React.FC = () => {
         <ShoutoutForm getGivenShoutouts={getGivenShoutouts} />
       </div>
 
-      <div className={styles.listsContainer}>
-        <div className={styles.listContainer}>
-          <h2 className={styles.shoutoutTitle}>Given Shoutouts</h2>
-          {givenShoutouts.length > 0 ? (
-            <ShoutoutList shoutouts={givenShoutouts} />
-          ) : (
-            <Message>Give someone a shoutout!</Message>
-          )}
-        </div>
-
-        <div className={styles.listContainer}>
-          <h2 className={styles.shoutoutTitle}>Received Shoutouts</h2>
-
-          {receivedShoutouts.length > 0 ? (
-            <ShoutoutList shoutouts={receivedShoutouts} />
-          ) : (
-            <Message>You currently have no shoutouts.</Message>
-          )}
-        </div>
+      <div className={styles.shoutoutListContainer}>
+        <h2>Given Shoutouts</h2>
+        {givenShoutouts.length > 0 ? (
+          <ShoutoutList shoutouts={givenShoutouts} />
+        ) : (
+          <Message>Give someone a shoutout!</Message>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/forms/index.tsx
+++ b/frontend/src/pages/forms/index.tsx
@@ -6,7 +6,7 @@ const navCardItems: readonly NavigationCardItem[] = [
   { header: 'Sign-In Form', description: 'Sign in to an event!', link: '/forms/signin' },
   {
     header: 'Shoutouts',
-    description: 'Give someone a shoutout or view your past given and received shoutouts.',
+    description: 'Give someone a shoutout or view your past given shoutouts.',
     link: '/forms/shoutouts'
   },
   {


### PR DESCRIPTION
### Summary <!-- Required -->

- Unified Shoutouts type by removing variant without the `giver` field
- Updated Shoutout `recipient` to be type `string` instead of `IdolMember`
- Removed "Received Shoutouts" section from members Shoutouts page
- Removed Shoutouts with old type from dev Firebase 
- Updated Dao tests for correct type


### Test Plan <!-- Required -->

- Manually tested that the Shoutouts form works and collects the correct information
- Ensured that anonymous and non-anymous Shoutout functionality still works
- Verified that correct Shoutout information appears in admin view as well as member view
- Ensured that submitted Shoutouts appear in dev Firebase