### PR TITLE
Hide shoutouts from admin view

### DIFF
--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -28,21 +28,13 @@ export const getShoutouts = async (
   return ShoutoutsDao.getShoutouts(memberEmail, type);
 };
 
-export const hideShoutout = async (body: string, user: IdolMember): Promise<Shoutout> => {
+export const hideShoutout = async (body: Shoutout, user: IdolMember): Promise<Shoutout> => {
   const canEdit = await PermissionsManager.canHideShoutouts(user);
   if (!canEdit) {
     throw new PermissionError(
       `User with email: ${user.email} does not have permission to hide shoutouts!`
     );
   }
-
-  const shoutout = await ShoutoutsDao.getInstance(body);
-
-  const shoutoutRef = {
-    ...shoutout,
-    hidden: true
-  };
-
-  await ShoutoutsDao.hideShoutout(shoutoutRef);
-  return shoutoutRef;
+  await ShoutoutsDao.hideShoutout(body);
+  return body;
 };

--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -28,13 +28,13 @@ export const getShoutouts = async (
   return ShoutoutsDao.getShoutouts(memberEmail, type);
 };
 
-export const hideShoutout = async (body: Shoutout, user: IdolMember): Promise<Shoutout> => {
+export const updateShoutout = async (body: Shoutout, user: IdolMember): Promise<Shoutout> => {
   const canEdit = await PermissionsManager.canHideShoutouts(user);
   if (!canEdit) {
     throw new PermissionError(
       `User with email: ${user.email} does not have permission to hide shoutouts!`
     );
   }
-  await ShoutoutsDao.hideShoutout(body);
+  await ShoutoutsDao.updateShoutout(body);
   return body;
 };

--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -28,13 +28,21 @@ export const getShoutouts = async (
   return ShoutoutsDao.getShoutouts(memberEmail, type);
 };
 
-export const hideShoutout = async (body: Shoutout, user: IdolMember): Promise<Shoutout> => {
+export const hideShoutout = async (body: string, user: IdolMember): Promise<Shoutout> => {
   const canEdit = await PermissionsManager.canHideShoutouts(user);
   if (!canEdit) {
     throw new PermissionError(
       `User with email: ${user.email} does not have permission to hide shoutouts!`
     );
   }
-  await ShoutoutsDao.hideShoutout(body);
-  return body;
+
+  const shoutout = await ShoutoutsDao.getInstance(body);
+
+  const shoutoutRef = {
+    ...shoutout,
+    hidden: true
+  };
+
+  await ShoutoutsDao.hideShoutout(shoutoutRef);
+  return shoutoutRef;
 };

--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -5,16 +5,7 @@ import ShoutoutsDao from '../dao/ShoutoutsDao';
 
 export const getAllShoutouts = (): Promise<Shoutout[]> => ShoutoutsDao.getAllShoutouts();
 
-export const giveShoutout = async (
-  body: {
-    giver: IdolMember;
-    receiver: string;
-    message: string;
-    isAnon: boolean;
-    timestamp: number;
-  },
-  user: IdolMember
-): Promise<Shoutout> => {
+export const giveShoutout = async (body: Shoutout, user: IdolMember): Promise<Shoutout> => {
   if (body.giver.email !== user.email) {
     throw new PermissionError(
       `User with email: ${user.email} can't post a shoutout from a different user!`
@@ -35,4 +26,15 @@ export const getShoutouts = async (
     );
   }
   return ShoutoutsDao.getShoutouts(memberEmail, type);
+};
+
+export const hideShoutout = async (body: Shoutout, user: IdolMember): Promise<Shoutout> => {
+  const canEdit = await PermissionsManager.canHideShoutouts(user);
+  if (!canEdit) {
+    throw new PermissionError(
+      `User with email: ${user.email} does not have permission to hide shoutouts!`
+    );
+  }
+  await ShoutoutsDao.hideShoutout(body);
+  return body;
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -24,7 +24,7 @@ import {
 } from './API/memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './API/imageAPI';
 import { allTeams, setTeam, deleteTeam } from './API/teamAPI';
-import { getAllShoutouts, getShoutouts, giveShoutout } from './API/shoutoutAPI';
+import { getAllShoutouts, getShoutouts, giveShoutout, hideShoutout } from './API/shoutoutAPI';
 import {
   allSignInForms,
   createSignInForm,
@@ -204,6 +204,10 @@ loginCheckedGet('/allShoutouts', async () => ({
 
 loginCheckedPost('/giveShoutout', async (req, user) => ({
   shoutout: await giveShoutout(req.body, user)
+}));
+
+loginCheckedPost('/hideShoutout', async (req, user) => ({
+  shoutout: await hideShoutout(req.body, user)
 }));
 
 // Permissions

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -207,7 +207,7 @@ loginCheckedPost('/giveShoutout', async (req, user) => ({
 }));
 
 loginCheckedPost('/hideShoutout', async (req, user) => ({
-  shoutout: await hideShoutout(req.body, user)
+  shoutout: await hideShoutout(req.body.uuid, user)
 }));
 
 // Permissions

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -24,7 +24,7 @@ import {
 } from './API/memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './API/imageAPI';
 import { allTeams, setTeam, deleteTeam } from './API/teamAPI';
-import { getAllShoutouts, getShoutouts, giveShoutout, hideShoutout } from './API/shoutoutAPI';
+import { getAllShoutouts, getShoutouts, giveShoutout, updateShoutout } from './API/shoutoutAPI';
 import {
   allSignInForms,
   createSignInForm,
@@ -206,8 +206,8 @@ loginCheckedPost('/giveShoutout', async (req, user) => ({
   shoutout: await giveShoutout(req.body, user)
 }));
 
-loginCheckedPost('/hideShoutout', async (req, user) => ({
-  shoutout: await hideShoutout(req.body, user)
+loginCheckedPost('/updateShoutout', async (req, user) => ({
+  shoutout: await updateShoutout(req.body, user)
 }));
 
 // Permissions

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -207,7 +207,7 @@ loginCheckedPost('/giveShoutout', async (req, user) => ({
 }));
 
 loginCheckedPost('/hideShoutout', async (req, user) => ({
-  shoutout: await hideShoutout(req.body.uuid, user)
+  shoutout: await hideShoutout(req.body, user)
 }));
 
 // Permissions

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -58,15 +58,27 @@ export default class ShoutoutsDao {
     return shoutout;
   }
 
+  static async getInstance(uuid: string): Promise<Shoutout> {
+    const doc = shoutoutCollection.doc(uuid);
+    const shoutout = await doc.get();
+    if (!shoutout.exists) throw new NotFoundError(`No shoutout '${uuid}' exists.`);
+
+    const data = shoutout.data() as DBShoutout;
+
+    const shoutoutRef: Shoutout = {
+      ...data,
+      giver: await getMemberFromDocumentReference(data.giver)
+    };
+
+    return shoutoutRef;
+  }
+
   static async hideShoutout(shoutout: Shoutout): Promise<Shoutout> {
-    const shoutoutDoc = shoutoutCollection.doc(shoutout.uuid);
-    const ref = await shoutoutDoc.get();
-    if (!ref.exists) throw new NotFoundError(`No shoutout '${shoutout.uuid}' exists.`);
     const shoutoutRef: DBShoutout = {
       ...shoutout,
       giver: memberCollection.doc(shoutout.giver.email)
     };
-    await shoutoutCollection.doc(shoutout.uuid).update(shoutoutRef);
+    await shoutoutCollection.doc(shoutout.uuid).set(shoutoutRef);
     return shoutout;
   }
 }

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -58,27 +58,15 @@ export default class ShoutoutsDao {
     return shoutout;
   }
 
-  static async getInstance(uuid: string): Promise<Shoutout> {
-    const doc = shoutoutCollection.doc(uuid);
-    const shoutout = await doc.get();
-    if (!shoutout.exists) throw new NotFoundError(`No shoutout '${uuid}' exists.`);
-
-    const data = shoutout.data() as DBShoutout;
-
-    const shoutoutRef: Shoutout = {
-      ...data,
-      giver: await getMemberFromDocumentReference(data.giver)
-    };
-
-    return shoutoutRef;
-  }
-
   static async hideShoutout(shoutout: Shoutout): Promise<Shoutout> {
+    const shoutoutDoc = shoutoutCollection.doc(shoutout.uuid);
+    const ref = await shoutoutDoc.get();
+    if (!ref.exists) throw new NotFoundError(`No shoutout '${shoutout.uuid}' exists.`);
     const shoutoutRef: DBShoutout = {
       ...shoutout,
       giver: memberCollection.doc(shoutout.giver.email)
     };
-    await shoutoutCollection.doc(shoutout.uuid).set(shoutoutRef);
+    await shoutoutCollection.doc(shoutout.uuid).update(shoutoutRef);
     return shoutout;
   }
 }

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -58,7 +58,7 @@ export default class ShoutoutsDao {
     return shoutout;
   }
 
-  static async hideShoutout(shoutout: Shoutout): Promise<Shoutout> {
+  static async updateShoutout(shoutout: Shoutout): Promise<Shoutout> {
     const shoutoutDoc = shoutoutCollection.doc(shoutout.uuid);
     const ref = await shoutoutDoc.get();
     if (!ref.exists) throw new NotFoundError(`No shoutout '${shoutout.uuid}' exists.`);

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -14,6 +14,8 @@ export type DBShoutout = {
   message: string;
   isAnon: boolean;
   timestamp: number;
+  hidden: boolean;
+  uuid: string;
 };
 
 export type Shoutout = {
@@ -22,6 +24,8 @@ export type Shoutout = {
   message: string;
   isAnon: boolean;
   timestamp: number;
+  hidden: boolean;
+  uuid: string;
 };
 
 export type DBSignInForm = {

--- a/backend/src/utils/permissionsManager.ts
+++ b/backend/src/utils/permissionsManager.ts
@@ -25,6 +25,10 @@ export default class PermissionsManager {
     return this.isLeadOrAdmin(mem);
   }
 
+  static async canHideShoutouts(mem: IdolMember): Promise<boolean> {
+    return this.isLeadOrAdmin(mem);
+  }
+
   static async canEditTeamEvent(mem: IdolMember): Promise<boolean> {
     return this.isLeadOrAdmin(mem);
   }

--- a/backend/tests/ShoutoutsDao.test.ts
+++ b/backend/tests/ShoutoutsDao.test.ts
@@ -51,6 +51,6 @@ test('Get sent shoutout', async () => {
 });
 
 test('Hide shoutout', async () => {
-  const hiddenShoutout = await ShoutoutsDao.hideShoutout(mockShoutout1);
+  const hiddenShoutout = await ShoutoutsDao.updateShoutout(mockShoutout1);
   expect(hiddenShoutout.hidden === true);
 });

--- a/backend/tests/ShoutoutsDao.test.ts
+++ b/backend/tests/ShoutoutsDao.test.ts
@@ -12,7 +12,9 @@ const mockShoutout1 = {
   receiver: 'Fake Idol Member',
   message: 'Mock Shoutout',
   isAnon: false,
-  timestamp: Date.now()
+  timestamp: Date.now(),
+  hidden: false,
+  uuid: 'xyz'
 };
 
 /* Adding mock users for testing sign-ins */
@@ -46,4 +48,9 @@ test('Send shoutout', async () => {
 test('Get sent shoutout', async () => {
   const shoutoutsSent = await ShoutoutsDao.getShoutouts(shoutoutData.mu1.email, 'given');
   expect(shoutoutsSent).toContainEqual(mockShoutout1);
+});
+
+test('Hide shoutout', async () => {
+  const hiddenShoutout = await ShoutoutsDao.hideShoutout(mockShoutout1);
+  expect(hiddenShoutout.hidden === true);
 });

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -55,10 +55,7 @@ export class ShoutoutsAPI {
     return APIWrapper.post(`${backendURL}/giveShoutout`, shoutout).then((res) => res.data);
   }
 
-  public static hideShoutout(uuid: string): Promise<ShoutoutResponseObj> {
-    return APIWrapper.post(`${backendURL}/hideShoutout`, uuid).then((res) => {
-      console.log(res);
-      return res.data;
-    });
+  public static hideShoutout(shoutout: Shoutout): Promise<ShoutoutResponseObj> {
+    return APIWrapper.post(`${backendURL}/hideShoutout`, shoutout).then((res) => res.data);
   }
 }

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -55,7 +55,10 @@ export class ShoutoutsAPI {
     return APIWrapper.post(`${backendURL}/giveShoutout`, shoutout).then((res) => res.data);
   }
 
-  public static hideShoutout(shoutout: Shoutout): Promise<ShoutoutResponseObj> {
-    return APIWrapper.post(`${backendURL}/hideShoutout`, shoutout).then((res) => res.data);
+  public static hideShoutout(uuid: string): Promise<ShoutoutResponseObj> {
+    return APIWrapper.post(`${backendURL}/hideShoutout`, uuid).then((res) => {
+      console.log(res);
+      return res.data;
+    });
   }
 }

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -9,6 +9,8 @@ export type Shoutout = {
   message: string;
   isAnon: boolean;
   timestamp: number;
+  hidden: boolean;
+  uuid: string;
 };
 
 type ShoutoutResponseObj = {
@@ -51,5 +53,9 @@ export class ShoutoutsAPI {
 
   public static giveShoutout(shoutout: Shoutout): Promise<ShoutoutResponseObj> {
     return APIWrapper.post(`${backendURL}/giveShoutout`, shoutout).then((res) => res.data);
+  }
+
+  public static hideShoutout(shoutout: Shoutout): Promise<ShoutoutResponseObj> {
+    return APIWrapper.post(`${backendURL}/hideShoutout`, shoutout).then((res) => res.data);
   }
 }

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -55,7 +55,7 @@ export class ShoutoutsAPI {
     return APIWrapper.post(`${backendURL}/giveShoutout`, shoutout).then((res) => res.data);
   }
 
-  public static hideShoutout(shoutout: Shoutout): Promise<ShoutoutResponseObj> {
-    return APIWrapper.post(`${backendURL}/hideShoutout`, shoutout).then((res) => res.data);
+  public static updateShoutout(shoutout: Shoutout): Promise<ShoutoutResponseObj> {
+    return APIWrapper.post(`${backendURL}/updateShoutout`, shoutout).then((res) => res.data);
   }
 }

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
@@ -17,7 +17,7 @@
 }
 
 .noShoutoutsContainer {
-  width: 100% !important;
+  width: 100%;
   white-space: pre-wrap;
 }
 

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
@@ -42,7 +42,22 @@
 .shoutoutFrom {
   color: gray;
   display: inline-block;
+  margin-top: 0 !important;
   align-self: left;
+}
+
+.shoutoutHide {
+  display: flex;
+  justify-content: space-between !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+.shoutoutMessage {
+  color: black;
+  font-weight: bold;
+  margin-top: 0 !important;
+  font-size: 15px !important;
 }
 
 .Wrapper {

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
@@ -1,5 +1,5 @@
 .shoutoutForm {
-  width: 90% !important;
+  width: 90%;
   align-self: center;
   margin: auto;
   padding-top: 10vh;
@@ -17,13 +17,13 @@
 }
 
 .noShoutoutsContainer {
-  width: 100% !important;
+  width: 100%;
   white-space: pre-wrap;
 }
 
 .shoutoutDetails {
   display: flex;
-  justify-content: space-between !important;
+  justify-content: space-between;
   margin-bottom: 0 !important;
 }
 
@@ -35,7 +35,7 @@
 
 .shoutoutDate {
   color: gray;
-  display: inline-block !important;
+  display: inline-block;
   justify-content: right;
 }
 
@@ -48,7 +48,7 @@
 
 .shoutoutHide {
   display: flex;
-  justify-content: space-between !important;
+  justify-content: space-between;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
 }

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
@@ -17,7 +17,7 @@
 }
 
 .noShoutoutsContainer {
-  width: 100%;
+  width: 100% !important;
   white-space: pre-wrap;
 }
 

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -63,7 +63,7 @@ const AdminShoutouts: React.FC = () => {
   const onHide = (shoutout: Shoutout) => {
     if (!shoutout.hidden) {
       setHide(true);
-      ShoutoutsAPI.hideShoutout({ ...shoutout, hidden: true }).then(() => {
+      ShoutoutsAPI.updateShoutout({ ...shoutout, hidden: true }).then(() => {
         Emitters.generalSuccess.emit({
           headerMsg: 'Shoutout Hidden',
           contentMsg: 'This shoutout was successfully hidden.'
@@ -110,7 +110,7 @@ const AdminShoutouts: React.FC = () => {
                         actions={[
                           'Cancel',
                           {
-                            key: 'hideShoutout',
+                            key: 'updateShoutout',
                             content: 'Hide Shoutout',
                             color: 'red',
                             onClick: () => onHide(shoutout)

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -63,7 +63,7 @@ const AdminShoutouts: React.FC = () => {
   const onHide = (shoutout: Shoutout) => {
     if (!shoutout.hidden) {
       setHide(true);
-      ShoutoutsAPI.hideShoutout({ ...shoutout, hidden: true }).then(() => {
+      ShoutoutsAPI.hideShoutout(shoutout.uuid).then(() => {
         Emitters.generalSuccess.emit({
           headerMsg: 'Shoutout Hidden',
           contentMsg: 'This shoutout was successfully hidden.'

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -63,7 +63,7 @@ const AdminShoutouts: React.FC = () => {
   const onHide = (shoutout: Shoutout) => {
     if (!shoutout.hidden) {
       setHide(true);
-      ShoutoutsAPI.hideShoutout(shoutout.uuid).then(() => {
+      ShoutoutsAPI.hideShoutout({ ...shoutout, hidden: true }).then(() => {
         Emitters.generalSuccess.emit({
           headerMsg: 'Shoutout Hidden',
           contentMsg: 'This shoutout was successfully hidden.'

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -30,7 +30,9 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
         receiver,
         message,
         isAnon,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        hidden: false,
+        uuid: ''
       };
       ShoutoutsAPI.giveShoutout(shoutout).then((val) => {
         if (val.error) {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request is the first step towards implementing hiding shoutouts in the admin view. 

- [x] added `hidden` field to Shoutouts type
- [x] added `uuid` field to Shoutouts type
- [x] implemented admin being able to hide a specific shoutout and confirmation modal
- [x] dynamically updated shoutouts list in admin view to hide chosen shoutout 
- [x] change hidden field in backend so shoutout remains hidden for other admins/future use 

### Test Plan <!-- Required -->

Manually tested using dev environment. Also added Dao test to test `hideShoutout()` endpoint.

### Notion Link

https://www.notion.so/cornelldti/Idol-FA22-5a158866a8a1472c98b1f3c042b480f8?p=d932c4d29e014f0481afb3016bcdeb39&pm=s

### Future

Next step will be to add 3-part button to toggle between hidden, unhidden, and all shoutouts. 