### PR TITLE
Add loading indicators on TEC admin-side 

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Message, Modal, Button } from 'semantic-ui-react';
+import { Card, Message, Modal, Button, Loader } from 'semantic-ui-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import EditTeamEvent from './EditTeamEvent';
@@ -16,6 +16,46 @@ const defaultTeamEvent: TeamEvent = {
   requests: [],
   attendees: [],
   uuid: ''
+};
+
+type AttendanceDisplayProps = {
+  isPending: boolean;
+  teamEvent: TeamEvent;
+};
+
+const AttendanceDisplay: React.FC<AttendanceDisplayProps> = ({ isPending, teamEvent }) => {
+  const attendance = isPending ? teamEvent.requests : teamEvent.attendees;
+
+  return (
+    <>
+      {attendance && attendance.length !== 0 ? (
+        <Card.Group>
+          {attendance.map((req, i) => (
+            <Card className={styles.memberCard} key={i}>
+              <Card.Content>
+                <Card.Header>
+                  {req.member.firstName} {req.member.lastName}
+                </Card.Header>
+                <Card.Meta>{req.member.email}</Card.Meta>
+              </Card.Content>
+              {isPending && (
+                <Card.Content extra>
+                  <TeamEventCreditReview
+                    teamEvent={teamEvent}
+                    teamEventAttendance={req}
+                  ></TeamEventCreditReview>
+                </Card.Content>
+              )}
+            </Card>
+          ))}
+        </Card.Group>
+      ) : (
+        <Message>
+          There are currently no {isPending ? 'pending' : 'approved'} members for this event.
+        </Message>
+      )}
+    </>
+  );
 };
 
 const TeamEventDetails: React.FC = () => {
@@ -41,8 +81,10 @@ const TeamEventDetails: React.FC = () => {
 
   useEffect(() => {
     if (isLoading) {
-      TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => setTeamEvent(teamEvent));
-      setLoading(false);
+      TeamEventsAPI.getTeamEventForm(uuid).then((teamEvent) => {
+        setTeamEvent(teamEvent);
+        setLoading(false);
+      });
     }
   }, [isLoading, uuid]);
 
@@ -55,6 +97,8 @@ const TeamEventDetails: React.FC = () => {
     });
     location.push('/admin/team-events');
   };
+
+  if (isLoading) return <Loader active />;
 
   return (
     <div className={styles.container}>
@@ -92,49 +136,13 @@ const TeamEventDetails: React.FC = () => {
         <div className={styles.listContainer}>
           <h2 className={styles.memberTitle}>Members Pending</h2>
 
-          {teamEvent.requests.length > 0 ? (
-            <Card.Group>
-              {teamEvent.requests.map((req, i) => (
-                <Card className={styles.memberCard} key={i}>
-                  <Card.Content>
-                    <Card.Header>
-                      {req.member.firstName} {req.member.lastName}
-                    </Card.Header>
-                    <Card.Meta>{req.member.email}</Card.Meta>
-                  </Card.Content>
-                  <Card.Content extra>
-                    <TeamEventCreditReview
-                      teamEvent={teamEvent}
-                      teamEventAttendance={req}
-                    ></TeamEventCreditReview>
-                  </Card.Content>
-                </Card>
-              ))}
-            </Card.Group>
-          ) : (
-            <Message>There are currently no pending members for this event.</Message>
-          )}
+          <AttendanceDisplay isPending={true} teamEvent={teamEvent} />
         </div>
 
         <div className={styles.listContainer}>
           <h2 className={styles.memberTitle}>Members Approved</h2>
 
-          {teamEvent.attendees.length > 0 ? (
-            <Card.Group className={styles.memberGroup}>
-              {teamEvent.attendees.map((req) => (
-                <Card key={req.member.netid}>
-                  <Card.Content>
-                    <Card.Header>
-                      {req.member.firstName} {req.member.lastName}
-                    </Card.Header>
-                    <Card.Meta>{req.member.email}</Card.Meta>
-                  </Card.Content>
-                </Card>
-              ))}
-            </Card.Group>
-          ) : (
-            <Message>There are currently no approved members for this event.</Message>
-          )}
+          <AttendanceDisplay isPending={false} teamEvent={teamEvent} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -1,11 +1,41 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Message } from 'semantic-ui-react';
+import { Card, Message, Loader } from 'semantic-ui-react';
 import Link from 'next/link';
 import TeamEventForm from './TeamEventForm';
 import styles from './TeamEvents.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters } from '../../../utils';
 import ClearTeamEventsModal from '../../Modals/ClearTeamEventsModal';
+
+type TeamEventsDisplayProps = {
+  isLoading: boolean;
+  teamEvents: TeamEvent[];
+};
+
+const TeamEventsDisplay: React.FC<TeamEventsDisplayProps> = ({ isLoading, teamEvents }) => {
+  if (isLoading) return <Loader active inline />;
+  return (
+    <>
+      {teamEvents && teamEvents.length !== 0 ? (
+        <Card.Group>
+          {teamEvents.map((teamEvent) => (
+            <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
+              <Card>
+                <Card.Content>
+                  <Card.Header>{teamEvent.name} </Card.Header>
+                  <Card.Meta>{teamEvent.date}</Card.Meta>
+                  <Card.Meta>{teamEvent.requests.length} pending requests</Card.Meta>
+                </Card.Content>
+              </Card>
+            </Link>
+          ))}
+        </Card.Group>
+      ) : (
+        <Message>There are currently no team event forms.</Message>
+      )}
+    </>
+  );
+};
 
 const TeamEvents: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
@@ -44,23 +74,7 @@ const TeamEvents: React.FC = () => {
       <div className={styles.wrapper}>
         <div>
           <h2>View All Team Events</h2>
-          {teamEvents.length !== 0 ? (
-            <Card.Group>
-              {teamEvents.map((teamEvent) => (
-                <Link key={teamEvent.uuid} href={`/admin/team-event-details/${teamEvent.uuid}`}>
-                  <Card>
-                    <Card.Content>
-                      <Card.Header>{teamEvent.name} </Card.Header>
-                      <Card.Meta>{teamEvent.date}</Card.Meta>
-                      <Card.Meta>{teamEvent.requests.length} pending requests</Card.Meta>
-                    </Card.Content>
-                  </Card>
-                </Link>
-              ))}
-            </Card.Group>
-          ) : (
-            <Message>There are currently no team event forms.</Message>
-          )}
+          <TeamEventsDisplay isLoading={isLoading} teamEvents={teamEvents} />
         </div>
         <div className={styles.resetButtonContainer}>
           <ClearTeamEventsModal setTeamEvents={setTeamEvents} />


### PR DESCRIPTION
### Summary <!-- Required -->

Added loading indicators on admin TEC dashboard and TEC details page to indicate that data is still loading when fetching from the backend. 
- `/admin/team-events` 
- `/admin/team-events/<uuid>`


### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Admin-TEC-form-loading-indicator-a288d04dc48a4fdb82d62a25ce297932)
### Test Plan <!-- Required -->
Loading indicator should appear when fetching from the backend. Some version of "No results" should still be displayed if the data is empty after fetching from the backend. 