### PR TITLE
TEC - Hour-based event credits are not calculated correctly and validation error messages are unhelpful

### DIFF
--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -74,4 +74,4 @@ export const clearAllTeamEvents = async (user: IdolMember): Promise<void> => {
 export const getAllTeamEventsForMember = async (
   email: string,
   isPending: boolean
-): Promise<TeamEventInfo[]> => TeamEventsDao.getTeamEventsForMember(email, isPending);
+): Promise<TeamEventHoursInfo[]> => TeamEventsDao.getTeamEventsForMember(email, isPending);

--- a/backend/src/dao/TeamEventsDao.ts
+++ b/backend/src/dao/TeamEventsDao.ts
@@ -131,15 +131,26 @@ export default class TeamEventsDao {
    * @param email - email of the user
    * @param isPending - get pending or approved requests
    */
-  static async getTeamEventsForMember(email: string, isPending: boolean): Promise<TeamEventInfo[]> {
+  static async getTeamEventsForMember(
+    email: string,
+    isPending: boolean
+  ): Promise<TeamEventHoursInfo[]> {
     const allTeamEvents = await this.getAllTeamEvents();
     const memberTeamEventInfoList = allTeamEvents.reduce(
-      (teamEvents: TeamEventInfo[], teamEvent: TeamEvent) => {
+      (teamEvents: TeamEventHoursInfo[], teamEvent: TeamEvent) => {
         const attendanceList = isPending ? teamEvent.requests : teamEvent.attendees;
-        const hasMemberRequest = attendanceList.some((val) => val.member.email === email);
-        if (hasMemberRequest) {
+        let hoursAttended;
+        const hasMemberAttendance = attendanceList.some((val) => {
+          const hasUser = val.member.email === email;
+          if (hasUser && teamEvent.hasHours) {
+            hoursAttended = val.hoursAttended;
+          }
+          return hasUser;
+        });
+
+        if (hasMemberAttendance) {
           const { attendees, requests, ...teamEventInfo } = teamEvent;
-          return [...teamEvents, teamEventInfo];
+          return [...teamEvents, { hoursAttended, ...teamEventInfo }];
         }
         return teamEvents;
       },

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -95,6 +95,10 @@ interface TeamEventInfo {
   readonly isCommunity: boolean;
 }
 
+interface TeamEventHoursInfo extends TeamEventInfo {
+  readonly hoursAttended?: number;
+}
+
 interface TeamEvent extends TeamEventInfo {
   readonly attendees: TeamEventAttendance[];
   readonly requests: TeamEventAttendance[];

--- a/frontend/src/API/TeamEventsAPI.ts
+++ b/frontend/src/API/TeamEventsAPI.ts
@@ -12,8 +12,8 @@ export type EventAttendance = TeamEventAttendance;
 export type Event = TeamEvent;
 
 export type MemberTECRequests = {
-  pending: TeamEventInfo[];
-  approved: TeamEventInfo[];
+  pending: TeamEventHoursInfo[];
+  approved: TeamEventHoursInfo[];
 };
 
 export class TeamEventsAPI {

--- a/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
@@ -34,12 +34,16 @@ const TeamEventForm = (props: Props): JSX.Element => {
     } else if (
       !teamEventCreditNum ||
       teamEventCreditNum === '' ||
-      isNaN(Number(teamEventCreditNum)) ||
-      Number(teamEventCreditNum) < 0.5
+      isNaN(Number(teamEventCreditNum))
     ) {
       Emitters.generalError.emit({
         headerMsg: 'No Team Event Credit Amount',
         contentMsg: 'Please enter how many credits the event is worth!'
+      });
+    } else if (Number(teamEventCreditNum) < 0.25) {
+      Emitters.generalError.emit({
+        headerMsg: 'Invalid Team Event Credit Amount',
+        contentMsg: 'The event should be worth 0.25 or more credits.'
       });
     } else if (teamEvent && editTeamEvent) {
       const editedTeamEvent: TeamEvent = {

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -15,8 +15,8 @@ const TeamEventCreditForm: React.FC = () => {
   const [image, setImage] = useState('');
   const [hours, setHours] = useState('');
   const [teamEventInfoList, setTeamEventInfoList] = useState<TeamEventInfo[]>([]);
-  const [approvedTEC, setApprovedTEC] = useState<TeamEventInfo[]>([]);
-  const [pendingTEC, setPendingTEC] = useState<TeamEventInfo[]>([]);
+  const [approvedTEC, setApprovedTEC] = useState<TeamEventHoursInfo[]>([]);
+  const [pendingTEC, setPendingTEC] = useState<TeamEventHoursInfo[]>([]);
 
   useEffect(() => {
     TeamEventsAPI.getAllTeamEventInfo().then((teamEvents) => setTeamEventInfoList(teamEvents));
@@ -55,10 +55,15 @@ const TeamEventCreditForm: React.FC = () => {
         headerMsg: 'No Image Uploaded',
         contentMsg: 'Please upload an image!'
       });
-    } else if (teamEvent.hasHours && (hours === '' || isNaN(Number(hours)) || Number(hours) < 1)) {
+    } else if (teamEvent.hasHours && (hours === '' || isNaN(Number(hours)))) {
       Emitters.generalError.emit({
         headerMsg: 'No Hours Entered',
         contentMsg: 'Please enter your hours!'
+      });
+    } else if (teamEvent.hasHours && Number(hours) <= 0) {
+      Emitters.generalError.emit({
+        headerMsg: 'Invalid Hours Entered',
+        contentMsg: 'Please enter a positive number of hours.'
       });
     } else {
       const newTeamEventAttendance: TeamEventAttendance = {
@@ -67,7 +72,7 @@ const TeamEventCreditForm: React.FC = () => {
         image: `eventProofs/${getNetIDFromEmail(userInfo.email)}/${new Date().toISOString()}`
       };
       requestTeamEventCredit(newTeamEventAttendance, teamEvent.uuid).then(() => {
-        setPendingTEC((pending) => [...pending, teamEvent]);
+        setPendingTEC((pending) => [...pending, { ...teamEvent, hoursAttended: Number(hours) }]);
         Emitters.generalSuccess.emit({
           headerMsg: 'Team Event Credit submitted!',
           contentMsg: `The leads were notified of your submission and your credit will be approved soon!`

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
@@ -8,8 +8,8 @@ const REQUIRED_MEMBER_TEC_CREDITS = 3;
 const REQUIRED_LEAD_TEC_CREDITS = 6;
 
 const TeamEventCreditDashboard = (props: {
-  approvedTEC: TeamEventInfo[];
-  pendingTEC: TeamEventInfo[];
+  approvedTEC: TeamEventHoursInfo[];
+  pendingTEC: TeamEventHoursInfo[];
 }): JSX.Element => {
   const { approvedTEC, pendingTEC } = props;
 
@@ -19,8 +19,15 @@ const TeamEventCreditDashboard = (props: {
   const requiredCredits =
     userRole === 'lead' ? REQUIRED_LEAD_TEC_CREDITS : REQUIRED_MEMBER_TEC_CREDITS; // number of required tec credits in a semester based on user role
 
+  const calculateNumCredits = ({
+    hasHours,
+    hoursAttended,
+    numCredits
+  }: TeamEventHoursInfo): number =>
+    hasHours && hoursAttended ? Number(numCredits) * hoursAttended : Number(numCredits);
+
   const approvedCredits = approvedTEC.reduce(
-    (approved, teamEvent) => approved + Number(teamEvent.numCredits),
+    (approved, teamEvent) => approved + calculateNumCredits(teamEvent),
     0
   );
   const approvedCommunityCredits = approvedTEC.reduce(
@@ -73,12 +80,12 @@ const TeamEventCreditDashboard = (props: {
           <label className={styles.bold}>Approved Events:</label>
           {approvedTEC.length !== 0 ? (
             <Card.Group>
-              {approvedTEC.map((teamEvent) => (
-                <Card>
+              {approvedTEC.map((teamEvent, i) => (
+                <Card key={i}>
                   <Card.Content>
                     <Card.Header>{teamEvent.name} </Card.Header>
                     <Card.Meta>{teamEvent.date}</Card.Meta>
-                    <Card.Meta>{`Number of Credits: ${teamEvent.numCredits}`}</Card.Meta>
+                    <Card.Meta>{`Number of Credits: ${calculateNumCredits(teamEvent)}`}</Card.Meta>
                     <Card.Meta>Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
                   </Card.Content>
                 </Card>
@@ -93,12 +100,12 @@ const TeamEventCreditDashboard = (props: {
           <label className={styles.bold}>Pending Approval For:</label>
           {pendingTEC.length !== 0 ? (
             <Card.Group>
-              {pendingTEC.map((teamEvent) => (
-                <Card>
+              {pendingTEC.map((teamEvent, i) => (
+                <Card key={i}>
                   <Card.Content>
                     <Card.Header>{teamEvent.name} </Card.Header>
                     <Card.Meta>{teamEvent.date}</Card.Meta>
-                    <Card.Meta>{`Number of Credits: ${teamEvent.numCredits}`}</Card.Meta>
+                    <Card.Meta>{`Number of Credits: ${calculateNumCredits(teamEvent)}`}</Card.Meta>
                   </Card.Content>
                 </Card>
               ))}


### PR DESCRIPTION
### Summary 
- Added new type `TeamEventHoursInfo` which includes `hoursAttended` field
- `/getTeamEventsForMember` endpoint now returns an additional `hoursAttended` field for each Team Event
- Calculation for team event credits is on the frontend
- Updated validation error messages to be more useful
- Changed validation to require 0.25 credits for creating Team Events, and a positive number for submitted hours attended
- Also fixed some warnings with using `.map(...)` for components without specifying the `key` field.

### Notion/Figma Link <!-- Optional -->

Notion: https://www.notion.so/cornelldti/TEC-Hour-based-event-credits-are-not-calculated-correctly-and-validation-error-messages-are-unhelp-87db9eb80ec24f76a80a4262ecbe8033?pvs=4

### Test Plan <!-- Required -->

Manual. Backend tests still pass.

### Notes <!-- Optional -->

### Breaking Changes <!-- Optional -->
