### PR TITLE
Add backend support for sign-in form questions

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -31,7 +31,8 @@ import {
   deleteSignInForm,
   signIn,
   signInFormExists,
-  signInFormExpired
+  signInFormExpired,
+  getSignInPrompt
 } from './API/signInFormAPI';
 import {
   createTeamEvent,
@@ -237,14 +238,17 @@ loginCheckedPost('/signInExpired', async (req, _) => ({
   expired: await signInFormExpired(req.body.id)
 }));
 loginCheckedPost('/signInCreate', async (req, user) =>
-  createSignInForm(req.body.id, req.body.expireAt, user)
+  createSignInForm(req.body.id, req.body.expireAt, req.body.prompt, user)
 );
 loginCheckedPost('/signInDelete', async (req, user) => {
   await deleteSignInForm(req.body.id, user);
   return {};
 });
-loginCheckedPost('/signIn', async (req, user) => signIn(req.body.id, user));
+loginCheckedPost('/signIn', async (req, user) => signIn(req.body.id, req.body.response, user));
 loginCheckedPost('/signInAll', async (_, user) => allSignInForms(user));
+loginCheckedGet('/signInPrompt/:id', async (req, _) => ({
+  prompt: await getSignInPrompt(req.params.id)
+}));
 
 // Team Events
 loginCheckedPost('/createTeamEvent', async (req, user) => createTeamEvent(req.body, user));

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -28,18 +28,18 @@ export type Shoutout = {
   uuid: string;
 };
 
-export type DBSignInForm = {
-  users: { signedInAt: number; user: firestore.DocumentReference }[];
-  createdAt: number;
-  expireAt: number;
-  id: string;
+export type DBSignInFormResponse = {
+  signedInAt: number;
+  user: firestore.DocumentReference;
+  response: string | null;
 };
 
-export type SignInForm = {
-  users: { signedInAt: number; user: IdolMember }[];
+export type DBSignInForm = {
+  users: DBSignInFormResponse[];
   createdAt: number;
   expireAt: number;
   id: string;
+  prompt: string | null;
 };
 
 export type DBTeamEventAttendance = {

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -66,14 +66,18 @@ interface ProfileImage {
   readonly fileName: string;
 }
 
+interface SignInResponse {
+  readonly signedInAt: number;
+  readonly user: IdolMember;
+  readonly response?: string;
+}
+
 interface SignInForm {
-  readonly users: readonly {
-    readonly signedInAt: number;
-    readonly user: IdolMember;
-  }[];
+  readonly users: SignInResponse[];
   readonly createdAt: number;
   readonly id: string;
   readonly expireAt: number;
+  readonly prompt?: string;
 }
 
 interface TeamEventAttendance {


### PR DESCRIPTION
### Summary <!-- Required -->
This PR is a step towards adding optional questions to sign-in forms. It adds backend support to make it possible to create sign-in forms with an optional prompt and to require sign-in requests to have a response to the prompt if the form has a prompt. 

### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Sign-in-Option-for-Adding-Questions-692bec37614d48a39b3d51982acc8858) (doesn't close this ticket) 
### Test Plan <!-- Required -->

There isn't really a good way to test this at the moment... But check the deploy preview to ensure that the user-facing functionality hasn't broken. The sign-in backend is missing a test suite ;~;. Might be worth it to add a test suite for sign-in feature in the future. 