### PR TITLE
Fix bug with anonymous shoutouts

### DIFF
--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -47,7 +47,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
           });
           setReceiver('');
           setMessage('');
-          setIsAnon(false);
+          setIsAnon(true);
           getGivenShoutouts();
         }
       });
@@ -67,7 +67,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
         <Checkbox
           label={{ children: 'Anonymous?' }}
           className={styles.isAnonCheckbox}
-          defaultChecked
+          checked={isAnon}
           onChange={() => setIsAnon(!isAnon)}
         />
       </div>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR resets the form to be anonymous by default after submitting, and makes the checkbox in sync with whether the shoutout is anonymous or not.

### Test Plan
Try submitting 2 anonymous shoutouts in a row, then uncheck the box to send a non anonymous one
