### PR TITLE
Handle errors and configure secrets for notification job

### DIFF
--- a/.github/workflows/idol-notifications.yml
+++ b/.github/workflows/idol-notifications.yml
@@ -26,4 +26,7 @@ jobs:
         env:
           FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
           FIREBASE_PRIVATE_KEY_ID: ${{ secrets.FIREBASE_PRIVATE_KEY_ID }}
+          OAUTH_CLIENTID: ${{ secrets.OAUTH_CLIENTID}}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
         run: yarn workspace backend send-idol-notifications

--- a/backend/scripts/send-idol-notifications.ts
+++ b/backend/scripts/send-idol-notifications.ts
@@ -59,7 +59,12 @@ const main = async () => {
 
   if (JSON.stringify(latestMembers) !== JSON.stringify(approvedMembers)) {
     console.log('Profile updates detected. Sending email notificatiosn to IDOL admins...');
-    await sendMemberUpdateNotifications();
+    try {
+      await sendMemberUpdateNotifications();
+    } catch (e) {
+      console.error(`Failed to send email notifications: ${e}`);
+      process.exit(1);
+    }
     console.log('Emails finished sending.');
   } else {
     console.log('No profile updates detected.');


### PR DESCRIPTION
### Summary <!-- Required -->
Configured GitHub action for IDOL notifications to read oauth secrets for sending emails and added proper handling of errors for failed email sending. 

### Notion/Figma Link <!-- Optional -->
N/A

### Test Plan <!-- Required -->
👀

