### PR TITLE
Refactor hiding shoutouts backend

### DIFF
--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -1,5 +1,5 @@
 import PermissionsManager from '../utils/permissionsManager';
-import { PermissionError } from '../utils/errors';
+import { NotFoundError, PermissionError } from '../utils/errors';
 import { Shoutout } from '../types/DataTypes';
 import ShoutoutsDao from '../dao/ShoutoutsDao';
 
@@ -28,13 +28,14 @@ export const getShoutouts = async (
   return ShoutoutsDao.getShoutouts(memberEmail, type);
 };
 
-export const updateShoutout = async (body: Shoutout, user: IdolMember): Promise<Shoutout> => {
+export const hideShoutout = async (uuid: string, user: IdolMember): Promise<void> => {
   const canEdit = await PermissionsManager.canHideShoutouts(user);
   if (!canEdit) {
     throw new PermissionError(
       `User with email: ${user.email} does not have permission to hide shoutouts!`
     );
   }
-  await ShoutoutsDao.updateShoutout(body);
-  return body;
+  const shoutout = await ShoutoutsDao.getShoutout(uuid);
+  if (!shoutout) throw new NotFoundError(`Shoutout with uuid: ${uuid} does not exist!`);
+  await ShoutoutsDao.updateShoutout({ ...shoutout, hidden: true });
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -24,7 +24,7 @@ import {
 } from './API/memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './API/imageAPI';
 import { allTeams, setTeam, deleteTeam } from './API/teamAPI';
-import { getAllShoutouts, getShoutouts, giveShoutout, updateShoutout } from './API/shoutoutAPI';
+import { getAllShoutouts, getShoutouts, giveShoutout, hideShoutout } from './API/shoutoutAPI';
 import {
   allSignInForms,
   createSignInForm,
@@ -213,9 +213,10 @@ loginCheckedPost('/giveShoutout', async (req, user) => ({
   shoutout: await giveShoutout(req.body, user)
 }));
 
-loginCheckedPost('/updateShoutout', async (req, user) => ({
-  shoutout: await updateShoutout(req.body, user)
-}));
+loginCheckedPost('/hideShoutout', async (req, user) => {
+  await hideShoutout(req.body.uuid, user);
+  return {};
+});
 
 // Permissions
 loginCheckedGet('/isAdmin', async (_, user) => ({

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -40,6 +40,16 @@ export default class ShoutoutsDao {
     );
   }
 
+  static async getShoutout(uuid: string): Promise<Shoutout | undefined> {
+    const doc = await shoutoutCollection.doc(uuid).get();
+    const dbShoutout = doc.data();
+    if (!dbShoutout) return undefined;
+    return {
+      ...dbShoutout,
+      giver: await getMemberFromDocumentReference(dbShoutout.giver)
+    };
+  }
+
   static async setShoutout(shoutout: {
     giver: IdolMember;
     receiver: string;

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -55,7 +55,7 @@ export class ShoutoutsAPI {
     return APIWrapper.post(`${backendURL}/giveShoutout`, shoutout).then((res) => res.data);
   }
 
-  public static updateShoutout(shoutout: Shoutout): Promise<ShoutoutResponseObj> {
-    return APIWrapper.post(`${backendURL}/updateShoutout`, shoutout).then((res) => res.data);
+  public static hideShoutout(uuid: string): Promise<void> {
+    return APIWrapper.post(`${backendURL}/hideShoutout`, { uuid }).then((res) => res.data);
   }
 }

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -63,11 +63,17 @@ const AdminShoutouts: React.FC = () => {
   const onHide = (shoutout: Shoutout) => {
     if (!shoutout.hidden) {
       setHide(true);
-      ShoutoutsAPI.updateShoutout({ ...shoutout, hidden: true }).then(() => {
+      ShoutoutsAPI.hideShoutout(shoutout.uuid).then(() => {
         Emitters.generalSuccess.emit({
           headerMsg: 'Shoutout Hidden',
           contentMsg: 'This shoutout was successfully hidden.'
         });
+        setDisplayShoutouts((shoutouts) =>
+          shoutouts.map((val) => {
+            if (val.uuid === shoutout.uuid) return { ...val, hidden: true };
+            return val;
+          })
+        );
       });
     }
   };
@@ -110,7 +116,7 @@ const AdminShoutouts: React.FC = () => {
                         actions={[
                           'Cancel',
                           {
-                            key: 'updateShoutout',
+                            key: 'hideShoutouts',
                             content: 'Hide Shoutout',
                             color: 'red',
                             onClick: () => onHide(shoutout)


### PR DESCRIPTION
### Summary <!-- Required -->
This PR refactors the backend for hiding shoutouts. Hiding a shoutout is now handled through `hideShoutout` in the API layer which only uses the shoutout's uuid. This makes it possible to create a separate `updateShoutout` endpoint if we ever wanted to grant users the ability to edit existing shoutouts. 

### Notion/Figma Link <!-- Optional -->

N/A
### Test Plan <!-- Required -->
Should be able to hide shoutouts without any issue

### Notes
Is there supposed to be a way to unhide shoutouts from UI/is this a planned feature? 