### PR TITLE
update time labels for portfolio

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "express-winston": "^4.2.0",
     "firebase-admin": "^9.12.0",
     "googleapis": "^100.0.0",
+    "luxon": "^3.3.0",
     "netlify-lambda": "^2.0.14",
     "nodemailer": "^6.7.3",
     "serverless-http": "^2.5.0",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@types/diff": "^5.0.1",
+    "@types/luxon": "^3.2.0",
     "esbuild": "^0.13.3",
     "esbuild-runner": "^2.2.1"
   }

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -4,9 +4,8 @@ import PermissionsManager from '../utils/permissionsManager';
 import { PermissionError, BadRequestError } from '../utils/errors';
 import { validateSubmission, isWithinDates } from '../utils/githubUtil';
 
-function zonedTime(timestamp: number, ianatz = 'America/New_York') {
-  return DateTime.fromMillis(timestamp, { zone: ianatz });
-}
+const zonedTime = (timestamp: number, ianatz = 'America/New_York') =>
+  DateTime.fromMillis(timestamp, { zone: ianatz });
 
 export const getAllDevPortfolios = async (user: IdolMember): Promise<DevPortfolio[]> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -1,7 +1,12 @@
+import { DateTime } from 'luxon';
 import DevPortfolioDao from '../dao/DevPortfolioDao';
 import PermissionsManager from '../utils/permissionsManager';
 import { PermissionError, BadRequestError } from '../utils/errors';
 import { validateSubmission, isWithinDates } from '../utils/githubUtil';
+
+function zonedTime(timestamp: number, ianatz = 'America/New_York') {
+  return DateTime.fromMillis(timestamp, { zone: ianatz });
+}
 
 export const getAllDevPortfolios = async (user: IdolMember): Promise<DevPortfolio[]> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
