### PR TITLE
Refactor backend Firebase config 

### DIFF
--- a/backend/scripts/update-dev-db.ts
+++ b/backend/scripts/update-dev-db.ts
@@ -1,4 +1,5 @@
 import admin from 'firebase-admin';
+import configureAccount from '../src/utils/firebase-utils';
 
 require('dotenv').config();
 
@@ -12,23 +13,6 @@ type DbData = {
     data: unknown;
   }[];
 }[];
-
-const configureAccount = (sa: unknown, isProd: boolean): unknown => {
-  const configAcc = sa;
-  let parsedPK;
-  try {
-    parsedPK = isProd
-      ? JSON.parse(process.env.FIREBASE_PRIVATE_KEY as string)
-      : JSON.parse(process.env.FIREBASE_DEV_PRIVATE_KEY as string);
-  } catch (err) {
-    parsedPK = isProd ? process.env.FIREBASE_PRIVATE_KEY : process.env.FIREBASE_DEV_PRIVATE_KEY;
-  }
-  configAcc.private_key = parsedPK;
-  configAcc.private_key_id = isProd
-    ? process.env.FIREBASE_PRIVATE_KEY_ID
-    : process.env.FIREBASE_DEV_PRIVATE_KEY_ID;
-  return configAcc;
-};
 
 async function deleteCollection(
   db: FirebaseFirestore.Firestore,

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -7,6 +7,7 @@ import {
   DBDevPortfolio,
   DevPortfolioSubmissionRequestLog
 } from './types/DataTypes';
+import configureAccount from './utils/firebase-utils';
 
 require('dotenv').config();
 
@@ -17,25 +18,8 @@ const devServiceAccount = require('../resources/cornelldti-idol-firebase-adminsd
 
 const serviceAccount = useProdDb ? prodServiceAccount : devServiceAccount;
 
-const configureAccount = (sa) => {
-  const configAcc = sa;
-  let parsedPK;
-  try {
-    parsedPK = useProdDb
-      ? JSON.parse(process.env.FIREBASE_PRIVATE_KEY as string)
-      : JSON.parse(process.env.FIREBASE_DEV_PRIVATE_KEY as string);
-  } catch (err) {
-    parsedPK = useProdDb ? process.env.FIREBASE_PRIVATE_KEY : process.env.FIREBASE_DEV_PRIVATE_KEY;
-  }
-  configAcc.private_key = parsedPK;
-  configAcc.private_key_id = useProdDb
-    ? process.env.FIREBASE_PRIVATE_KEY_ID
-    : process.env.FIREBASE_DEV_PRIVATE_KEY_ID;
-  return configAcc;
-};
-
 export const app = admin.initializeApp({
-  credential: admin.credential.cert(configureAccount(serviceAccount)),
+  credential: admin.credential.cert(configureAccount(serviceAccount, useProdDb)),
   databaseURL: 'https://idol-b6c68.firebaseio.com',
   storageBucket: useProdDb ? 'gs://idol-b6c68.appspot.com' : 'gs://cornelldti-idol.appspot.com'
 });

--- a/backend/src/utils/firebase-utils.ts
+++ b/backend/src/utils/firebase-utils.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+const configureAccount = (sa: any, isProd: boolean) => {
+  const configAcc = sa;
+  let parsedPK;
+  try {
+    parsedPK = isProd
+      ? JSON.parse(process.env.FIREBASE_PRIVATE_KEY as string)
+      : JSON.parse(process.env.FIREBASE_DEV_PRIVATE_KEY as string);
+  } catch (err) {
+    parsedPK = isProd ? process.env.FIREBASE_PRIVATE_KEY : process.env.FIREBASE_DEV_PRIVATE_KEY;
+  }
+  configAcc.private_key = parsedPK;
+  configAcc.private_key_id = isProd
+    ? process.env.FIREBASE_PRIVATE_KEY_ID
+    : process.env.FIREBASE_DEV_PRIVATE_KEY_ID;
+  return configAcc;
+};
+
+export default configureAccount;


### PR DESCRIPTION
### Summary <!-- Required -->

Refactored the `configureAccount` function for backend Firebase config to be one function in `firebase-utils.ts` that can be used for the backend functions and various scripts. 

### Notion/Figma Link <!-- Optional -->

N/A - This is an initial PR for setting up a cronjob to send profile update notification emails. 

### Test Plan <!-- Required -->
Backend should work as before for prod and dev Firebase instances and existing cronjobs should run with no issue. 


