### PR TITLE
Add message and sign out button if signed in user is not idol user

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -153,6 +153,12 @@ router.get('/allApprovedMembers', async (_, res) => {
 router.get('/membersFromAllSemesters', async (_, res) => {
   res.status(200).json(await MembersDao.getMembersFromAllSemesters());
 });
+router.get('/isIDOLMember/:email', async (req, res) => {
+  const members = await allMembers();
+  res.status(200).json({
+    isIDOLMember: members.find((member) => member.email === req.params.email) !== undefined
+  });
+});
 
 router.get('/info', async (req, res) => {
   res.json({

--- a/frontend/src/API/MembersAPI.ts
+++ b/frontend/src/API/MembersAPI.ts
@@ -24,4 +24,10 @@ export class MembersAPI {
   public static updateMember(member: Member): Promise<MemberResponseObj> {
     return APIWrapper.post(`${backendURL}/updateMember`, member).then((res) => res.data);
   }
+
+  public static isIDOLMember(email: string): Promise<boolean> {
+    return APIWrapper.get(`${backendURL}/isIDOLMember/${email}`).then(
+      (res) => res.data.isIDOLMember
+    );
+  }
 }

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -1,4 +1,4 @@
-import { Loader, Button, Modal, Header } from 'semantic-ui-react';
+import { Loader, Modal } from 'semantic-ui-react';
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import { onSnapshot } from 'firebase/firestore';
 import {

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -1,10 +1,16 @@
-import { Loader } from 'semantic-ui-react';
+import { Loader, Button } from 'semantic-ui-react';
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import { onSnapshot } from 'firebase/firestore';
-import { adminsCollection, membersCollection, approvedMembersCollection } from '../../firebase';
+import {
+  adminsCollection,
+  membersCollection,
+  approvedMembersCollection,
+  auth
+} from '../../firebase';
 import { useUserEmail } from './UserProvider/UserProvider';
 import { Team } from '../../API/TeamsAPI';
 import { allowAdmin } from '../../environment';
+import { MembersAPI } from '../../API/MembersAPI';
 
 type ListenedFirestoreData = {
   readonly adminEmails?: readonly string[];
@@ -82,6 +88,9 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
   const [adminEmails, setAdminEmails] = useState<readonly string[] | undefined>();
   const [members, setMembers] = useState<readonly IdolMember[] | undefined>();
   const [approvedMembers, setApprovedMembers] = useState<readonly IdolMember[] | undefined>();
+  const [isIDOLMember, setIsIDOLMember] = useState(true);
+
+  const userEmail = useUserEmail();
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'test') {
@@ -89,6 +98,7 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
         // Do not run firestore listeners in test environment.
       };
     }
+    MembersAPI.isIDOLMember(userEmail).then((isIDOLMember) => setIsIDOLMember(isIDOLMember));
     const unsubscriberOfAdminEmails = onSnapshot(adminsCollection, (snapshot) => {
       setAdminEmails(snapshot.docs.map((it) => it.id));
     });
@@ -103,7 +113,7 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
       unsubscriberOfMembers();
       unsubscriberOfApprovedMembers();
     };
-  }, []);
+  }, [userEmail]);
 
   return (
     <FirestoreDataContext.Provider value={{ adminEmails, members, approvedMembers }}>
@@ -112,7 +122,37 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
         process.env.NODE_ENV === 'test' && children
       }
       {adminEmails == null || members == null || approvedMembers == null ? (
-        <Loader active={true} size="massive" />
+        <div style={{ marginTop: '45%' }}>
+          <Loader style={{ fontSize: 12 }} active size="massive"></Loader>
+          {!isIDOLMember && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'flex-start',
+                padding: '0 15%'
+              }}
+            >
+              You do not appear to be registered as a user within the IDOL system. Only DTI members
+              should have access to this site. If you are a DTI member, please make sure that you
+              are logged in with your @cornell.edu email address. If you are logged in with your
+              @cornell.edu email address and are still seeing this message, please use the
+              #idol-support channel in Slack to get in touch with the IDOL team and receive
+              assistance.
+              <Button
+                style={{
+                  marginTop: '30px',
+                  marginLeft: 'auto',
+                  marginRight: 'auto',
+                  width: '150px'
+                }}
+                onClick={() => auth.signOut()}
+              >
+                Sign Out
+              </Button>
+            </div>
+          )}
+        </div>
       ) : (
         children
       )}

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -1,4 +1,4 @@
-import { Loader, Button } from 'semantic-ui-react';
+import { Loader, Button, Modal, Header } from 'semantic-ui-react';
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import { onSnapshot } from 'firebase/firestore';
 import {
@@ -122,35 +122,20 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
         process.env.NODE_ENV === 'test' && children
       }
       {adminEmails == null || members == null || approvedMembers == null ? (
-        <div style={{ marginTop: '45%' }}>
-          <Loader style={{ fontSize: 12 }} active size="massive"></Loader>
+        <div>
+          <Loader active size="massive" />
           {!isIDOLMember && (
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'flex-start',
-                padding: '0 15%'
-              }}
-            >
-              You do not appear to be registered as a user within the IDOL system. Only DTI members
-              should have access to this site. If you are a DTI member, please make sure that you
-              are logged in with your @cornell.edu email address. If you are logged in with your
-              @cornell.edu email address and are still seeing this message, please use the
-              #idol-support channel in Slack to get in touch with the IDOL team and receive
-              assistance.
-              <Button
-                style={{
-                  marginTop: '30px',
-                  marginLeft: 'auto',
-                  marginRight: 'auto',
-                  width: '150px'
-                }}
-                onClick={() => auth.signOut()}
-              >
-                Sign Out
-              </Button>
-            </div>
+            <Modal
+              basic
+              open={!isIDOLMember}
+              header="Hey there :)"
+              content="You do not appear to be registered as a user within the IDOL system. Only DTI members should
+            have access to this site. If you are a DTI member, please make sure that you are logged in
+            with your @cornell.edu email address. If you are logged in with your @cornell.edu email
+            address and are still seeing this message, please use the #idol-support channel in Slack to
+            get in touch with the IDOL team and receive assistance."
+              actions={[{ key: 'sign-out', content: 'Sign out', onClick: () => auth.signOut() }]}
+            />
           )}
         </div>
       ) : (


### PR DESCRIPTION
### Summary <!-- Required -->
Add a message when a user that logs in is not registered as IDOL member. Also add a sign out button to allow users to logout in case the user accidentally logged in with a different email address. 

<img width="931" alt="image" src="https://user-images.githubusercontent.com/65922473/202599669-9f74eace-3894-45a4-96d0-f04da5900bbd.png">

### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Frontend-Gracefully-handle-login-for-non-members-a971c61611f64db5814aeae2b1e8b7b9)
### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
- Login with non @cornell.edu email address -- the error message and sign out button should appear. 
    - Sign out button should log you out 
- Login with your @cornell.edu email address -- the error message should not appear 
