### PR TITLE
Add email notification cronjob for profile updates

### DIFF
--- a/.github/workflows/idol-notifications.yml
+++ b/.github/workflows/idol-notifications.yml
@@ -1,0 +1,29 @@
+name: IDOL Notifications
+on:
+  schedule:
+    # Runs script at 8AM UTC (3AM or 4AM ET) on the first day of every month
+    - cron: '0 23 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: .node-version
+      - name: Use Yarn Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+          restore-keys: yarn-
+      - name: Install
+        run: yarn
+      - name: Profile update notifications
+        env:
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          FIREBASE_PRIVATE_KEY_ID: ${{ secrets.FIREBASE_PRIVATE_KEY_ID }}
+        run: yarn workspace backend send-idol-notifications

--- a/.github/workflows/idol-notifications.yml
+++ b/.github/workflows/idol-notifications.yml
@@ -1,7 +1,7 @@
 name: IDOL Notifications
 on:
   schedule:
-    # Runs script at 8AM UTC (3AM or 4AM ET) on the first day of every month
+    # Runs script at 8AM UTC (6PM or 7PM ET) everyday. This hsould be an hour before pull-from-idol
     - cron: '0 23 * * *'
 
 jobs:

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "dev": "esr src/api.ts",
     "tsc": "tsc",
     "build": "tsc",
-    "update-dev-db": "esr scripts/update-dev-db.ts"
+    "update-dev-db": "esr scripts/update-dev-db.ts",
+    "send-idol-notifications": "esr scripts/send-idol-notifications.ts"
   },
   "license": "AGPL-3.0",
   "dependencies": {

--- a/backend/scripts/send-idol-notifications.ts
+++ b/backend/scripts/send-idol-notifications.ts
@@ -1,0 +1,69 @@
+/* eslint-disable no-console */
+import admin from 'firebase-admin';
+
+require('dotenv').config();
+
+// eslint-disable-next-line import/first
+import getEmailTransporter from '../src/nodemailer';
+// eslint-disable-next-line import/first
+import configureAccount from '../src/utils/firebase-utils';
+
+const serviceAcc = require('../resources/idol-b6c68-firebase-adminsdk-h4e6t-40e4bd5536.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(configureAccount(serviceAcc, true)),
+  databaseURL: 'https://idol-b6c68.firebaseio.com',
+  storageBucket: 'gs://cornelldti-idol.appspot.com'
+});
+
+const db = admin.firestore();
+
+export const sendMail = async (to: string, subject: string, text: string): Promise<unknown> => {
+  const mailOptions = {
+    from: 'dti.idol.github.bot@gmail.com',
+    to,
+    subject: `IDOL Notifs: ${subject}`,
+    text
+  };
+  const transporter = await getEmailTransporter();
+  if (!transporter) return {};
+  const info = await transporter
+    .sendMail(mailOptions)
+    .then((info) => info)
+    .catch((error) => error);
+  return info;
+};
+
+export const sendMemberUpdateNotifications = async () => {
+  const subject = 'IDOL Member Profile Change';
+  const text =
+    "Hey! You are receiving this email because you're an IDOL admin.\n\nThere are DTI members who have updated their profile and are requesting your approval. Please visit https://idol.cornelldti.org/admin/member-review to review the changes.";
+  const adminEmails = await db
+    .collection('admins')
+    .get()
+    .then((docRefs) => docRefs.docs.map((doc) => doc.id));
+  return Promise.all(adminEmails.map((email) => sendMail(email, subject, text)));
+};
+
+const main = async () => {
+  console.log('Reading members and approved-members collections...');
+  const latestMembers = await db
+    .collection('members')
+    .get()
+    .then((vals) => vals.docs.map((doc) => doc.data()));
+
+  const approvedMembers = await db
+    .collection('approved-members')
+    .get()
+    .then((vals) => vals.docs.map((doc) => doc.data()));
+
+  if (JSON.stringify(latestMembers) !== JSON.stringify(approvedMembers)) {
+    console.log('Profile updates detected. Sending email notificatiosn to IDOL admins...');
+    await sendMemberUpdateNotifications();
+    console.log('Emails finished sending.');
+  } else {
+    console.log('No profile updates detected.');
+  }
+};
+
+main();

--- a/backend/src/nodemailer.ts
+++ b/backend/src/nodemailer.ts
@@ -1,6 +1,8 @@
 import nodemailer, { TransportOptions } from 'nodemailer';
 import { google } from 'googleapis';
 
+require('dotenv').config();
+
 const oauth2Client = new google.auth.OAuth2(
   process.env.OAUTH_CLIENTID,
   process.env.OAUTH_CLIENT_SECRET,


### PR DESCRIPTION
### Summary <!-- Required -->

Add cronjob that sends email notifications to IDOL admins if there are unapproved profile updates. The cronjob should run everyday at 6pm (I think 7pm with daylight savings). 

### Notion/Figma Link <!-- Optional -->

N/A
### Test Plan <!-- Required -->
Tested the script locally, won't be able to test cronjob until this is merged. 
