### PR TITLE
add three view button for admin shoutouts view

### DIFF
--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -28,7 +28,11 @@ export const getShoutouts = async (
   return ShoutoutsDao.getShoutouts(memberEmail, type);
 };
 
-export const hideShoutout = async (uuid: string, user: IdolMember): Promise<void> => {
+export const hideShoutout = async (
+  uuid: string,
+  hide: boolean,
+  user: IdolMember
+): Promise<void> => {
   const canEdit = await PermissionsManager.canHideShoutouts(user);
   if (!canEdit) {
     throw new PermissionError(
@@ -37,5 +41,5 @@ export const hideShoutout = async (uuid: string, user: IdolMember): Promise<void
   }
   const shoutout = await ShoutoutsDao.getShoutout(uuid);
   if (!shoutout) throw new NotFoundError(`Shoutout with uuid: ${uuid} does not exist!`);
-  await ShoutoutsDao.updateShoutout({ ...shoutout, hidden: true });
+  await ShoutoutsDao.updateShoutout({ ...shoutout, hidden: hide });
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -214,7 +214,7 @@ loginCheckedPost('/giveShoutout', async (req, user) => ({
 }));
 
 loginCheckedPost('/hideShoutout', async (req, user) => {
-  await hideShoutout(req.body.uuid, user);
+  await hideShoutout(req.body.uuid, req.body.hide, user);
   return {};
 });
 

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -55,7 +55,7 @@ export class ShoutoutsAPI {
     return APIWrapper.post(`${backendURL}/giveShoutout`, shoutout).then((res) => res.data);
   }
 
-  public static hideShoutout(uuid: string): Promise<void> {
-    return APIWrapper.post(`${backendURL}/hideShoutout`, { uuid }).then((res) => res.data);
+  public static hideShoutout(uuid: string, hide: boolean): Promise<void> {
+    return APIWrapper.post(`${backendURL}/hideShoutout`, { uuid, hide }).then((res) => res.data);
   }
 }

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.module.css
@@ -3,11 +3,17 @@
   align-self: center;
   margin: auto;
   padding-top: 10vh;
-  padding-bottom: 5vh;
+  padding-bottom: 3vh;
 }
 
 .formTitle {
   margin-bottom: 2vh;
+  text-decoration-line: underline;
+}
+
+.buttonGroup {
+  padding-left: 5%;
+  padding-bottom: 3vh;
 }
 
 .shoutoutsListContainer {
@@ -17,7 +23,7 @@
 }
 
 .noShoutoutsContainer {
-  width: 100%;
+  width: 100% !important;
   white-space: pre-wrap;
 }
 
@@ -28,9 +34,12 @@
 }
 
 .shoutoutTo {
-  color: black;
   font-weight: bold;
-  font-size: 17px;
+  font-size: 18px !important;
+}
+
+.presentShoutoutTo {
+  font-size: 25px !important;
 }
 
 .shoutoutDate {
@@ -46,11 +55,21 @@
   align-self: left;
 }
 
+.presentShoutoutFrom {
+  margin-top: 0 !important;
+}
+
 .shoutoutHide {
   display: flex;
   justify-content: space-between;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
+}
+
+.presentShoutoutMessage {
+  color: black;
+  margin-top: 0 !important;
+  font-size: 25px !important;
 }
 
 .shoutoutMessage {

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Form, Item, Card, Modal } from 'semantic-ui-react';
+import { Button, Form, Item, Card, Modal, Header } from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Emitters } from '../../../utils';
@@ -7,10 +7,12 @@ import { ShoutoutsAPI, Shoutout } from '../../../API/ShoutoutsAPI';
 import styles from './AdminShoutouts.module.css';
 
 const AdminShoutouts: React.FC = () => {
+  const [allShoutouts, setAllShoutouts] = useState<Shoutout[]>([]);
   const [displayShoutouts, setDisplayShoutouts] = useState<Shoutout[]>([]);
   const [earlyDate, setEarlyDate] = useState<Date>(new Date(Date.now() - 12096e5));
   const [lastDate, setLastDate] = useState<Date>(new Date());
   const [hide, setHide] = useState(false);
+  const [view, setView] = useState('ALL');
 
   const updateShoutouts = useCallback(() => {
     ShoutoutsAPI.getAllShoutouts().then((shoutouts) => {
@@ -21,30 +23,164 @@ const AdminShoutouts: React.FC = () => {
             'Please make sure the latest shoutout date is after the earliest shoutout date.'
         });
       } else {
-        setDisplayShoutouts(
-          shoutouts.filter((shoutout) => {
+        const filteredShoutouts = shoutouts
+          .filter((shoutout) => {
             const shoutoutDate = new Date(shoutout.timestamp);
-            return !shoutout.hidden && shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
+            return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
           })
-        );
+          .sort((a, b) => a.timestamp - b.timestamp);
+        setAllShoutouts(filteredShoutouts);
+        if (view === 'PRESENT')
+          setDisplayShoutouts(filteredShoutouts.filter((shoutout) => !shoutout.hidden));
+        else if (view === 'HIDDEN')
+          setDisplayShoutouts(filteredShoutouts.filter((shoutout) => shoutout.hidden));
+        else setDisplayShoutouts(filteredShoutouts);
         setHide(false);
       }
     });
-  }, [earlyDate, lastDate, setHide]);
+  }, [earlyDate, lastDate, setHide, view]);
 
   useEffect(() => {
     updateShoutouts();
   }, [earlyDate, lastDate, hide, updateShoutouts]);
 