@@ -47,21 +52,25 @@ export const createNewDevPortfolio = async (
     instance.name.length === 0 ||
     instance.deadline < instance.earliestValidDate ||
     (instance.lateDeadline && instance.lateDeadline < instance.deadline)
-  )
+  ) {
     throw new BadRequestError(
       `Unable to create the new dev portfolio instance: The provided dev portfolio is invalid.`
     );
-  const updatedDeadline = new Date(instance.deadline);
-  const updatedEarliestValidDate = new Date(instance.earliestValidDate);
-  const updatedLateDeadline = instance.lateDeadline ? new Date(instance.lateDeadline) : null;
-  const modifiedInstance = {
-    ...instance,
-    deadline: updatedDeadline.setHours(23, 59, 59),
-    earliestValidDate: updatedEarliestValidDate.setHours(0, 0, 0)
-  };
-  if (updatedLateDeadline) {
-    modifiedInstance.lateDeadline = updatedLateDeadline.setHours(23, 59, 59);
   }
+
+  const updatedDeadline = zonedTime(instance.deadline).endOf('day');
+  const updatedEarliestValidDate = zonedTime(instance.earliestValidDate).startOf('day');
+  const updatedLateDeadline = instance.lateDeadline
+    ? zonedTime(instance.lateDeadline).endOf('day')
+    : null;
+
+  const modifiedInstance: DevPortfolio = {
+    ...instance,
+    deadline: updatedDeadline.valueOf(),
+    earliestValidDate: updatedEarliestValidDate.valueOf(),
+    lateDeadline: updatedLateDeadline ? updatedDeadline.valueOf() : null
+  };
+
   return DevPortfolioDao.createNewInstance(modifiedInstance);
 };
 

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -68,7 +68,7 @@ export const createNewDevPortfolio = async (
     ...instance,
     deadline: updatedDeadline.valueOf(),
     earliestValidDate: updatedEarliestValidDate.valueOf(),
-    lateDeadline: updatedLateDeadline ? updatedDeadline.valueOf() : null
+    lateDeadline: updatedLateDeadline ? updatedLateDeadline.valueOf() : null
   };
 
   return DevPortfolioDao.createNewInstance(modifiedInstance);

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -1,12 +1,10 @@
-import { DateTime } from 'luxon';
 import DevPortfolioDao from '../src/dao/DevPortfolioDao'; // eslint-disable-line  @typescript-eslint/no-unused-vars
 import PermissionsManager from '../src/utils/permissionsManager';
 import {
   fakeIdolMember,
   fakeDevPortfolio,
   fakeDevPortfolioSubmission,
-  fakeCreateDevPortfolio,
-  fakeCreateDevPortfolioResult
+  fakeCreateDevPortfolio
 } from './data/createData';
 import {
   getDevPortfolio,

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -1,6 +1,13 @@
+import { DateTime } from 'luxon';
 import DevPortfolioDao from '../src/dao/DevPortfolioDao'; // eslint-disable-line  @typescript-eslint/no-unused-vars
 import PermissionsManager from '../src/utils/permissionsManager';
-import { fakeIdolMember, fakeDevPortfolio, fakeDevPortfolioSubmission } from './data/createData';
+import {
+  fakeIdolMember,
+  fakeDevPortfolio,
+  fakeDevPortfolioSubmission,
+  fakeCreateDevPortfolio,
+  fakeCreateDevPortfolioResult
+} from './data/createData';
 import {
   getDevPortfolio,
   deleteDevPortfolio,
@@ -108,19 +115,11 @@ describe('User is lead or admin', () => {
   });
 
   test('createDevPortfolio should be successful', async () => {
-    const expectedDeadline = new Date(devPortfolio.deadline).setHours(23, 59, 59);
-    const expectedEarliestValidDate = new Date(devPortfolio.earliestValidDate).setHours(0, 0, 0);
-    const expectedLateDeadline = new Date(devPortfolio.lateDeadline).setHours(23, 59, 59);
-    await createNewDevPortfolio(devPortfolio, user);
+    const [input, output] = fakeCreateDevPortfolio();
+    await createNewDevPortfolio(input, user);
     expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
     expect(DevPortfolioDao.createNewInstance).toBeCalled();
-    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].deadline).toEqual(expectedDeadline);
-    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].earliestValidDate).toEqual(
-      expectedEarliestValidDate
-    );
-    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].lateDeadline).toEqual(
-      expectedLateDeadline
-    );
+    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0]).toEqual(output);
   });
 
   describe('test createNewDevPortfolio validation', () => {

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -123,3 +123,25 @@ export const fakeDevPortfolio = (): DevPortfolio => {
   };
   return DP;
 };
+
+/** Create fake Dev Portfolios for portfolio creation test */
+export const fakeCreateDevPortfolio = (): [DevPortfolio, DevPortfolio] => {
+  const uuid = faker.datatype.uuid();
+  const input = {
+    name: 'testdevportfolio',
+    deadline: 1679260752410, // 2023-03-19T21:19:12.410Z
+    lateDeadline: 1679692752410, // 2023-03-24T21:19:12.410Z
+    earliestValidDate: 1651363200020, // 2022-05-01T00:00:00.020Z
+    submissions: [],
+    uuid
+  };
+  const output = {
+    name: 'testdevportfolio',
+    deadline: 1679284799999, // 2023-03-20T03:59:59.999Z (11:59:59 EST)
+    lateDeadline: 1679716799999, // 2023-03-25T03:59:59.999Z (11:59:59 EST)
+    earliestValidDate: 1651291200000, // 2022-04-30T04:00:00.000Z
+    submissions: [],
+    uuid
+  };
+  return [input, output];
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "csvtojson": "^2.0.10",
     "export-to-csv": "^0.2.1",
     "firebase": "^9.1.1",
+    "luxon": "^3.3.0",
     "moment": "^2.29.1",
     "next": "^12.0.1",
     "prismjs": "^1.25.0",
@@ -50,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "@types/luxon": "^3.2.0",
     "@types/styled-components": "^5.1.24"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,6 @@
     "export-to-csv": "^0.2.1",
     "firebase": "^9.1.1",
     "luxon": "^3.3.0",
-    "moment": "^2.29.1",
     "next": "^12.0.1",
     "prismjs": "^1.25.0",
     "react": "^17.0.2",

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -133,7 +133,7 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
               );
           }}
           loading={isRegrading}
-          class="right-button"
+          className="right-button"
         >
           Regrade All Submissions
         </Button>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -89,6 +89,9 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
     csvExporter.generateCsv(csvData);
   };
 
