### PR TITLE
Add meta data type for TEC to patch security issue 

### DIFF
--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -4,8 +4,8 @@ import { PermissionError } from '../utils/errors';
 import PermissionsManager from '../utils/permissionsManager';
 
 export const getAllTeamEvents = async (user: IdolMember): Promise<TeamEvent[]> => {
-  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
-  if (!isLeadOrAdmin) throw new PermissionError('does not have permissions');
+  const canEditTeamEvents = await PermissionsManager.canEditTeamEvent(user);
+  if (!canEditTeamEvents) throw new PermissionError('does not have permissions');
   return TeamEventsDao.getAllTeamEvents();
 };
 
@@ -34,9 +34,11 @@ export const updateTeamEvent = async (
   teamEvent: TeamEvent,
   user: IdolMember
 ): Promise<TeamEvent> => {
-  // if (!PermissionsManager.canEditTeamEvent(user)) {
-  //   throw new PermissionError("You don't have permission to update a team event!");
-  // }
+  if (!PermissionsManager.canEditTeamEvent(user)) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to update team events`
+    );
+  }
   await TeamEventsDao.updateTeamEvent(teamEvent);
   return teamEvent;
 };
@@ -53,8 +55,14 @@ export const requestTeamEventCredit = async (
   await TeamEventsDao.updateTeamEvent(updatedTeamEvent);
 };
 
-export const getTeamEvent = async (uuid: string, user: IdolMember): Promise<TeamEvent> =>
-  TeamEventsDao.getTeamEvent(uuid);
+export const getTeamEvent = async (uuid: string, user: IdolMember): Promise<TeamEvent> => {
+  const canEditTeamEvents = await PermissionsManager.canEditTeamEvent(user);
+  if (!canEditTeamEvents)
+    throw new PermissionError(
+      `User with email ${user.email} does not have permission to get full team event`
+    );
+  return TeamEventsDao.getTeamEvent(uuid);
+};
 
 export const clearAllTeamEvents = async (user: IdolMember): Promise<void> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);

--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -4,10 +4,13 @@ import { PermissionError } from '../utils/errors';
 import PermissionsManager from '../utils/permissionsManager';
 
 export const getAllTeamEvents = async (user: IdolMember): Promise<TeamEvent[]> => {
-  const canCreateTeamEvent = await PermissionsManager.canEditTeamEvent(user);
-  if (!canCreateTeamEvent) throw new PermissionError('does not have permissions');
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  if (!isLeadOrAdmin) throw new PermissionError('does not have permissions');
   return TeamEventsDao.getAllTeamEvents();
 };
+
+export const getAllTeamEventInfo = async (): Promise<TeamEventInfo[]> =>
+  TeamEventsDao.getAllTeamEventInfo();
 
 export const createTeamEvent = async (
   teamEvent: TeamEvent,
@@ -38,6 +41,18 @@ export const updateTeamEvent = async (
   return teamEvent;
 };
 
+export const requestTeamEventCredit = async (
+  uuid: string,
+  request: TeamEventAttendance
+): Promise<void> => {
+  const teamEvent = await TeamEventsDao.getTeamEvent(uuid);
+  const updatedTeamEvent = {
+    ...teamEvent,
+    requests: [...teamEvent.requests, request]
+  };
+  await TeamEventsDao.updateTeamEvent(updatedTeamEvent);
+};
+
 export const getTeamEvent = async (uuid: string, user: IdolMember): Promise<TeamEvent> =>
   TeamEventsDao.getTeamEvent(uuid);
 
@@ -49,3 +64,7 @@ export const clearAllTeamEvents = async (user: IdolMember): Promise<void> => {
     );
   await TeamEventsDao.deleteAllTeamEvents();
 };
+export const getAllTeamEventsForMember = async (
+  email: string,
+  isPending: boolean
+): Promise<TeamEventInfo[]> => TeamEventsDao.getTeamEventsForMember(email, isPending);

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -36,10 +36,13 @@ import {
 import {
   createTeamEvent,
   deleteTeamEvent,
+  getAllTeamEventInfo,
   getAllTeamEvents,
   getTeamEvent,
   updateTeamEvent,
-  clearAllTeamEvents
+  clearAllTeamEvents,
+  requestTeamEventCredit,
+  getAllTeamEventsForMember
 } from './API/teamEventsAPI';
 import {
   getAllCandidateDeciderInstances,
@@ -259,6 +262,17 @@ loginCheckedDelete('/clearAllTeamEvents', async (_, user) => {
   await clearAllTeamEvents(user);
   return {};
 });
+loginCheckedGet('/getAllTeamEventInfo', async () => ({
+  allTeamEventInfo: await getAllTeamEventInfo()
+}));
+loginCheckedPost('/requestTeamEventCredit', async (req, _) => {
+  await requestTeamEventCredit(req.body.uuid, req.body.request);
+  return {};
+});
+loginCheckedGet('/getAllTeamEventsForMember', async (_, user) => ({
+  pending: await getAllTeamEventsForMember(user.email, true),
+  approved: await getAllTeamEventsForMember(user.email, false)
+}));
 
 // Team Events Proof Image
 loginCheckedGet('/getEventProofImage/:name(*)', async (req, user) => ({

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -82,14 +82,17 @@ interface TeamEventAttendance {
   image: string;
 }
 
-interface TeamEvent {
-  name: string;
-  date: string;
-  numCredits: string;
-  hasHours: boolean;
+interface TeamEventInfo {
+  readonly name: string;
+  readonly date: string;
+  readonly numCredits: string;
+  readonly hasHours: boolean;
+  readonly uuid: string;
+}
+
+interface TeamEvent extends TeamEventInfo {
   readonly attendees: TeamEventAttendance[];
   readonly requests: TeamEventAttendance[];
-  readonly uuid: string;
 }
 
 interface EventProofImage {

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -33,7 +33,7 @@ export class TeamEventsAPI {
   }
 
   public static getAllTeamEventInfo(): Promise<TeamEventInfo[]> {
-    const res = APIWrapper.get(`${backendURL}/getAllTeamEventINfo`).then((res) => res.data);
+    const res = APIWrapper.get(`${backendURL}/getAllTeamEventInfo`).then((res) => res.data);
     return res.then((val) => {
       if (val.error) {
         Emitters.generalError.emit({

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -11,6 +11,11 @@ export type EventAttendance = TeamEventAttendance;
 
 export type Event = TeamEvent;
 
+export type MemberTECRequests = {
+  pending: TeamEventInfo[];
+  approved: TeamEventInfo[];
+};
+
 export class TeamEventsAPI {
   public static getAllTeamEvents(): Promise<Event[]> {
     const eventsProm = APIWrapper.get(`${backendURL}/getAllTeamEvents`).then((res) => res.data);
@@ -27,6 +32,20 @@ export class TeamEventsAPI {
     });
   }
 
+  public static getAllTeamEventInfo(): Promise<TeamEventInfo[]> {
+    const res = APIWrapper.get(`${backendURL}/getAllTeamEventINfo`).then((res) => res.data);
+    return res.then((val) => {
+      if (val.error) {
+        Emitters.generalError.emit({
+          headerMsg: "Couldn't get all events",
+          contentMsg: `Error was: ${val.err}`
+        });
+        return [];
+      }
+      return val.allTeamEventInfo as TeamEventInfo[];
+    });
+  }
+
   public static getTeamEventForm(uuid: string): Promise<Event> {
     const eventProm = APIWrapper.get(`${backendURL}/getTeamEvent/${uuid}`).then((res) => res.data);
     return eventProm.then((val) => {
@@ -37,13 +56,6 @@ export class TeamEventsAPI {
 
   public static createTeamEventForm(teamEvent: Event): Promise<TeamEventResponseObj> {
     return APIWrapper.post(`${backendURL}/createTeamEvent`, teamEvent).then((res) => res.data);
-  }
-
-  public static requestTeamEventCredit(teamEvent: Event): Promise<TeamEventResponseObj> {
-    // need to add image processing
-    return APIWrapper.post(`${backendURL}/updateTeamEvent`, teamEvent).then(
-      (res) => res.data.event
-    );
   }
 
   public static async deleteTeamEventForm(teamEvent: Event): Promise<void> {
@@ -58,5 +70,16 @@ export class TeamEventsAPI {
 
   public static async clearAllTeamEvents(): Promise<void> {
     await APIWrapper.delete(`${backendURL}/clearAllTeamEvents`);
+  }
+
+  public static async requestTeamEventCredit(
+    uuid: string,
+    request: TeamEventAttendance
+  ): Promise<void> {
+    APIWrapper.post(`${backendURL}/requestTeamEventCredit`, { uuid, request });
+  }
+
+  public static async getAllTeamEventsForMember(): Promise<MemberTECRequests> {
+    return APIWrapper.get(`${backendURL}/getAllTeamEventsForMember`).then((val) => val.data);
   }
 }

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -11,13 +11,13 @@ const TeamEventCreditForm: React.FC = () => {
   // When the user is logged in, `useSelf` always return non-null data.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const userInfo = useSelf()!;
-  const [teamEvent, setTeamEvent] = useState<TeamEvent | undefined>(undefined);
+  const [teamEvent, setTeamEvent] = useState<TeamEventInfo | undefined>(undefined);
   const [image, setImage] = useState('');
   const [hours, setHours] = useState('');
-  const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
+  const [teamEventInfoList, setTeamEventInfoList] = useState<TeamEventInfo[]>([]);
 
   useEffect(() => {
-    TeamEventsAPI.getAllTeamEvents().then((teamEvents) => setTeamEvents(teamEvents));
+    TeamEventsAPI.getAllTeamEventInfo().then((teamEvents) => setTeamEventInfoList(teamEvents));
   }, []);
 
   const handleNewImage = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -26,12 +26,8 @@ const TeamEventCreditForm: React.FC = () => {
     setImage(newImage);
   };
 
-  const requestTeamEventCredit = (
-    eventCreditRequest: TeamEventAttendance,
-    teamEvent: TeamEvent
-  ) => {
-    teamEvent?.requests.push(eventCreditRequest);
-    TeamEventsAPI.requestTeamEventCredit(teamEvent);
+  const requestTeamEventCredit = (eventCreditRequest: TeamEventAttendance, uuid: string) => {
+    TeamEventsAPI.requestTeamEventCredit(uuid, eventCreditRequest);
     // upload image
     fetch(image)
       .then((res) => res.blob())
@@ -64,7 +60,7 @@ const TeamEventCreditForm: React.FC = () => {
         hoursAttended: Number(hours),
         image: `eventProofs/${getNetIDFromEmail(userInfo.email)}/${new Date().toISOString()}`
       };
-      requestTeamEventCredit(newTeamEventAttendance, teamEvent);
+      requestTeamEventCredit(newTeamEventAttendance, teamEvent.uuid);
       Emitters.generalSuccess.emit({
         headerMsg: 'Team Event Credit submitted!',
         contentMsg: `The leads were notified of your submission and your credit will be approved soon!`
@@ -85,19 +81,19 @@ const TeamEventCreditForm: React.FC = () => {
             Select a Team Event: <span className={styles.red_color}>*</span>
           </label>
           <div className={styles.center_and_flex}>
-            {teamEvents && !teamEvent ? (
+            {teamEventInfoList && !teamEvent ? (
               <Dropdown
                 placeholder="Select a Team Event"
                 fluid
                 search
                 selection
-                options={teamEvents.map((event) => ({
+                options={teamEventInfoList.map((event) => ({
                   key: event.uuid,
                   text: event.name,
                   value: event.uuid
                 }))}
                 onChange={(_, data) => {
-                  setTeamEvent(teamEvents.find((event) => event.uuid === data.value));
+                  setTeamEvent(teamEventInfoList.find((event) => event.uuid === data.value));
                 }}
               />
             ) : undefined}
@@ -162,7 +158,7 @@ const TeamEventCreditForm: React.FC = () => {
         <Form.Button floated="right" onClick={submitTeamEventCredit}>
           Submit
         </Form.Button>
-        <TeamEventCreditDashboard teamEvents={teamEvents} />
+        <TeamEventCreditDashboard />
       </Form>
     </div>
   );

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
@@ -33,7 +33,7 @@ const TeamEventCreditDashboard = (): JSX.Element => {
         <h1>Check Team Event Credits</h1>
         <p>
           Check your team event credit status for this semester here! Every DTI member must complete
-          {REQUIRED_TEC_CREDITS} team event credits to fulfill this requirement.
+           {REQUIRED_TEC_CREDITS} team event credits to fulfill this requirement.
         </p>
 
         <div className={styles.inline}>

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
@@ -32,7 +32,7 @@ const TeamEventCreditDashboard = (): JSX.Element => {
         <div className={styles.header}></div>
         <h1>Check Team Event Credits</h1>
         <p>
-          Check your team event credit status for this semester here! Every DTI member must complete
+          Check your team event credit status for this semester here! Every DTI member must complete{' '}
           {REQUIRED_TEC_CREDITS} team event credits to fulfill this requirement.
         </p>
 

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
@@ -33,7 +33,7 @@ const TeamEventCreditDashboard = (): JSX.Element => {
         <h1>Check Team Event Credits</h1>
         <p>
           Check your team event credit status for this semester here! Every DTI member must complete
-          3 team event credits to fulfill this requirement.
+          {REQUIRED_TEC_CREDITS} team event credits to fulfill this requirement.
         </p>
 
         <div className={styles.inline}>

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
@@ -1,39 +1,30 @@
 import React, { useEffect, useState } from 'react';
 import { Form, Card, Message } from 'semantic-ui-react';
-import { useSelf } from '../../Common/FirestoreDataProvider';
+import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import styles from './TeamEventCreditsForm.module.css';
 
-const TeamEventCreditDashboard = (props: { teamEvents: TeamEvent[] }): JSX.Element => {
+const REQUIRED_TEC_CREDITS = 3; // number of required tec credits in a semester
+
+const TeamEventCreditDashboard = (): JSX.Element => {
   // When the user is logged in, `useSelf` always return non-null data.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const userInfo = useSelf()!;
-  const { teamEvents } = props;
 
-  const [countApprovedCredits, setCountApprovedCredits] = useState(0);
-  const [countRemainingCredits, setCountRemainingCredits] = useState(3);
-  const [approvedTEC, setApprovedTEC] = useState<TeamEvent[]>([]);
-  const [pendingTEC, setPendingTEC] = useState<TeamEvent[]>([]);
+  const [approvedTEC, setApprovedTEC] = useState<TeamEventInfo[]>([]);
+  const [pendingTEC, setPendingTEC] = useState<TeamEventInfo[]>([]);
 
   useEffect(() => {
-    teamEvents.forEach((currTeamEvent) => {
-      currTeamEvent.attendees.forEach((currApprovedMember) => {
-        if (currApprovedMember.member.email === userInfo.email) {
-          const currCredits = Number(currTeamEvent.numCredits);
-          setCountApprovedCredits((countApprovedCredits) => countApprovedCredits + currCredits);
-          setCountRemainingCredits((countRemainingCredits) => {
-            if (countRemainingCredits - currCredits <= 0) return 0;
-            return countRemainingCredits - currCredits;
-          });
-          setApprovedTEC((approvedTEC) => [...approvedTEC, currTeamEvent]);
-        }
-      });
-      currTeamEvent.requests.forEach((currApprovedMember) => {
-        if (currApprovedMember.member.email === userInfo.email) {
-          setPendingTEC((pendingTEC) => [...pendingTEC, currTeamEvent]);
-        }
-      });
+    TeamEventsAPI.getAllTeamEventsForMember().then((val) => {
+      setApprovedTEC(val.approved);
+      setPendingTEC(val.pending);
     });
-  }, [teamEvents, userInfo.email]);
+  }, []);
+
+  const approvedCredits = approvedTEC.reduce(
+    (approved, teamEvent) => approved + Number(teamEvent.numCredits),
+    0
+  );
+  const remainingCredits =
+    REQUIRED_TEC_CREDITS - approvedCredits > 0 ? REQUIRED_TEC_CREDITS - approvedCredits : 0;
 
   return (
     <div>
@@ -47,15 +38,14 @@ const TeamEventCreditDashboard = (props: { teamEvents: TeamEvent[] }): JSX.Eleme
 
         <div className={styles.inline}>
           <label className={styles.bold}>
-            Your Approved Credits:{' '}
-            <span className={styles.dark_grey_color}>{countApprovedCredits}</span>
+            Your Approved Credits: <span className={styles.dark_grey_color}>{approvedCredits}</span>
           </label>
         </div>
 
         <div className={styles.inline}>
           <label className={styles.bold}>
             Remaining Credits Needed:{' '}
-            <span className={styles.dark_grey_color}>{countRemainingCredits}</span>
+            <span className={styles.dark_grey_color}>{remainingCredits}</span>
           </label>
         </div>
 

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
@@ -33,7 +33,7 @@ const TeamEventCreditDashboard = (): JSX.Element => {
         <h1>Check Team Event Credits</h1>
         <p>
           Check your team event credit status for this semester here! Every DTI member must complete
-           {REQUIRED_TEC_CREDITS} team event credits to fulfill this requirement.
+          {REQUIRED_TEC_CREDITS} team event credits to fulfill this requirement.
         </p>
 
         <div className={styles.inline}>


### PR DESCRIPTION
### Summary <!-- Required -->
- Added `TeamEventInfo` type with the metadata for `TeamEvent` type 
```
interface TeamEventInfo {
  readonly name: string;
  readonly date: string;
  readonly numCredits: string;
  readonly hasHours: boolean;
  readonly uuid: string;
}
```
- Member-side team event form only retrieves `TeamEventInfo` type now so that members aren't able to see who has pending/approved TEC requests 
- Changed the way that new TEC requests are handled so that frontend doesn't need access to the `TeamEvent` object 
- Changed the way that the TEC dashboard for members retrieves/determines the pending/approved requests for a member 
- Only leads/admins have permissions to call the `/getAllTeamEvents` endpoint now 

### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Member-TEC-Security-Fix-644f57516d0a474688a5d3c5878bbdec)

### Test Plan <!-- Required -->
- Manually testing -- ensured that existing functionality works 
- Pending/approved requests should not show up on member-side form in network tab 

