### PR TITLE
Allow admins to delete all team events 

### DIFF
--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -40,3 +40,12 @@ export const updateTeamEvent = async (
 
 export const getTeamEvent = async (uuid: string, user: IdolMember): Promise<TeamEvent> =>
   TeamEventsDao.getTeamEvent(uuid);
+
+export const clearAllTeamEvents = async (user: IdolMember): Promise<void> => {
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  if (!isLeadOrAdmin)
+    throw new PermissionError(
+      `User with email ${user.email} does not have sufficient permissions to delete all team events.`
+    );
+  await TeamEventsDao.deleteAllTeamEvents();
+};

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -38,7 +38,8 @@ import {
   deleteTeamEvent,
   getAllTeamEvents,
   getTeamEvent,
-  updateTeamEvent
+  updateTeamEvent,
+  clearAllTeamEvents
 } from './API/teamEventsAPI';
 import {
   getAllCandidateDeciderInstances,
@@ -248,6 +249,10 @@ loginCheckedPost('/updateTeamEvent', async (req, user) => ({
 }));
 loginCheckedPost('/deleteTeamEvent', async (req, user) => {
   await deleteTeamEvent(req.body, user);
+  return {};
+});
+loginCheckedDelete('/clearAllTeamEvents', async (_, user) => {
+  await clearAllTeamEvents(user);
   return {};
 });
 

--- a/backend/src/dao/TeamEventsDao.ts
+++ b/backend/src/dao/TeamEventsDao.ts
@@ -103,4 +103,12 @@ export default class TeamEventsDao {
     await teamEventsCollection.doc(event.uuid).update(teamEventRef);
     return event;
   }
+
+  static async deleteAllTeamEvents(): Promise<void> {
+    const batch = teamEventsCollection.firestore.batch();
+    const coll = await teamEventsCollection.get();
+
+    coll.docs.forEach((doc) => batch.delete(doc.ref));
+    await batch.commit();
+  }
 }

--- a/backend/src/dao/TeamEventsDao.ts
+++ b/backend/src/dao/TeamEventsDao.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { TeamEvent, DBTeamEvent } from '../types/DataTypes';
-import { memberCollection, teamEventsCollection } from '../firebase';
+import { memberCollection, teamEventsCollection, bucket } from '../firebase';
 import { NotFoundError } from '../utils/errors';
 import { getMemberFromDocumentReference } from '../utils/memberUtil';
 
@@ -104,11 +104,15 @@ export default class TeamEventsDao {
     return event;
   }
 
+  /* Deletes all team event documents and proof images */
   static async deleteAllTeamEvents(): Promise<void> {
     const batch = teamEventsCollection.firestore.batch();
     const coll = await teamEventsCollection.get();
 
     coll.docs.forEach((doc) => batch.delete(doc.ref));
     await batch.commit();
+
+    const proofImageFiles = await bucket.getFiles({ prefix: 'eventProofs/' });
+    await Promise.all(proofImageFiles[0].map((file) => file.delete()));
   }
 }

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -55,4 +55,8 @@ export class TeamEventsAPI {
       (rest) => rest.data.event
     );
   }
+
+  public static async clearAllTeamEvents(): Promise<void> {
+    await APIWrapper.delete(`${backendURL}/clearAllTeamEvents`);
+  }
 }

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.module.css
@@ -16,3 +16,7 @@
   margin-bottom: 1rem;
   border-radius: 4px 4px 4px 4px;
 }
+
+.resetButtonContainer {
+  margin-top: 2rem;
+}

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -5,6 +5,7 @@ import TeamEventForm from './TeamEventForm';
 import styles from './TeamEvents.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters } from '../../../utils';
+import ClearTeamEventsModal from '../../Modals/ClearTeamEventsModal';
 
 const TeamEvents: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
