### PR TITLE
Hide broken/in-progress pages from users.

### DIFF
--- a/frontend/src/components/Candidate-Decider/CandidateDeciderBase.module.css
+++ b/frontend/src/components/Candidate-Decider/CandidateDeciderBase.module.css
@@ -1,3 +1,7 @@
 .instanceGroup {
   margin: 20px;
 }
+
+.emptyMessage {
+  margin: 5%;
+}

--- a/frontend/src/components/Candidate-Decider/CandidateDeciderBase.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDeciderBase.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Card } from 'semantic-ui-react';
+import Link from 'next/link';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import styles from './CandidateDeciderBase.module.css';
 
@@ -16,15 +17,23 @@ const CandidateDeciderBase: React.FC = () => {
     <div>Loading...</div>
   ) : (
     <div className={styles.instanceGroup}>
-      <Card.Group>
-        {instances.map((instance) => (
-          <Card href={`/candidate-decider/${instance.uuid}`} key={instance.uuid}>
-            <Card.Content>
-              <Card.Header>{instance.name}</Card.Header>
-            </Card.Content>
-          </Card>
-        ))}
-      </Card.Group>
+      {!instances || instances.length === 0 ? (
+        <h1 className={styles.emptyMessage}>
+          You currently do not have access to any candidate decider instances! Please contact{' '}
+          <Link href="https://cornelldti.slack.com/channels/idol-support">#idol-support</Link> if
+          you think this is a mistake.
+        </h1>
+      ) : (
+        <Card.Group>
+          {instances.map((instance) => (
+            <Card href={`/candidate-decider/${instance.uuid}`} key={instance.uuid}>
+              <Card.Content>
+                <Card.Header>{instance.name}</Card.Header>
+              </Card.Content>
+            </Card>
+          ))}
+        </Card.Group>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -112,12 +112,6 @@ const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermis
         Forms
       </Menu.Item>
     </Link>
-    <Link href="/games">
-      <Menu.Item>
-        <Icon name="game" />
-        Games
-      </Menu.Item>
-    </Link>
     {hasAdminPermission && (
       <Link href="/candidate-decider">
         <Menu.Item>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -112,13 +112,11 @@ const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermis
         Forms
       </Menu.Item>
     </Link>
-    {hasAdminPermission && (
-      <Link href="/candidate-decider">
-        <Menu.Item>
-          <Icon name="chart bar outline" />
-          Candidate Decider
-        </Menu.Item>
-      </Link>
-    )}
+    <Link href="/candidate-decider">
+      <Menu.Item>
+        <Icon name="chart bar outline" />
+        Candidate Decider
+      </Menu.Item>
+    </Link>
   </>
 );

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -118,11 +118,13 @@ const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermis
         Games
       </Menu.Item>
     </Link>
-    <Link href="/candidate-decider">
-      <Menu.Item>
-        <Icon name="chart bar outline" />
-        Candidate Decider
-      </Menu.Item>
-    </Link>
+    {hasAdminPermission && (
+      <Link href="/candidate-decider">
+        <Menu.Item>
+          <Icon name="chart bar outline" />
+          Candidate Decider
+        </Menu.Item>
+      </Link>
+    )}
   </>
 );

--- a/frontend/src/pages/forms/index.tsx
+++ b/frontend/src/pages/forms/index.tsx
@@ -7,7 +7,8 @@ const navCardItems: readonly NavigationCardItem[] = [
   {
     header: 'Shoutouts',
     description: 'Give someone a shoutout or view your past given shoutouts.',
-    link: '/forms/shoutouts'
+    link: '/forms/shoutouts',
+    adminOnly: true
   },
   {
     header: 'Edit Profile',
@@ -28,8 +29,7 @@ const navCardItems: readonly NavigationCardItem[] = [
   {
     header: 'Dev Portfolio Assignments',
     description: 'Submit opened and reviewed pull requests.',
-    link: '/forms/devPortfolio',
-    adminOnly: true
+    link: '/forms/devPortfolio'
   }
 ];
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR removes access to broken pages or features that are not ready for release.
- Removed "Games" tab
- Add message if user's arent supposed to see candidate decider instances
- Hide shoutouts feature until ready for use

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Non-admin view
<img width="960" alt="image" src="https://user-images.githubusercontent.com/81320443/199346415-01250b92-93cc-49f6-aed5-479c961c970f.png">

<img width="960" alt="image" src="https://user-images.githubusercontent.com/81320443/198840511-5fd91cb2-bd22-46d0-811a-0d70ae07ba2a.png">
