### PR TITLE
updateShoutouts only fetches when allShoutouts is empty

### DIFF
--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -17,30 +17,31 @@ const AdminShoutouts: React.FC = () => {
   const [view, setView] = useState<ViewMode>('ALL');
 
   const updateShoutouts = useCallback(() => {
-    ShoutoutsAPI.getAllShoutouts().then((shoutouts) => {
-      if (lastDate < earlyDate) {
-        Emitters.generalError.emit({
-          headerMsg: 'Invalid Date Range',
-          contentMsg:
-            'Please make sure the latest shoutout date is after the earliest shoutout date.'
-        });
-      } else {
-        const filteredShoutouts = shoutouts
-          .filter((shoutout) => {
-            const shoutoutDate = new Date(shoutout.timestamp);
-            return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
-          })
-          .sort((a, b) => a.timestamp - b.timestamp);
-        setAllShoutouts(filteredShoutouts);
-        if (view === 'PRESENT')
-          setDisplayShoutouts(filteredShoutouts.filter((shoutout) => !shoutout.hidden));
-        else if (view === 'HIDDEN')
-          setDisplayShoutouts(filteredShoutouts.filter((shoutout) => shoutout.hidden));
-        else setDisplayShoutouts(filteredShoutouts);
-        setHide(false);
-      }
-    });
-  }, [earlyDate, lastDate, setHide, view]);
+    if (lastDate < earlyDate) {
+      Emitters.generalError.emit({
+        headerMsg: 'Invalid Date Range',
+        contentMsg: 'Please make sure the latest shoutout date is after the earliest shoutout date.'
+      });
+    }
+    if (allShoutouts.length === 0) {
+      ShoutoutsAPI.getAllShoutouts().then((shoutouts) => {
+        setAllShoutouts(shoutouts);
+      });
+    } else {
+      const filteredShoutouts = allShoutouts
+        .filter((shoutout) => {
+          const shoutoutDate = new Date(shoutout.timestamp);
+          return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
+        })
+        .sort((a, b) => a.timestamp - b.timestamp);
+      if (view === 'PRESENT')
+        setDisplayShoutouts(filteredShoutouts.filter((shoutout) => !shoutout.hidden));
+      else if (view === 'HIDDEN')
+        setDisplayShoutouts(filteredShoutouts.filter((shoutout) => shoutout.hidden));
+      else setDisplayShoutouts(filteredShoutouts);
+      setHide(false);
+    }
+  }, [allShoutouts, earlyDate, lastDate, view]);
 
   useEffect(() => {
     updateShoutouts();


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

- broke up the `if` block in `updateShoutouts` into three blocks:
  - first one checks if the date range is valid
  - second one updates `allShoutouts` by calling `getAllShoutouts()` if `allShoutouts` is empty
  - third one filters `allShoutouts` to display only shoutouts that are in the date range and/or hidden if it is not empty
- added `allShoutouts` to the dependency array for `updateShoutouts`

<!-- Optional: If adding/updating endpoints, update the backend api specification (openapi.yaml) -->

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/cornelldti/Shoutouts-Fix-excess-reads-c9c10c482b644ae3a05e07f46f1b3b05?pvs=4

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
![Screen Recording 2023-03-11 at 1 03 43 AM](https://user-images.githubusercontent.com/69322572/224468141-1cbbce12-c332-4caf-93c4-d35ba2a5e5f8.gif)


### Notes <!-- Optional -->

- reloading the page still makes a call to the API, which allows users to fetch any additional shoutouts if they were added after the page loaded

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
