### PR TITLE
Temporarily disable community events for TEC

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+        with:
+          node-version-file: .node-version
       - name: Use Yarn Cache
         uses: actions/cache@v1
         with:
@@ -36,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+        with:
+          node-version-file: .node-version
       - name: Use Yarn Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/pull-from-idol.yml
+++ b/.github/workflows/pull-from-idol.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           token: ${{ secrets.BOT_TOKEN }}
       - uses: actions/setup-node@v2
+        with:
+          node-version-file: .node-version
       - name: Use Yarn Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/update-dev-db.yml
+++ b/.github/workflows/update-dev-db.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           token: ${{ secrets.BOT_TOKEN }}
       - uses: actions/setup-node@v2
+        with:
+          node-version-file: .node-version
       - name: Use Yarn Cache
         uses: actions/cache@v1
         with:

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -59,6 +59,9 @@ const AttendanceDisplay: React.FC<AttendanceDisplayProps> = ({ isPending, teamEv
   );
 };
 
+// remove this variable and usage when community events ready to be released
+const COMMUNITY_EVENTS = false;
+
 const TeamEventDetails: React.FC = () => {
   const location = useRouter();
   const uuid = location.query.uuid as string;
@@ -131,9 +134,11 @@ const TeamEventDetails: React.FC = () => {
         <h3 className={styles.eventDetails}>Date: {teamEvent.date}</h3>
         <h3 className={styles.eventDetails}>Credits: {teamEvent.numCredits}</h3>
         <h3 className={styles.eventDetails}>Has Hours: {teamEvent.hasHours ? 'yes' : 'no'}</h3>
-        <h3 className={styles.eventDetails}>
-          Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}
-        </h3>
+        {COMMUNITY_EVENTS && (
+          <h3 className={styles.eventDetails}>
+            Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}
+          </h3>
+        )}
       </div>
 
       <div className={styles.listsContainer}>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
@@ -11,6 +11,9 @@ type Props = {
   editTeamEvent?: (teamEvent: TeamEvent) => void;
 };
 
