### PR TITLE
Add backend validation for creating new dev portfolio 

### DIFF
--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -42,7 +42,15 @@ export const createNewDevPortfolio = async (
       `User with email: ${user.email} does not have permission to create dev portfolio!`
     );
   }
-
+  if (
+    !instance.name ||
+    instance.name.length === 0 ||
+    instance.deadline < instance.earliestValidDate ||
+    (instance.lateDeadline && instance.lateDeadline < instance.deadline)
+  )
+    throw new BadRequestError(
+      `Unable to create the new dev portfolio instance: The provided dev portfolio is invalid.`
+    );
   const updatedDeadline = new Date(instance.deadline);
   const updatedEarliestValidDate = new Date(instance.earliestValidDate);
   const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : null;

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -123,6 +123,38 @@ describe('User is lead or admin', () => {
     );
   });
 
+  describe('test createNewDevPortfolio validation', () => {
+    test('name validation', () => {
+      const dp = fakeDevPortfolio();
+      dp.name = '';
+      expect(createNewDevPortfolio(dp, user)).rejects.toThrow(
+        new BadRequestError(
+          `Unable to create the new dev portfolio instance: The provided dev portfolio is invalid.`
+        )
+      );
+    });
+
+    test('deadline and earliestValidDate validation', () => {
+      const dp = fakeDevPortfolio();
+      dp.earliestValidDate = dp.deadline + 52;
+      expect(createNewDevPortfolio(dp, user)).rejects.toThrow(
+        new BadRequestError(
+          `Unable to create the new dev portfolio instance: The provided dev portfolio is invalid.`
+        )
+      );
+    });
+
+    test('deadline and late deadline validateion', () => {
+      const dp = fakeDevPortfolio();
+      dp.lateDeadline = dp.deadline - 52;
+      expect(createNewDevPortfolio(dp, user)).rejects.toThrow(
+        new BadRequestError(
+          `Unable to create the new dev portfolio instance: The provided dev portfolio is invalid.`
+        )
+      );
+    });
+  });
+
   test('deleteDevPortfolio should be successful', async () => {
     await deleteDevPortfolio(devPortfolio.uuid, user);
     expect(PermissionsManager.isLeadOrAdmin).toBeCalled();


### PR DESCRIPTION
### Summary <!-- Required -->
Add validation in `createNewDevPortfolio` to validate the new dev portfolio's name, earliestValidDate, deadline, and lateDeadline. 

### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/DP-Admin-Add-validation-for-creating-new-DP-assignment-1958f66c24254272a93fbdda0c7fe5a6)
### Test Plan <!-- Required -->
Added tests to verify that the validation works 