@@ -41,24 +42,29 @@ const TeamEvents: React.FC = () => {
         <TeamEventForm formType={'create'}></TeamEventForm>
       </div>
       <div className={styles.wrapper}>
-        <h2>View All Team Events</h2>
-        {teamEvents.length !== 0 ? (
-          <Card.Group>
-            {teamEvents.map((teamEvent) => (
-              <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
-                <Card>
-                  <Card.Content>
-                    <Card.Header>{teamEvent.name} </Card.Header>
-                    <Card.Meta>{teamEvent.date}</Card.Meta>
-                    <Card.Meta>{teamEvent.requests.length} pending requests</Card.Meta>
-                  </Card.Content>
-                </Card>
-              </Link>
-            ))}
-          </Card.Group>
-        ) : (
-          <Message>There are currently no team event forms.</Message>
-        )}
+        <div>
+          <h2>View All Team Events</h2>
+          {teamEvents.length !== 0 ? (
+            <Card.Group>
+              {teamEvents.map((teamEvent) => (
+                <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
+                  <Card>
+                    <Card.Content>
+                      <Card.Header>{teamEvent.name} </Card.Header>
+                      <Card.Meta>{teamEvent.date}</Card.Meta>
+                      <Card.Meta>{teamEvent.requests.length} pending requests</Card.Meta>
+                    </Card.Content>
+                  </Card>
+                </Link>
+              ))}
+            </Card.Group>
+          ) : (
+            <Message>There are currently no team event forms.</Message>
+          )}
+        </div>
+        <div className={styles.resetButtonContainer}>
+          <ClearTeamEventsModal setTeamEvents={setTeamEvents} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/Modals/ClearTeamEventsModal.tsx
+++ b/frontend/src/components/Modals/ClearTeamEventsModal.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Modal, Button } from 'semantic-ui-react';
+import { TeamEventsAPI } from '../../API/TeamEventsAPI';
+
+type Props = {
+  setTeamEvents: React.Dispatch<React.SetStateAction<TeamEvent[]>>;
+};
+
+const ClearTeamEventsModal: React.FC<Props> = ({ setTeamEvents }) => (
+  <Modal
+    basic
+    trigger={<Button negative>Clear all Team Events</Button>}
+    header="WARNING: Are you sure you want to clear ALL team events?"
+    content="Please make sure that you want to clear all team events. Deleting all team events deletes all metadata and corresponding attendance data. This action is NOT recoverable."
+    actions={[
+      { key: 'cancel', content: 'Cancel', positive: true },
+      {
+        key: 'confirm',
+        content: 'Confirm delete',
+        negative: true,
+        onClick: () => {
+          TeamEventsAPI.clearAllTeamEvents().then(() => setTeamEvents([]));
+        }
+      }
+    ]}
+  />
+);
+
+export default ClearTeamEventsModal;

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 export const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = false;
+export const useProdDb = true;
 
 /** Switch to false to test IDOL as a non-admin user. Change back to true before committing. */
 export const allowAdmin = true;

--- a/frontend/src/environment.ts
+++ b/frontend/src/environment.ts
@@ -4,7 +4,7 @@ export const isProduction = process.env.NODE_ENV === 'production';
 export const useProdBackendForDev = false;
 
 /** Switch to false to use development Firebase instance. Change back to true before committing. */
-export const useProdDb = true;
+export const useProdDb = false;
 
 /** Switch to false to test IDOL as a non-admin user. Change back to true before committing. */
 export const allowAdmin = true;


### PR DESCRIPTION
### Summary <!-- Required -->
Allow admins to delete all team events on the admin dashboard 

![image](https://user-images.githubusercontent.com/65922473/200216072-90e0276f-7592-499c-84ac-ad3d80f01f11.png)


### Notion/Figma Link <!-- Optional -->
[Notion link](https://www.notion.so/cornelldti/Admin-TEC-Add-ability-to-delete-events-2fb725f13de345b1bb1208545b7d2547)
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Test locally -- You will need to create team events/request credit since all existing ones have been deleted. 