### PR TITLE
fix bug to allow 0.5 credit team events to be created

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
@@ -34,7 +34,7 @@ const TeamEventForm = (props: Props): JSX.Element => {
       !teamEventCreditNum ||
       teamEventCreditNum === '' ||
       isNaN(Number(teamEventCreditNum)) ||
-      Number(teamEventCreditNum) < 1
+      Number(teamEventCreditNum) < 0.5
     ) {
       Emitters.generalError.emit({
         headerMsg: 'No Team Event Credit Amount',


### PR DESCRIPTION
### Summary <!-- Required -->
Fixes bug that prevented 0.5 credit team events from being created 

### Notion/Figma Link <!-- Optional -->
[Notion link](https://www.notion.so/cornelldti/TEC-Bug-Can-t-set-event-credits-amount-to-0-5-63dbafe26c504e1499ab7f3691c18901)

### Test Plan <!-- Required -->
Should be able to create a 0.5 credit team event 