### PR TITLE
Change hoursAttended type of DBTeamEventAttendance and TeamEventAttendance to be number | null

### DIFF
--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -34,7 +34,7 @@ export type DBSignInForm = {
 
 export type DBTeamEventAttendance = {
   member: firestore.DocumentReference;
-  hoursAttended?: number;
+  hoursAttended: number | null;
   image: string;
   eventUuid: string;
   pending: boolean;

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -82,7 +82,7 @@ interface SignInForm {
 
 interface TeamEventAttendance {
   member: IdolMember;
-  hoursAttended?: number;
+  hoursAttended: number | null;
   image: string;
   readonly eventUuid: string;
   readonly pending: boolean;


### PR DESCRIPTION
Firebase does not take undefined as a value, but it does take null. None of our other DB types use undefined. We should update this type so we don't have to explicitly handle an undefined case.