### PR TITLE
Change frontend TE attendance object and Team event submission bug

### DIFF
--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -60,7 +60,7 @@ const TeamEventCreditForm: React.FC = () => {
         headerMsg: 'No Hours Entered',
         contentMsg: 'Please enter your hours!'
       });
-    } else if (Number(hours) < 0.5) {
+    } else if (teamEvent.hasHours && Number(hours) < 0.5) {
       Emitters.generalError.emit({
         headerMsg: 'Minimum Hours Violated',
         contentMsg: 'Team events must be logged for at least 0.5 hours!'
@@ -68,7 +68,7 @@ const TeamEventCreditForm: React.FC = () => {
     } else {
       const newTeamEventAttendance: TeamEventAttendance = {
         member: userInfo,
-        hoursAttended: Number(hours),
+        hoursAttended: teamEvent.hasHours ? Number(hours) : undefined,
         image: `eventProofs/${getNetIDFromEmail(userInfo.email)}/${new Date().toISOString()}`,
         eventUuid: teamEvent.uuid,
         pending: true,


### PR DESCRIPTION
### Summary 

Closes two tickets: Change frontend TE attendance object and Team event submission bug. 

Add a check to make sure team event has hours before validating that the number of hours submitted is under 0.5.
Also only submit the hours field if the event hasHours, otherwise just override the field to submit `undefined`.

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/cornelldti/Change-frontend-TE-attendance-object-7077ac178e2442f0a4f8490f70ad1325?pvs=4

https://www.notion.so/cornelldti/Team-event-submission-bug-a984ffeb39e34a2fabc752f7b3aadead?pvs=4
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Manual testing
<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