+  // console.log(new Date(portfolio?.lateDeadline));
+  const timeLabel = (isoDate: number) => new Date(isoDate).toLocaleString();
+
   return !portfolio ? (
     <></>
   ) : (
@@ -98,14 +101,14 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
       </Header>
 
       <Header as="h3" textAlign="center">
-        Earliest Valid Date: {new Date(portfolio.earliestValidDate).toDateString()}
+        Earliest Valid Date: {timeLabel(portfolio.earliestValidDate)}
       </Header>
       <Header textAlign="center" as="h3">
-        Deadline: {new Date(portfolio.deadline).toDateString()}
+        Deadline: {timeLabel(portfolio.deadline)}
       </Header>
       {portfolio.lateDeadline && (
         <Header textAlign="center" as="h3">
-          Late Deadline: {new Date(portfolio.lateDeadline).toDateString()}
+          Late Deadline: {timeLabel(portfolio.lateDeadline)}
         </Header>
       )}
       {isAdminView ? <Button onClick={() => handleExportToCsv()}>Export to CSV</Button> : <></>}
@@ -177,17 +180,17 @@ const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio, isAd
   };
 
   return (
-    <Table celled>
+    <Table celled unstackable>
       <Table.Header>
-        <Table.HeaderCell rowSpan="2">Name</Table.HeaderCell>
-        <Table.HeaderCell rowSpan="2">Opened PRs</Table.HeaderCell>
-        <Table.HeaderCell rowSpan="2">Reviewed PRs</Table.HeaderCell>
-        <Table.HeaderCell rowSpan="2">Status</Table.HeaderCell>
-        {sortedSubmissions.some((submission) => submission.text) ? (
-          <Table.HeaderCell rowSpan="2"></Table.HeaderCell>
-        ) : (
-          <></>
-        )}
+        <Table.Row>
+          <Table.HeaderCell>Name</Table.HeaderCell>
+          <Table.HeaderCell>Opened PRs</Table.HeaderCell>
+          <Table.HeaderCell>Reviewed PRs</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          {sortedSubmissions.some((submission) => submission.text) && (
+            <Table.HeaderCell></Table.HeaderCell>
+          )}
+        </Table.Row>
       </Table.Header>
       <Table.Body>
         {sortedSubmissions.map((submission, i) => {
@@ -239,9 +242,10 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
         negative={submissionStatus === 'invalid'}
         warning={submissionStatus === 'pending'}
       >
-        <Table.Cell rowSpan={`${numRows}`}>{`${submission.member.firstName} ${
-          submission.member.lastName
-        } (${submission.member.netid})${submission.isLate ? '*' : ''}`}</Table.Cell>
+        <Table.Cell rowSpan={`${numRows}`}>
+          {`${submission.member.firstName} ${submission.member.lastName} (${submission.member.netid})`}
+          {submission.isLate && <Icon name="exclamation circle" />}`
+        </Table.Cell>
         <Table.Cell>
           <PullRequestDisplay
             prSubmission={submission.openedPRs.length > 0 ? submission.openedPRs[0] : undefined}

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -89,7 +89,6 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
     csvExporter.generateCsv(csvData);
   };
 
-  // console.log(new Date(portfolio?.lateDeadline));
   const timeLabel = (isoDate: number) => new Date(isoDate).toLocaleString();
 
   return !portfolio ? (
@@ -148,7 +147,8 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
       )}
       <DetailsTable portfolio={portfolio} isAdminView={isAdminView} />
       <span>
-        <b>* = Late submission</b>
+        <Icon name="exclamation circle" color="red" />
+        <b>= Late submission</b>
       </span>
     </Container>
   );
@@ -244,7 +244,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
       >
         <Table.Cell rowSpan={`${numRows}`}>
           {`${submission.member.firstName} ${submission.member.lastName} (${submission.member.netid})`}
-          {submission.isLate && <Icon name="exclamation circle" />}`
+          {submission.isLate && <Icon name="exclamation circle" color="red" />}
         </Table.Cell>
         <Table.Cell>
           <PullRequestDisplay

--- a/frontend/src/components/Admin/SignInForm/SignInFormCreator.tsx
+++ b/frontend/src/components/Admin/SignInForm/SignInFormCreator.tsx
@@ -15,7 +15,7 @@ import {
   SemanticICONS
 } from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import SignInFormAPI from '../../../API/SignInFormAPI';
 import { Emitters } from '../../../utils';
 import styles from './SignInFormCreator.module.css';
@@ -28,10 +28,10 @@ const CODE_VALIDATION_RE = '^[a-zA-Z0-9-]+$';
 const regexInput = new RegExp(CODE_VALIDATION_RE);
 
 const calculateMinTime = (date: Date) => {
-  if (moment(date).isSame(moment(), 'day')) {
-    return moment().add(0.5, 'hours').toDate();
+  if (DateTime.fromJSDate(date).hasSame(DateTime.now(), 'day')) {
+    return DateTime.now().plus({ minutes: 30 }).toJSDate();
   }
-  return moment().startOf('day').toDate();
+  return DateTime.now().startOf('day').toJSDate();
 };
 
 const CodeForm: React.FC<{
@@ -45,7 +45,7 @@ const CodeForm: React.FC<{
 }> = ({ defaultValue, onClick, disabled, info, error, success, link }) => {
   const [inputVal, setInputVal] = useState(defaultValue || '');
   const [showCopied, setShowCopied] = useState(false);
-  const [expiryDate, setExpiryDate] = useState(moment().add(2, 'hours').toDate());
+  const [expiryDate, setExpiryDate] = useState(DateTime.now().plus({ hours: 2 }).toJSDate());
   const [validInput, setValidInput] = useState(true);
   const [minTime, setMinTime] = useState(new Date());
 
@@ -133,13 +133,21 @@ const CodeForm: React.FC<{
           <div>
             <label className={styles.dateLabel}>Code Expiry</label>
             <DatePicker
+              popperModifiers={[
+                {
+                  name: 'arrow',
+                  options: {
+                    padding: { right: 25 }
+                  }
+                }
+              ]}
               selected={expiryDate}
               onChange={handleDateChange}
               showTimeSelect
               disabled={disabled}
               minDate={new Date()}
               minTime={minTime}
-              maxTime={moment().endOf('day').toDate()}
+              maxTime={DateTime.now().endOf('day').toJSDate()}
               dateFormat="MMM d, yyyy h:mm aa"
             />
             <div>
@@ -264,7 +272,7 @@ const CreateSignInForm: React.FC<{ id: string; expiryDate: number }> = ({ id, ex
       defaultValue={id}
       onClick={onResultsScreenResubmit}
       error={{
-        header: `The expiry date ${new Date(expiryDate).toLocaleTimeString()} on 
+        header: `The expiry date ${new Date(expiryDate).toLocaleTimeString()} on
             ${new Date(expiryDate).toLocaleDateString()} is in the past!`,
         content: 'Choose a different expiry date to continue.'
       }}

--- a/frontend/src/components/Common/SignIn/SignIn.tsx
+++ b/frontend/src/components/Common/SignIn/SignIn.tsx
@@ -9,7 +9,7 @@ import { auth, provider } from '../../../firebase';
 const SignIn: React.FC = () => {
   const onGoogleSignIn = () => {
     signInWithPopup(auth, provider).catch((err) => {
-      console.error(err);
+      /* pop-up cancelled */
     });
   };
 

--- a/frontend/src/components/Common/SignIn/SignIn.tsx
+++ b/frontend/src/components/Common/SignIn/SignIn.tsx
@@ -8,7 +8,9 @@ import { auth, provider } from '../../../firebase';
 
 const SignIn: React.FC = () => {
   const onGoogleSignIn = () => {
-    signInWithPopup(auth, provider);
+    signInWithPopup(auth, provider).catch((err) => {
+      console.error(err);
+    });
   };
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11228,11 +11228,6 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-moment@^2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,6 +2950,11 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
+"@types/luxon@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.2.0.tgz#99901b4ab29a5fdffc88fff59b3b47fbfbe0557b"
+  integrity sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==
+
 "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
@@ -10643,6 +10648,11 @@ lru-memoizer@^2.1.4:
   dependencies:
     lodash.clonedeep "^4.5.0"
     lru-cache "~4.0.0"
+
+luxon@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
+  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
 
 lz-string@^1.4.4:
   version "1.4.4"


### PR DESCRIPTION
### Summary <!-- Required -->

The backend create dev portfolio endpoint now sets deadlines to end of the day in the `America/New_York` time zone (and also the start of the day for earliest submission). Previously, it was using the local time zone of the server (which was not the expected behavior).

Also updated the portfolio submission UI's text, table, and late icon. Previously, only the date was shown; now, it is clear when something is past the deadline. The Table header was also bugged.

![image](https://user-images.githubusercontent.com/52215742/224169395-b9830ddc-b0d3-40f6-838e-ffc17aeb0b13.png)

Ticket: <https://www.notion.so/cornelldti/DP-Bug-Deadlines-are-not-in-EST-8de856d9a9d14261accb5afbf3c91669?pvs=4>

### Test Plan <!-- Required -->

Instead of doing logic in the test files, updated tests with hard-coded values.

### Notes

For some reason, when closing the sign-in popup (instead of signing in), the promise returns an error for popup cancelled, which was not being caught anywhere. Currently catching it to avoid warnings being shown. It's makes sense firebase throws an error since the user cancelled, but catching it wouldn't require any additional logic.

Sign-in still works fine though.

### Breaking Changes <!-- Optional -->

Switched to luxon date time library and removed moment (the project is dead).

Changed tests because the original logic was incorrect.