+  const ListTitle = (): JSX.Element => {
+    let title = 'All Shoutouts';
+    if (view === 'HIDDEN') title = 'Hidden Shoutouts';
+    if (view === 'PRESENT') title = '';
+    return <Header className={styles.formTitle} content={title}></Header>;
+  };
+
   const fromString = (shoutout: Shoutout): string => {
     if (!shoutout.isAnon) {
       const { giver } = shoutout;
-      return `From: ${giver?.firstName} ${giver?.lastName}`;
+      return ` (From: ${giver?.firstName} ${giver?.lastName})`;
     }
-    return `From: Anonymous`;
+    return ` (From: Anonymous)`;
   };
+
   const dateString = (shoutout: Shoutout): string =>
     `${new Date(shoutout.timestamp).toDateString()}`;
+
+  const onHide = (shoutout: Shoutout) => {
+    setHide(true);
+    const oppHide = !shoutout.hidden;
+    ShoutoutsAPI.hideShoutout(shoutout.uuid, oppHide).then(() => {
+      if (oppHide) {
+        Emitters.generalSuccess.emit({
+          headerMsg: 'Shoutout Hidden',
+          contentMsg: 'This shoutout was successfully hidden.'
+        });
+      } else {
+        Emitters.generalSuccess.emit({
+          headerMsg: 'Shoutout Unhidden',
+          contentMsg: 'This shoutout was successfully unhidden.'
+        });
+      }
+    });
+  };
+
+  const HideModal = (props: { shoutout: Shoutout }): JSX.Element => {
+    const { shoutout } = props;
+    if (!shoutout.hidden)
+      return (
+        <Modal
+          trigger={<Button icon="eye" size="tiny" />}
+          header="Hide Shoutout"
+          content="Are you sure that you want to hide this shoutout?"
+          actions={[
+            'Cancel',
+            {
+              key: 'hideShoutouts',
+              content: 'Hide Shoutout',
+              color: 'red',
+              onClick: () => onHide(shoutout)
+            }
+          ]}
+        />
+      );
+    return (
+      <Modal
+        trigger={<Button icon="eye slash" size="tiny" />}
+        header="Unhide Shoutout"
+        content="Are you sure that you want to show this shoutout?"
+        actions={[
+          'Cancel',
+          {
+            key: 'unhideShoutouts',
+            content: 'Unhide Shoutout',
+            color: 'red',
+            onClick: () => onHide(shoutout)
+          }
+        ]}
+      />
+    );
+  };
+
+  const DisplayList = (): JSX.Element => {
+    if (displayShoutouts.length === 0)
+      return (
+        <Card className={styles.noShoutoutsContainer}>
+          <Card.Content>No shoutouts in this date range.</Card.Content>
+        </Card>
+      );
+    if (view === 'PRESENT')
+      return (
+        <Item.Group divided>
+          {displayShoutouts.map((shoutout, i) => (
+            <Item key={i}>
+              <Item.Content>
+                <Item.Header
+                  className={styles.presentShoutoutTo}
+                >{`${shoutout.receiver}`}</Item.Header>
+                <Item.Meta
+                  className={styles.presentShoutoutFrom}
+                  content={` ${fromString(shoutout)}`}
+                />
+                <Item.Description
+                  className={styles.presentShoutoutMessage}
+                  content={shoutout.message}
+                />
+              </Item.Content>
+            </Item>
+          ))}
+        </Item.Group>
+      );
+    return (
+      <Item.Group divided>
+        {displayShoutouts.map((shoutout, i) => (
+          <Item key={i}>
+            <Item.Content>
+              <Item.Group widths="equal" className={styles.shoutoutDetails}>
+                <Item.Header className={styles.shoutoutTo}>{`${shoutout.receiver}`}</Item.Header>
+                <Item.Meta className={styles.shoutoutDate} content={dateString(shoutout)} />
+              </Item.Group>
+              <Item.Group widths="equal" className={styles.shoutoutHide}>
+                <Item.Meta className={styles.shoutoutFrom} content={fromString(shoutout)} />
+                <HideModal shoutout={shoutout} />
+              </Item.Group>
+              <Item.Description className={styles.shoutoutMessage} content={shoutout.message} />
+            </Item.Content>
+          </Item>
+        ))}
+      </Item.Group>
+    );
+  };
+
+  const ButtonPiece = (props: { shoutoutList: Shoutout[]; buttonText: string }): JSX.Element => {
+    const { shoutoutList, buttonText } = props;
+    return (
+      <Button
+        basic
+        color="grey"
+        onClick={() => {
+          setView(buttonText);
+          setDisplayShoutouts(shoutoutList);
+        }}
+        content={buttonText}
+      />
+    );
+  };
 
   const ChooseDate = (props: {
     dateField: Date;
@@ -60,79 +196,29 @@ const AdminShoutouts: React.FC = () => {
     );
   };
 
-  const onHide = (shoutout: Shoutout) => {
-    if (!shoutout.hidden) {
-      setHide(true);
-      ShoutoutsAPI.hideShoutout(shoutout.uuid).then(() => {
-        Emitters.generalSuccess.emit({
-          headerMsg: 'Shoutout Hidden',
-          contentMsg: 'This shoutout was successfully hidden.'
-        });
-        setDisplayShoutouts((shoutouts) =>
-          shoutouts.map((val) => {
-            if (val.uuid === shoutout.uuid) return { ...val, hidden: true };
-            return val;
-          })
-        );
-      });
-    }
-  };
-
   return (
     <div>
       <Form className={styles.shoutoutForm}>
-        <h2 className={styles.formTitle}>Select date range to display shoutouts:</h2>
+        <h2>Filter shoutouts:</h2>
         <Form.Group width="equals">
           <ChooseDate dateField={earlyDate} dateFunction={setEarlyDate} />
           <ChooseDate dateField={lastDate} dateFunction={setLastDate} />
+          <Button.Group className={styles.buttonGroup}>
+            <ButtonPiece shoutoutList={allShoutouts} buttonText={'ALL'} />
+            <ButtonPiece
+              shoutoutList={allShoutouts.filter((shoutout) => shoutout.hidden)}
+              buttonText={'HIDDEN'}
+            />
+            <ButtonPiece
+              shoutoutList={allShoutouts.filter((shoutout) => !shoutout.hidden)}
+              buttonText={'PRESENT'}
+            />
+          </Button.Group>
         </Form.Group>
       </Form>
-
       <div className={styles.shoutoutsListContainer}>
-        <h2 className={styles.formTitle}>Shoutouts List! 📣</h2>
-        {displayShoutouts.length === 0 ? (
-          <Card className={styles.noShoutoutsContainer}>
-            <Card.Content>No shoutouts in this date range.</Card.Content>
-          </Card>
-        ) : (
-          <Item.Group divided>
-            {displayShoutouts
-              .sort((a, b) => a.timestamp - b.timestamp)
-              .map((shoutout, i) => (
-                <Item key={i}>
-                  <Item.Content>
-                    <Item.Group widths="equal" className={styles.shoutoutDetails}>
-                      <Item.Header
-                        className={styles.shoutoutTo}
-                      >{`${shoutout.receiver}`}</Item.Header>
-                      <Item.Meta className={styles.shoutoutDate} content={dateString(shoutout)} />
-                    </Item.Group>
-                    <Item.Group widths="equal" className={styles.shoutoutHide}>
-                      <Item.Meta className={styles.shoutoutFrom} content={fromString(shoutout)} />
-                      <Modal
-                        trigger={<Button icon="eye" size="tiny" />}
-                        header="Hide Shoutout"
-                        content="Are you sure that you want to hide this shoutout?"
-                        actions={[
-                          'Cancel',
-                          {
-                            key: 'hideShoutouts',
-                            content: 'Hide Shoutout',
-                            color: 'red',
-                            onClick: () => onHide(shoutout)
-                          }
-                        ]}
-                      />
-                    </Item.Group>
-                    <Item.Description
-                      className={styles.shoutoutMessage}
-                      content={shoutout.message}
-                    />
-                  </Item.Content>
-                </Item>
-              ))}
-          </Item.Group>
-        )}
+        <ListTitle />
+        <DisplayList />
       </div>
     </div>
   );


### PR DESCRIPTION
### Summary <!-- Required -->
This pull request adds more filtering functionality for the admin view of shoutouts.

- [x] Add a 3-part button (All, Hidden, Present) to the top of the admin view. Default view is all shoutouts so leads can easily manage them.
- [x] Toggling the button filters the shoutouts to show both hidden and unhidden, just hidden, or just unhidden shoutouts
- [x] Admins can unhide hidden shoutouts by pressing the hide button again in the All and Hidden shoutouts views
- [x] Present view makes shoutout content bigger to be presentable for all-hands 

### Notion/Figma Link <!-- Optional -->
(https://www.notion.so/cornelldti/Shoutouts-Add-switcher-to-filter-hidden-shoutouts-e500323c198f4b278541214be232e1ca)

### Test Plan <!-- Required -->
Manually tested that each of the 3 buttons worked and that shoutouts show up with correct information.