+// remove this variable and usage when community events ready to be released
+const COMMUNITY_EVENTS = false;
+
 const TeamEventForm = (props: Props): JSX.Element => {
   const { formType, setOpen, teamEvent, editTeamEvent } = props;
 
@@ -151,25 +154,27 @@ const TeamEventForm = (props: Props): JSX.Element => {
           </Form.Field>
         </Form.Group>
 
-        <label className={styles.label}>Is this a community event?</label>
-        <Form.Group inline>
-          <Form.Field>
-            <Radio
-              label="Yes"
-              value="Yes"
-              checked={isCommunity}
-              onChange={() => setIsCommunity(true)}
-            />
-          </Form.Field>
-          <Form.Field>
-            <Radio
-              label="No"
-              value="No"
-              checked={!isCommunity}
-              onChange={() => setIsCommunity(false)}
-            />
-          </Form.Field>
-        </Form.Group>
+        {COMMUNITY_EVENTS && <label className={styles.label}>Is this a community event?</label>}
+        {COMMUNITY_EVENTS && (
+          <Form.Group inline>
+            <Form.Field>
+              <Radio
+                label="Yes"
+                value="Yes"
+                checked={isCommunity}
+                onChange={() => setIsCommunity(true)}
+              />
+            </Form.Field>
+            <Form.Field>
+              <Radio
+                label="No"
+                value="No"
+                checked={!isCommunity}
+                onChange={() => setIsCommunity(false)}
+              />
+            </Form.Field>
+          </Form.Group>
+        )}
 
         {formType === 'create' && (
           <Form.Button floated="right" onClick={submitTeamEvent}>

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -12,6 +12,9 @@ type TeamEventsDisplayProps = {
   teamEvents: TeamEvent[];
 };
 
+// remove this variable and usage when community events ready to be released
+const COMMUNITY_EVENTS = false;
+
 const TeamEventsDisplay: React.FC<TeamEventsDisplayProps> = ({ isLoading, teamEvents }) => {
   if (isLoading) return <Loader active inline />;
   return (
@@ -25,7 +28,9 @@ const TeamEventsDisplay: React.FC<TeamEventsDisplayProps> = ({ isLoading, teamEv
                   <Card.Header>{teamEvent.name} </Card.Header>
                   <Card.Meta>{teamEvent.date}</Card.Meta>
                   <Card.Meta>{teamEvent.requests.length} pending requests</Card.Meta>
-                  <Card.Meta>Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
+                  {COMMUNITY_EVENTS && (
+                    <Card.Meta>Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
+                  )}
                 </Card.Content>
               </Card>
             </Link>

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
@@ -36,11 +36,25 @@ const TeamEventCreditDashboard = (props: {
     remainingCredits = REQUIRED_COMMUNITY_CREDITS - approvedCommunityCredits;
   else remainingCredits = 0;
 
+  // remove this variable and usage when community events ready to be released
+  const COMMUNITY_EVENTS = false;
+
   let headerString;
   if (userRole !== 'lead')
-    headerString = `Check your team event credit status for this semester here! Every DTI member must complete ${REQUIRED_MEMBER_TEC_CREDITS} team event credits and ${REQUIRED_COMMUNITY_CREDITS} community team event credits to fulfill this requirement.`;
+    headerString = `Check your team event credit status for this semester here!  
+    Every DTI member must complete ${REQUIRED_MEMBER_TEC_CREDITS} team event credits 
+    ${
+      COMMUNITY_EVENTS
+        ? `and ${REQUIRED_COMMUNITY_CREDITS} community team event credits to fulfill this requirement.`
+        : ''
+    }`;
   else
-    headerString = `Since you are a lead, you must complete ${REQUIRED_LEAD_TEC_CREDITS} total team event credits, with ${REQUIRED_COMMUNITY_CREDITS} of them being community event credits.`;
+    headerString = `Since you are a lead, you must complete ${REQUIRED_LEAD_TEC_CREDITS} total team event credits
+    ${
+      COMMUNITY_EVENTS
+        ? `, with ${REQUIRED_COMMUNITY_CREDITS} of them being community event credits.`
+        : ''
+    }`;
 
   return (
     <div>
@@ -55,12 +69,14 @@ const TeamEventCreditDashboard = (props: {
           </label>
         </div>
 
-        <div className={styles.inline}>
-          <label className={styles.bold}>
-            Your Approved Community Credits:{' '}
-            <span className={styles.dark_grey_color}>{approvedCommunityCredits}</span>
-          </label>
-        </div>
+        {COMMUNITY_EVENTS && (
+          <div className={styles.inline}>
+            <label className={styles.bold}>
+              Your Approved Community Credits:{' '}
+              <span className={styles.dark_grey_color}>{approvedCommunityCredits}</span>
+            </label>
+          </div>
+        )}
 
         <div className={styles.inline}>
           <label className={styles.bold}>
@@ -79,7 +95,9 @@ const TeamEventCreditDashboard = (props: {
                     <Card.Header>{teamEvent.name} </Card.Header>
                     <Card.Meta>{teamEvent.date}</Card.Meta>
                     <Card.Meta>{`Number of Credits: ${teamEvent.numCredits}`}</Card.Meta>
-                    <Card.Meta>Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
+                    {COMMUNITY_EVENTS && (
+                      <Card.Meta>Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
+                    )}
                   </Card.Content>
                 </Card>
               ))}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

The leads have decided not to have a separate community event tally this semester. However, this may be released in future semesters, so for now we should hide the ability to make Team Events "community" events, and hide the tally for community events from users.


### Notion/Figma Link <!-- Optional -->

[Notion](https://www.notion.so/cornelldti/Idol-SP23-e65533742dca4f898581cc5c496e821e?p=125511cf68374e268cc4edf42e88ec9b&pm=s)

### Test Plan <!-- Required -->

Manually test to see that community events can no longer be created on the admin side, and that community event tallies are not visible on the member side.

### Notes <!-- Optional -->

I used a variable so we can toggle the community event visibility, instead of removing it or commenting it out. It is still spread out across several files which is not ideal, so im open to suggestions on how to accomplish this better.
