### PR TITLE
Add `ignoreUndefinedProperties` to firestore settings

### DIFF
--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -27,6 +27,7 @@ export const app = admin.initializeApp({
 
 export const bucket = admin.storage().bucket();
 export const db = admin.firestore();
+db.settings({ ignoreUndefinedProperties: true });
 
 export const memberCollection: admin.firestore.CollectionReference<IdolMember> = db
   .collection('members')


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds the `ignoreUndefinedProperties` setting when we initialize the database object. From the firebase docs:

> ignoreUndefinedProperties: boolean

> Whether to skip nested properties that are set to undefined during object serialization. If set to true, these properties are skipped and not written to Firestore. If set to false or omitted, the SDK throws an exception when it encounters properties of type undefined.



### Test Plan <!-- Required -->

:eyes:
