### PR TITLE
Allow admins to delete team events

### DIFF
--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -20,11 +20,11 @@ export const createTeamEvent = async (
   return teamEvent;
 };
 
-export const deleteTeamEvent = async (teamEvent: TeamEvent, user: IdolMember): Promise<void> => {
+export const deleteTeamEvent = async (uuid: string, user: IdolMember): Promise<void> => {
   if (!PermissionsManager.canEditTeamEvent(user)) {
     throw new PermissionError("You don't have permission to delete a team event!");
   }
-  await TeamEventsDao.deleteTeamEvent(teamEvent);
+  await TeamEventsDao.deleteTeamEvent(uuid);
 };
 
 export const updateTeamEvent = async (

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -247,7 +247,7 @@ loginCheckedPost('/updateTeamEvent', async (req, user) => ({
   event: await updateTeamEvent(req.body, user)
 }));
 loginCheckedPost('/deleteTeamEvent', async (req, user) => {
-  await deleteTeamEvent(req.body, user);
+  await deleteTeamEvent(req.body.uuid, user);
   return {};
 });
 

--- a/backend/src/dao/TeamEventsDao.ts
+++ b/backend/src/dao/TeamEventsDao.ts
@@ -57,10 +57,10 @@ export default class TeamEventsDao {
     };
   }
 
-  static async deleteTeamEvent(teamEvent: TeamEvent): Promise<void> {
-    const eventDoc = teamEventsCollection.doc(teamEvent.uuid);
+  static async deleteTeamEvent(uuid: string): Promise<void> {
+    const eventDoc = teamEventsCollection.doc(uuid);
     const eventRef = await eventDoc.get();
-    if (!eventRef.exists) throw new NotFoundError(`No team event '${teamEvent.uuid}' exists.`);
+    if (!eventRef.exists) throw new NotFoundError(`No team event '${uuid}' exists.`);
     await eventDoc.delete();
   }
 

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -46,8 +46,8 @@ export class TeamEventsAPI {
     );
   }
 
-  public static async deleteTeamEventForm(teamEvent: Event): Promise<void> {
-    await APIWrapper.post(`${backendURL}/deleteTeamEvent`, teamEvent);
+  public static async deleteTeamEventForm(uuid: string): Promise<void> {
+    await APIWrapper.post(`${backendURL}/deleteTeamEvent`, { uuid });
   }
 
   public static updateTeamEventForm(teamEvent: Event): Promise<TeamEventResponseObj> {

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -47,7 +47,7 @@ const TeamEventDetails: React.FC = () => {
   }, [isLoading, uuid]);
 
   const deleteTeamEvent = () => {
-    TeamEventsAPI.deleteTeamEventForm(teamEvent).then(() => {
+    TeamEventsAPI.deleteTeamEventForm(teamEvent.uuid).then(() => {
       Emitters.generalSuccess.emit({
         headerMsg: 'Team Event Deleted!',
         contentMsg: 'The team event was successfully deleted!'

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Card, Message } from 'semantic-ui-react';
-import Link from 'next/link';
 import TeamEventForm from './TeamEventForm';
 import styles from './TeamEvents.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters } from '../../../utils';
+import TECDeleteModal from '../../Modals/TECDeleteModal';
 
 const TeamEvents: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
@@ -45,15 +45,22 @@ const TeamEvents: React.FC = () => {
         {teamEvents.length !== 0 ? (
           <Card.Group>
             {teamEvents.map((teamEvent) => (
-              <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
-                <Card>
-                  <Card.Content>
-                    <Card.Header>{teamEvent.name} </Card.Header>
-                    <Card.Meta>{teamEvent.date}</Card.Meta>
-                    <Card.Meta>{teamEvent.requests.length} pending requests</Card.Meta>
-                  </Card.Content>
-                </Card>
-              </Link>
+              <Card>
+                <Card.Content>
+                  <TECDeleteModal
+                    uuid={teamEvent.uuid}
+                    name={teamEvent.name}
+                    setTeamEvents={setTeamEvents}
+                  />
+                  <Card.Header>
+                    <a key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
+                      {teamEvent.name}
+                    </a>
+                  </Card.Header>
+                  <Card.Meta>{teamEvent.date}</Card.Meta>
+                  <Card.Meta>{teamEvent.requests.length} pending requests</Card.Meta>
+                </Card.Content>
+              </Card>
             ))}
           </Card.Group>
         ) : (

--- a/frontend/src/components/Modals/TECDeleteModal.module.css
+++ b/frontend/src/components/Modals/TECDeleteModal.module.css
@@ -1,0 +1,4 @@
+.trashIcon {
+  position: absolute;
+  right: 1%;
+}

--- a/frontend/src/components/Modals/TECDeleteModal.tsx
+++ b/frontend/src/components/Modals/TECDeleteModal.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Modal, Icon, Button } from 'semantic-ui-react';
+import { TeamEventsAPI } from '../../API/TeamEventsAPI';
+import styles from './TECDeleteModal.module.css';
+
+type Props = {
+  uuid: string;
+  name: string;
+  setTeamEvents: React.Dispatch<React.SetStateAction<TeamEvent[]>>;
+};
+
+const TECDeleteModal: React.FC<Props> = ({ uuid, name, setTeamEvents }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  return (
+    <Modal
+      open={isOpen}
+      onOpen={() => setIsOpen(true)}
+      onClose={() => setIsOpen(false)}
+      trigger={<Icon className={styles.trashIcon} name="trash" color="red" />}
+    >
+      <Modal.Header>
+        Are you sure you want to delete <b>{name}</b>?
+      </Modal.Header>
+      <Modal.Description>
+        Deleting this team event will delete all metadata and corresponding credit requests
+      </Modal.Description>
+      <Modal.Actions>
+        <Button positive onClick={() => setIsOpen(false)}>
+          Cancel
+        </Button>
+        <Button
+          negative
+          onClick={() => {
+            TeamEventsAPI.deleteTeamEventForm(uuid).then(() => {
+              setTeamEvents((teamEvents) =>
+                teamEvents.filter((teamEvent) => teamEvent.uuid !== uuid)
+              );
+              setIsOpen(false);
+            });
+          }}
+        >
+          Delete
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default TECDeleteModal;


### PR DESCRIPTION
### Summary <!-- Required -->

Allow admins to delete team events on the admin dashboard 


### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Admin-TEC-Add-ability-to-delete-events-2fb725f13de345b1bb1208545b7d2547)
### Test Plan <!-- Required -->

Manually test deleting a test team event in the preview 