### PR TITLE
Add BaseDao class and refactor daos 

### DIFF
--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -2,6 +2,8 @@ import CandidateDeciderDao from '../dao/CandidateDeciderDao';
 import { NotFoundError, PermissionError } from '../utils/errors';
 import PermissionsManager from '../utils/permissionsManager';
 
+const candidateDeciderDao = new CandidateDeciderDao();
+
 export const getAllCandidateDeciderInstances = async (
   user: IdolMember
 ): Promise<CandidateDeciderInfo[]> => CandidateDeciderDao.getAllInstances();
@@ -14,7 +16,7 @@ export const createNewCandidateDeciderInstance = async (
     throw new PermissionError(
       'User does not have permission to create new Candidate Decider instance'
     );
-  return CandidateDeciderDao.createNewInstance(instance);
+  return candidateDeciderDao.createNewInstance(instance);
 };
 
 export const toggleCandidateDeciderInstance = async (
@@ -25,7 +27,13 @@ export const toggleCandidateDeciderInstance = async (
     throw new PermissionError(
       'User does not have permission to create new Candidate Decider instance'
     );
-  await CandidateDeciderDao.toggleInstance(uuid);
+  const instance = await candidateDeciderDao.getInstance(uuid);
+  if (!instance)
+    throw new NotFoundError(`Candidate decider instance with uuid ${uuid} does not exist!`);
+  await candidateDeciderDao.updateInstance({
+    ...instance,
+    isOpen: !instance.isOpen
+  });
 };
 
 export const deleteCandidateDeciderInstance = async (
@@ -36,14 +44,14 @@ export const deleteCandidateDeciderInstance = async (
     throw new PermissionError(
       'User does not have permission to create new Candidate Decider instance'
     );
-  await CandidateDeciderDao.deleteInstance(uuid);
+  await candidateDeciderDao.deleteInstance(uuid);
 };
 
 export const getCandidateDeciderInstance = async (
   uuid: string,
   user: IdolMember
 ): Promise<CandidateDeciderInstance> => {
-  const instance = await CandidateDeciderDao.getInstance(uuid);
+  const instance = await candidateDeciderDao.getInstance(uuid);
   if (!instance) {
     throw new NotFoundError(`Instance with uuid ${uuid} does not exist`);
   }
@@ -67,7 +75,7 @@ export const updateCandidateDeciderRating = async (
   id: number,
   rating: Rating
 ): Promise<void> => {
-  const instance = await CandidateDeciderDao.getInstance(uuid);
+  const instance = await candidateDeciderDao.getInstance(uuid);
   if (!instance) {
     throw new NotFoundError(`Instance with uuid ${uuid} does not exist`);
   }
@@ -95,7 +103,7 @@ export const updateCandidateDeciderRating = async (
           }
     )
   };
-  CandidateDeciderDao.updateInstance(updatedInstance);
+  candidateDeciderDao.updateInstance(updatedInstance);
 };
 
 export const updateCandidateDeciderComment = async (
@@ -104,7 +112,7 @@ export const updateCandidateDeciderComment = async (
   id: number,
   comment: string
 ): Promise<void> => {
-  const instance = await CandidateDeciderDao.getInstance(uuid);
+  const instance = await candidateDeciderDao.getInstance(uuid);
   if (!instance) {
     throw new NotFoundError(`Instance with uuid ${uuid} does not exist`);
   }
@@ -132,5 +140,5 @@ export const updateCandidateDeciderComment = async (
           }
     )
   };
-  CandidateDeciderDao.updateInstance(updatedInstance);
+  candidateDeciderDao.updateInstance(updatedInstance);
 };

--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -6,7 +6,7 @@ const candidateDeciderDao = new CandidateDeciderDao();
 
 export const getAllCandidateDeciderInstances = async (
   user: IdolMember
-): Promise<CandidateDeciderInfo[]> => CandidateDeciderDao.getAllInstances();
+): Promise<CandidateDeciderInfo[]> => candidateDeciderDao.getAllInstances();
 
 export const createNewCandidateDeciderInstance = async (
   instance: CandidateDeciderInstance,

--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -15,15 +15,15 @@ export const getAllDevPortfolios = async (user: IdolMember): Promise<DevPortfoli
 };
 
 export const getAllDevPortfolioInfo = async (): Promise<DevPortfolioInfo[]> =>
-  DevPortfolioDao.getAllDevPortfolioInfo();
+  devPortfolioDao.getAllDevPortfolioInfo();
 
 export const getDevPortfolioInfo = async (uuid: string): Promise<DevPortfolioInfo> =>
-  DevPortfolioDao.getDevPortfolioInfo(uuid);
+  devPortfolioDao.getDevPortfolioInfo(uuid);
 
 export const getUsersDevPortfolioSubmissions = async (
   uuid: string,
   user: IdolMember
-): Promise<DevPortfolioSubmission[]> => DevPortfolioDao.getUsersDevPortfolioSubmissions(uuid, user);
+): Promise<DevPortfolioSubmission[]> => devPortfolioDao.getUsersDevPortfolioSubmissions(uuid, user);
 
 export const getDevPortfolio = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
@@ -98,7 +98,7 @@ export const makeDevPortfolioSubmission = async (
     );
   }
   const validatedSubmission = await validateSubmission(devPortfolio, submission);
-  return DevPortfolioDao.makeDevPortfolioSubmission(uuid, {
+  return devPortfolioDao.makeDevPortfolioSubmission(uuid, {
     ...validatedSubmission,
     isLate: Boolean(devPortfolio.lateDeadline && Date.now() > devPortfolio.deadline)
   });

--- a/backend/src/API/memberAPI.ts
+++ b/backend/src/API/memberAPI.ts
@@ -6,6 +6,8 @@ import { bucket } from '../firebase';
 import { getNetIDFromEmail, computeMembersDiff } from '../utils/memberUtil';
 import { sendMemberUpdateNotifications } from './mailAPI';
 
+const membersDao = new MembersDao();
+
 export const allMembers = (): Promise<readonly IdolMember[]> => MembersDao.getAllMembers(false);
 
 export const allApprovedMembers = (): Promise<readonly IdolMember[]> =>
@@ -21,7 +23,7 @@ export const setMember = async (body: IdolMember, user: IdolMember): Promise<Ido
   if (!body.email || body.email === '') {
     throw new BadRequestError("Couldn't edit member with undefined email!");
   }
-  return MembersDao.setMember(body.email, body);
+  return membersDao.setMember(body.email, body);
 };
 
 export const updateMember = async (
@@ -50,7 +52,7 @@ export const updateMember = async (
     );
   }
 
-  return MembersDao.updateMember(body.email, body).then(async (mem) => {
+  return membersDao.updateMember(body.email, body).then(async (mem) => {
     sendMemberUpdateNotifications(req);
     return mem;
   });
@@ -66,7 +68,7 @@ export const deleteMember = async (email: string, user: IdolMember): Promise<voi
   if (!email || email === '') {
     throw new BadRequestError("Couldn't delete member with undefined email!");
   }
-  await MembersDao.deleteMember(email).then(() =>
+  await membersDao.deleteMember(email).then(() =>
     deleteImage(email).catch(() => {
       /* Ignore the error since the user might not have a profile picture. */
     })

--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -26,7 +26,7 @@ export const getShoutouts = async (
       `User with email: ${user.email} does not have permission to get shoutouts!`
     );
   }
-  return ShoutoutsDao.getShoutouts(memberEmail, type);
+  return shoutoutsDao.getShoutouts(memberEmail, type);
 };
 
 export const hideShoutout = async (

--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -2,7 +2,9 @@ import PermissionsManager from '../utils/permissionsManager';
 import { NotFoundError, PermissionError } from '../utils/errors';
 import ShoutoutsDao from '../dao/ShoutoutsDao';
 
-export const getAllShoutouts = (): Promise<Shoutout[]> => ShoutoutsDao.getAllShoutouts();
+const shoutoutsDao = new ShoutoutsDao();
+
+export const getAllShoutouts = (): Promise<Shoutout[]> => shoutoutsDao.getAllShoutouts();
 
 export const giveShoutout = async (body: Shoutout, user: IdolMember): Promise<Shoutout> => {
   if (body.giver.email !== user.email) {
@@ -10,7 +12,7 @@ export const giveShoutout = async (body: Shoutout, user: IdolMember): Promise<Sh
       `User with email: ${user.email} can't post a shoutout from a different user!`
     );
   }
-  return ShoutoutsDao.setShoutout(body);
+  return shoutoutsDao.createShoutout(body);
 };
 
 export const getShoutouts = async (
@@ -38,13 +40,13 @@ export const hideShoutout = async (
       `User with email: ${user.email} does not have permission to hide shoutouts!`
     );
   }
-  const shoutout = await ShoutoutsDao.getShoutout(uuid);
+  const shoutout = await shoutoutsDao.getShoutout(uuid);
   if (!shoutout) throw new NotFoundError(`Shoutout with uuid: ${uuid} does not exist!`);
-  await ShoutoutsDao.updateShoutout({ ...shoutout, hidden: hide });
+  await shoutoutsDao.updateShoutout({ ...shoutout, hidden: hide });
 };
 
 export const deleteShoutout = async (uuid: string, user: IdolMember): Promise<void> => {
-  const shoutout = await ShoutoutsDao.getShoutout(uuid);
+  const shoutout = await shoutoutsDao.getShoutout(uuid);
   if (!shoutout) {
     throw new NotFoundError(`No shoutout with id '${uuid}' found.`);
   }
@@ -54,5 +56,5 @@ export const deleteShoutout = async (uuid: string, user: IdolMember): Promise<vo
       `You are not a lead or admin, so you can't delete a shoutout from a different user!`
     );
   }
-  await ShoutoutsDao.deleteShoutout(uuid);
+  await shoutoutsDao.deleteShoutout(uuid);
 };

--- a/backend/src/API/teamAPI.ts
+++ b/backend/src/API/teamAPI.ts
@@ -4,6 +4,8 @@ import { Team } from '../types/DataTypes';
 import { BadRequestError, PermissionError } from '../utils/errors';
 import MembersDao from '../dao/MembersDao';
 
+const membersDao = new MembersDao();
+
 export const allTeams = (): Promise<readonly Team[]> => MembersDao.getAllTeams();
 
 const updateTeamMembers = async (team: Team): Promise<void> => {
@@ -42,7 +44,7 @@ const updateCurrentMembers = async (team: Team, oldTeam: Team): Promise<void> =>
         ...member,
         subteams: [...member.subteams, team.name]
       };
-      await MembersDao.setMember(updatedMember.email, updatedMember);
+      await membersDao.setMember(updatedMember.email, updatedMember);
     })
   );
 
@@ -52,7 +54,7 @@ const updateCurrentMembers = async (team: Team, oldTeam: Team): Promise<void> =>
         ...member,
         subteams: member.subteams.filter((subteam) => subteam !== team.name)
       };
-      MembersDao.setMember(updatedMember.email, updatedMember);
+      membersDao.setMember(updatedMember.email, updatedMember);
     })
   );
 };
@@ -74,7 +76,7 @@ const updateFormerMembers = async (team: Team, oldTeam: Team): Promise<void> => 
         ...member,
         formerSubteams: member.formerSubteams ? [...member.formerSubteams, team.name] : [team.name]
       };
-      await MembersDao.setMember(updatedMember.email, updatedMember);
+      await membersDao.setMember(updatedMember.email, updatedMember);
     })
   );
   await Promise.all(
@@ -85,7 +87,7 @@ const updateFormerMembers = async (team: Team, oldTeam: Team): Promise<void> => 
           ? member.formerSubteams.filter((subteam) => subteam !== team.name)
           : []
       };
-      await MembersDao.setMember(updatedMember.email, updatedMember);
+      await membersDao.setMember(updatedMember.email, updatedMember);
     })
   );
 };

--- a/backend/src/dao/BaseDao.ts
+++ b/backend/src/dao/BaseDao.ts
@@ -1,6 +1,6 @@
 import { firestore } from 'firebase-admin';
 
-export default class BaseDao<E, D> {
+export default abstract class BaseDao<E, D> {
   readonly collection: firestore.CollectionReference<D>;
 
   readonly materializeData: (d: D) => Promise<E>;

--- a/backend/src/dao/BaseDao.ts
+++ b/backend/src/dao/BaseDao.ts
@@ -17,6 +17,11 @@ export default abstract class BaseDao<E, D> {
     this.serializeData = serializeData;
   }
 
+  /**
+   * Gets a document with docID
+   * @param docID
+   * @returns The document with id: docID
+   */
   protected async getDocument(docID: string): Promise<E | null> {
     const doc = await this.collection.doc(docID).get();
     const data = doc.data();
@@ -24,21 +29,40 @@ export default abstract class BaseDao<E, D> {
     return this.materializeData(data);
   }
 
+  /**
+   * @returns All documents in the collection
+   */
   protected async getAllDocuments(): Promise<E[]> {
     const docRefs = await this.collection.get();
     return Promise.all(docRefs.docs.map((doc) => this.materializeData(doc.data())));
   }
 
+  /**
+   * Creates a document with id: docID and data: data
+   * @param docID - The id of the document
+   * @param data - The data in the document
+   * @returns The new document
+   */
   protected async createDocument(docID: string, data: E): Promise<E> {
     const doc = await this.serializeData(data);
     await this.collection.doc(docID).set(doc);
     return data;
   }
 
+  /**
+   * Deletes document with id docID
+   * @param docID - The ide of the document to delete
+   */
   protected async deleteDocument(docID: string): Promise<void> {
     await this.collection.doc(docID).delete();
   }
 
+  /**
+   * Updates a document
+   * @param docID - The id of the document to update
+   * @param data - The updated data for the document
+   * @returns - The newly updated document
+   */
   protected async updateDocument(docID: string, data: E): Promise<E> {
     const doc = await this.serializeData(data);
     await this.collection.doc(docID).update(doc as firestore.UpdateData);

--- a/backend/src/dao/BaseDao.ts
+++ b/backend/src/dao/BaseDao.ts
@@ -1,0 +1,47 @@
+import { firestore } from 'firebase-admin';
+
+export default class BaseDao<E, D> {
+  readonly collection: firestore.CollectionReference<D>;
+
+  readonly materializeData: (d: D) => Promise<E>;
+
+  readonly serializeData: (e: E) => Promise<D>;
+
+  constructor(
+    collection: firestore.CollectionReference<D>,
+    materializeData: (d: D) => Promise<E>,
+    serializeData: (e: E) => Promise<D>
+  ) {
+    this.collection = collection;
+    this.materializeData = materializeData;
+    this.serializeData = serializeData;
+  }
+
+  protected async getDocument(docID: string): Promise<E | null> {
+    const doc = await this.collection.doc(docID).get();
+    const data = doc.data();
+    if (!data) return null;
+    return this.materializeData(data);
+  }
+
+  protected async getAllDocuments(): Promise<E[]> {
+    const docRefs = await this.collection.get();
+    return Promise.all(docRefs.docs.map((doc) => this.materializeData(doc.data())));
+  }
+
+  protected async createDocument(docID: string, data: E): Promise<E> {
+    const doc = await this.serializeData(data);
+    await this.collection.doc(docID).set(doc);
+    return data;
+  }
+
+  protected async deleteDocument(docID: string): Promise<void> {
+    await this.collection.doc(docID).delete();
+  }
+
+  protected async updateDocument(docID: string, data: E): Promise<E> {
+    const doc = await this.serializeData(data);
+    await this.collection.doc(docID).update(doc as firestore.UpdateData);
+    return data;
+  }
+}

--- a/backend/src/dao/CandidateDeciderDao.ts
+++ b/backend/src/dao/CandidateDeciderDao.ts
@@ -66,8 +66,8 @@ export default class CandidateDeciderDao extends BaseDao<
     );
   }
 
-  static async getAllInstances(): Promise<CandidateDeciderInfo[]> {
-    const instanceRefs = await candidateDeciderCollection.get();
+  async getAllInstances(): Promise<CandidateDeciderInfo[]> {
+    const instanceRefs = await this.collection.get();
 
     return Promise.all(
       instanceRefs.docs.map(async (instanceRefs) => {

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -3,6 +3,7 @@ import { devPortfolioCollection, memberCollection } from '../firebase';
 import { DBDevPortfolio, DBDevPortfolioSubmission } from '../types/DataTypes';
 import { getMemberFromDocumentReference } from '../utils/memberUtil';
 import { getSubmissionStatus } from '../utils/githubUtil';
+import BaseDao from './BaseDao';
 
 export function devPortfolioSubmissionToDBDevPortfolioSubmission(
   submission: DevPortfolioSubmission
@@ -13,40 +14,39 @@ export function devPortfolioSubmissionToDBDevPortfolioSubmission(
   };
 }
 
-export default class DevPortfolioDao {
-  private static async DBDevPortfolioToDevPortfolio(data: DBDevPortfolio): Promise<DevPortfolio> {
-    const submissions = await Promise.all(
-      data.submissions.map(async (submission) => {
-        const fromDb = {
-          ...submission,
-          member: await getMemberFromDocumentReference(submission.member)
-        } as DevPortfolioSubmission;
-
-        // since not all submissions could have this field yet
-        if (!fromDb.status) {
-          return { ...fromDb, status: getSubmissionStatus(fromDb) };
-        }
-        return fromDb;
-      })
-    );
-
-    return { ...data, submissions };
-  }
-
-  private static devPortfolioToDBDevPortfolio(instance: DevPortfolio): DBDevPortfolio {
-    return {
-      ...instance,
-      uuid: instance.uuid ? instance.uuid : uuidv4(),
-      submissions: instance.submissions.map((submission) => ({
+async function DBDevPortfolioToDevPortfolio(data: DBDevPortfolio): Promise<DevPortfolio> {
+  const submissions = await Promise.all(
+    data.submissions.map(async (submission) => {
+      const fromDb = {
         ...submission,
-        member: memberCollection.doc(submission.member.email)
-      }))
-    };
-  }
+        member: await getMemberFromDocumentReference(submission.member)
+      } as DevPortfolioSubmission;
 
-  public static async getDevPortfolio(uuid: string): Promise<DevPortfolio> {
-    const doc = await devPortfolioCollection.doc(uuid).get();
-    return this.DBDevPortfolioToDevPortfolio(doc.data() as DBDevPortfolio);
+      // since not all submissions could have this field yet
+      if (!fromDb.status) {
+        return { ...fromDb, status: getSubmissionStatus(fromDb) };
+      }
+      return fromDb;
+    })
+  );
+
+  return { ...data, submissions };
+}
+
+async function devPortfolioToDBDevPortfolio(instance: DevPortfolio): Promise<DBDevPortfolio> {
+  return {
+    ...instance,
+    uuid: instance.uuid ? instance.uuid : uuidv4(),
+    submissions: instance.submissions.map((submission) => ({
+      ...submission,
+      member: memberCollection.doc(submission.member.email)
+    }))
+  };
+}
+
+export default class DevPortfolioDao extends BaseDao<DevPortfolio, DBDevPortfolio> {
+  constructor() {
+    super(devPortfolioCollection, DBDevPortfolioToDevPortfolio, devPortfolioToDBDevPortfolio);
   }
 
   static async makeDevPortfolioSubmission(
@@ -64,23 +64,12 @@ export default class DevPortfolioDao {
     return submission;
   }
 
-  static async getInstance(uuid: string): Promise<DevPortfolio | null> {
-    const doc = await devPortfolioCollection.doc(uuid).get();
-    if (!doc) return null;
-
-    const data = doc.data() as DBDevPortfolio;
-
-    return DevPortfolioDao.DBDevPortfolioToDevPortfolio(data);
+  async getInstance(uuid: string): Promise<DevPortfolio | null> {
+    return this.getDocument(uuid);
   }
 
-  static async getAllInstances(): Promise<DevPortfolio[]> {
-    const instanceRefs = await devPortfolioCollection.get();
-
-    return Promise.all(
-      instanceRefs.docs.map(async (instanceRefs) =>
-        DevPortfolioDao.DBDevPortfolioToDevPortfolio(instanceRefs.data() as DBDevPortfolio)
-      )
-    );
+  async getAllInstances(): Promise<DevPortfolio[]> {
+    return this.getAllDocuments();
   }
 
   public static async getAllDevPortfolioInfo(): Promise<DevPortfolioInfo[]> {
@@ -113,23 +102,19 @@ export default class DevPortfolioDao {
     return dBSubmissions.map((submission) => ({ ...submission, member: user }));
   }
 
-  static async createNewInstance(instance: DevPortfolio): Promise<DevPortfolio> {
-    const portfolio = {
+  async createNewInstance(instance: DevPortfolio): Promise<DevPortfolio> {
+    const instanceWithUUID = {
       ...instance,
-      submissions: [],
       uuid: instance.uuid ? instance.uuid : uuidv4()
     };
-    devPortfolioCollection.doc(portfolio.uuid).set(portfolio);
-    return portfolio;
+    return this.createDocument(instanceWithUUID.uuid, instanceWithUUID);
   }
 
-  static async updateInstance(updatedInstance: DevPortfolio): Promise<void> {
-    const dbInstance = this.devPortfolioToDBDevPortfolio(updatedInstance);
-
-    await devPortfolioCollection.doc(dbInstance.uuid).set(dbInstance);
+  async updateInstance(updatedInstance: DevPortfolio): Promise<DevPortfolio> {
+    return this.updateDocument(updatedInstance.uuid, updatedInstance);
   }
 
-  static async deleteInstance(uuid: string): Promise<void> {
-    await devPortfolioCollection.doc(uuid).delete();
+  async deleteInstance(uuid: string): Promise<void> {
+    await this.deleteDocument(uuid);
   }
 }

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -49,7 +49,7 @@ export default class DevPortfolioDao extends BaseDao<DevPortfolio, DBDevPortfoli
     super(devPortfolioCollection, materializeDevPortfolio, serializeDevPortfolio);
   }
 
-  static async makeDevPortfolioSubmission(
+  async makeDevPortfolioSubmission(
     uuid: string,
     submission: DevPortfolioSubmission
   ): Promise<DevPortfolioSubmission> {
@@ -59,7 +59,7 @@ export default class DevPortfolioDao extends BaseDao<DevPortfolio, DBDevPortfoli
 
     const subs = data.submissions;
     subs.push(devPortfolioSubmissionToDBDevPortfolioSubmission(submission));
-    await devPortfolioCollection.doc(uuid).update({ submissions: subs });
+    await this.collection.doc(uuid).update({ submissions: subs });
 
     return submission;
   }
@@ -72,8 +72,8 @@ export default class DevPortfolioDao extends BaseDao<DevPortfolio, DBDevPortfoli
     return this.getAllDocuments();
   }
 
-  public static async getAllDevPortfolioInfo(): Promise<DevPortfolioInfo[]> {
-    const instanceInfoRefs = await devPortfolioCollection
+  async getAllDevPortfolioInfo(): Promise<DevPortfolioInfo[]> {
+    const instanceInfoRefs = await this.collection
       .select('deadline', 'earliestValidDate', 'name', 'uuid', 'lateDeadline')
       .get();
     return Promise.all(
@@ -84,17 +84,17 @@ export default class DevPortfolioDao extends BaseDao<DevPortfolio, DBDevPortfoli
     );
   }
 
-  public static async getDevPortfolioInfo(uuid: string): Promise<DevPortfolioInfo> {
-    const portfolioRef = await devPortfolioCollection.doc(uuid).get();
+  async getDevPortfolioInfo(uuid: string): Promise<DevPortfolioInfo> {
+    const portfolioRef = await this.collection.doc(uuid).get();
     const { submissions, ...devPortfolioInfo } = portfolioRef.data() as DBDevPortfolio;
     return devPortfolioInfo;
   }
 
-  public static async getUsersDevPortfolioSubmissions(
+  async getUsersDevPortfolioSubmissions(
     uuid: string,
     user: IdolMember
   ): Promise<DevPortfolioSubmission[]> {
-    const portfolioData = (await devPortfolioCollection.doc(uuid).get()).data() as DBDevPortfolio;
+    const portfolioData = (await this.collection.doc(uuid).get()).data() as DBDevPortfolio;
     const dBSubmissions = portfolioData.submissions.filter(
       (submission) => submission.member.id === user.email
     );

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -14,7 +14,7 @@ export function devPortfolioSubmissionToDBDevPortfolioSubmission(
   };
 }
 
-async function DBDevPortfolioToDevPortfolio(data: DBDevPortfolio): Promise<DevPortfolio> {
+async function materializeDevPortfolio(data: DBDevPortfolio): Promise<DevPortfolio> {
   const submissions = await Promise.all(
     data.submissions.map(async (submission) => {
       const fromDb = {
@@ -33,7 +33,7 @@ async function DBDevPortfolioToDevPortfolio(data: DBDevPortfolio): Promise<DevPo
   return { ...data, submissions };
 }
 
-async function devPortfolioToDBDevPortfolio(instance: DevPortfolio): Promise<DBDevPortfolio> {
+async function serializeDevPortfolio(instance: DevPortfolio): Promise<DBDevPortfolio> {
   return {
     ...instance,
     uuid: instance.uuid ? instance.uuid : uuidv4(),
@@ -46,7 +46,7 @@ async function devPortfolioToDBDevPortfolio(instance: DevPortfolio): Promise<DBD
 
 export default class DevPortfolioDao extends BaseDao<DevPortfolio, DBDevPortfolio> {
   constructor() {
-    super(devPortfolioCollection, DBDevPortfolioToDevPortfolio, devPortfolioToDBDevPortfolio);
+    super(devPortfolioCollection, materializeDevPortfolio, serializeDevPortfolio);
   }
 
   static async makeDevPortfolioSubmission(

--- a/backend/src/dao/MembersDao.ts
+++ b/backend/src/dao/MembersDao.ts
@@ -1,8 +1,17 @@
 import { db, approvedMemberCollection, memberCollection } from '../firebase';
 import { Team } from '../types/DataTypes';
 import { archivedMembersBySemesters, archivedMembersByEmail } from '../members-archive';
+import BaseDao from './BaseDao';
 
-export default class MembersDao {
+export default class MembersDao extends BaseDao<IdolMember, IdolMember> {
+  constructor() {
+    super(
+      memberCollection,
+      async (member) => member,
+      async (member) => member
+    );
+  }
+
   static async getAllMembers(fromApproved: boolean): Promise<IdolMember[]> {
     return (fromApproved ? approvedMemberCollection : memberCollection)
       .get()
@@ -24,18 +33,16 @@ export default class MembersDao {
     return archivedMembersByEmail[email];
   }
 
-  static async deleteMember(email: string): Promise<void> {
-    await memberCollection.doc(email).delete();
+  async deleteMember(email: string): Promise<void> {
+    await this.deleteDocument(email);
   }
 
-  static async setMember(email: string, member: IdolMember): Promise<IdolMember> {
-    await memberCollection.doc(email).set(member);
-    return member;
+  async setMember(email: string, member: IdolMember): Promise<IdolMember> {
+    return this.createDocument(email, member);
   }
 
-  static async updateMember(email: string, member: IdolMember): Promise<IdolMember> {
-    await memberCollection.doc(email).update(member);
-    return member;
+  async updateMember(email: string, member: IdolMember): Promise<IdolMember> {
+    return this.updateDocument(email, member);
   }
 
   /**

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -4,14 +4,14 @@ import { DBShoutout } from '../types/DataTypes';
 import { getMemberFromDocumentReference } from '../utils/memberUtil';
 import BaseDao from './BaseDao';
 
-async function shoutoutToDBShoutout(shoutout: Shoutout): Promise<DBShoutout> {
+async function serializeShoutout(shoutout: Shoutout): Promise<DBShoutout> {
   return {
     ...shoutout,
     giver: memberCollection.doc(shoutout.giver.email)
   };
 }
 
-async function dbShoutoutToShoutout(dbShoutout: DBShoutout): Promise<Shoutout> {
+async function materializeShoutout(dbShoutout: DBShoutout): Promise<Shoutout> {
   return {
     ...dbShoutout,
     giver: await getMemberFromDocumentReference(dbShoutout.giver)
@@ -20,7 +20,7 @@ async function dbShoutoutToShoutout(dbShoutout: DBShoutout): Promise<Shoutout> {
 
 export default class ShoutoutsDao extends BaseDao<Shoutout, DBShoutout> {
   constructor() {
-    super(shoutoutCollection, dbShoutoutToShoutout, shoutoutToDBShoutout);
+    super(shoutoutCollection, materializeShoutout, serializeShoutout);
   }
 
   async getAllShoutouts(): Promise<Shoutout[]> {
@@ -33,7 +33,7 @@ export default class ShoutoutsDao extends BaseDao<Shoutout, DBShoutout> {
       .where(givenOrReceived, '==', memberCollection.doc(email))
       .get();
     return Promise.all(
-      shoutoutRefs.docs.map(async (shoutoutRef) => dbShoutoutToShoutout(shoutoutRef.data()))
+      shoutoutRefs.docs.map(async (shoutoutRef) => materializeShoutout(shoutoutRef.data()))
     );
   }
 

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -27,9 +27,9 @@ export default class ShoutoutsDao extends BaseDao<Shoutout, DBShoutout> {
     return this.getAllDocuments();
   }
 
-  static async getShoutouts(email: string, type: 'given' | 'received'): Promise<Shoutout[]> {
+  async getShoutouts(email: string, type: 'given' | 'received'): Promise<Shoutout[]> {
     const givenOrReceived = type === 'given' ? 'giver' : 'receiver';
-    const shoutoutRefs = await shoutoutCollection
+    const shoutoutRefs = await this.collection
       .where(givenOrReceived, '==', memberCollection.doc(email))
       .get();
     return Promise.all(

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -1,22 +1,30 @@
 import { v4 as uuidv4 } from 'uuid';
 import { memberCollection, shoutoutCollection } from '../firebase';
 import { DBShoutout } from '../types/DataTypes';
-import { NotFoundError } from '../utils/errors';
 import { getMemberFromDocumentReference } from '../utils/memberUtil';
+import BaseDao from './BaseDao';
 
-export default class ShoutoutsDao {
-  static async getAllShoutouts(): Promise<Shoutout[]> {
-    const shoutoutRefs = await shoutoutCollection.get();
-    return Promise.all(
-      shoutoutRefs.docs.map(async (doc) => {
-        const dbShoutout = doc.data() as DBShoutout;
-        const giver = await getMemberFromDocumentReference(dbShoutout.giver);
-        return {
-          ...dbShoutout,
-          giver
-        };
-      })
-    );
+async function shoutoutToDBShoutout(shoutout: Shoutout): Promise<DBShoutout> {
+  return {
+    ...shoutout,
+    giver: memberCollection.doc(shoutout.giver.email)
+  };
+}
+
+async function dbShoutoutToShoutout(dbShoutout: DBShoutout): Promise<Shoutout> {
+  return {
+    ...dbShoutout,
+    giver: await getMemberFromDocumentReference(dbShoutout.giver)
+  };
+}
+
+export default class ShoutoutsDao extends BaseDao<Shoutout, DBShoutout> {
+  constructor() {
+    super(shoutoutCollection, dbShoutoutToShoutout, shoutoutToDBShoutout);
+  }
+
+  async getAllShoutouts(): Promise<Shoutout[]> {
+    return this.getAllDocuments();
   }
 
   static async getShoutouts(email: string, type: 'given' | 'received'): Promise<Shoutout[]> {
@@ -25,62 +33,27 @@ export default class ShoutoutsDao {
       .where(givenOrReceived, '==', memberCollection.doc(email))
       .get();
     return Promise.all(
-      shoutoutRefs.docs.map(async (shoutoutRef) => {
-        const { giver, receiver, message, isAnon, timestamp, hidden, uuid } = shoutoutRef.data();
-        return {
-          giver: await getMemberFromDocumentReference(giver),
-          receiver,
-          message,
-          isAnon,
-          timestamp,
-          hidden,
-          uuid
-        };
-      })
+      shoutoutRefs.docs.map(async (shoutoutRef) => dbShoutoutToShoutout(shoutoutRef.data()))
     );
   }
 
-  static async getShoutout(uuid: string): Promise<Shoutout | undefined> {
-    const doc = await shoutoutCollection.doc(uuid).get();
-    const dbShoutout = doc.data();
-    if (!dbShoutout) return undefined;
-    return {
-      ...dbShoutout,
-      giver: await getMemberFromDocumentReference(dbShoutout.giver)
-    };
+  async getShoutout(uuid: string): Promise<Shoutout | null> {
+    return this.getDocument(uuid);
   }
 
-  static async setShoutout(shoutout: {
-    giver: IdolMember;
-    receiver: string;
-    message: string;
-    isAnon: boolean;
-    timestamp: number;
-    hidden: boolean;
-    uuid: string;
-  }): Promise<Shoutout> {
-    const shoutoutRef: DBShoutout = {
+  async createShoutout(shoutout: Shoutout): Promise<Shoutout> {
+    const shoutoutWithUUID = {
       ...shoutout,
-      giver: memberCollection.doc(shoutout.giver.email),
       uuid: shoutout.uuid ? shoutout.uuid : uuidv4()
     };
-    await shoutoutCollection.doc(shoutoutRef.uuid).set(shoutoutRef);
-    return shoutout;
+    return this.createDocument(shoutoutWithUUID.uuid, shoutoutWithUUID);
   }
 
-  static async updateShoutout(shoutout: Shoutout): Promise<Shoutout> {
-    const shoutoutDoc = shoutoutCollection.doc(shoutout.uuid);
-    const ref = await shoutoutDoc.get();
-    if (!ref.exists) throw new NotFoundError(`No shoutout '${shoutout.uuid}' exists.`);
-    const shoutoutRef: DBShoutout = {
-      ...shoutout,
-      giver: memberCollection.doc(shoutout.giver.email)
-    };
-    await shoutoutCollection.doc(shoutout.uuid).update(shoutoutRef);
-    return shoutout;
+  async updateShoutout(shoutout: Shoutout): Promise<Shoutout> {
+    return this.updateDocument(shoutout.uuid, shoutout);
   }
 
-  static async deleteShoutout(uuid: string): Promise<void> {
-    await shoutoutCollection.doc(uuid).delete();
+  async deleteShoutout(uuid: string): Promise<void> {
+    await this.deleteDocument(uuid);
   }
 }

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -6,7 +6,8 @@ import {
   deleteDevPortfolio,
   createNewDevPortfolio,
   makeDevPortfolioSubmission,
-  regradeSubmissions
+  regradeSubmissions,
+  devPortfolioDao
 } from '../src/API/devPortfolioAPI';
 import { PermissionError, BadRequestError } from '../src/utils/errors';
 import * as githubUtils from '../src/utils/githubUtil';
@@ -69,15 +70,15 @@ describe('User is lead or admin', () => {
     const mockDeleteInstance = jest.fn().mockResolvedValue(undefined);
 
     PermissionsManager.isLeadOrAdmin = mockIsLeadOrAdmin;
-    DevPortfolioDao.createNewInstance = mockCreateInstance;
-    DevPortfolioDao.getDevPortfolio = mockGetInstance;
-    DevPortfolioDao.deleteInstance = mockDeleteInstance;
+    devPortfolioDao.createNewInstance = mockCreateInstance;
+    devPortfolioDao.getInstance = mockGetInstance;
+    devPortfolioDao.deleteInstance = mockDeleteInstance;
   });
 
   describe('regradeSubmissions tests', () => {
     test("regradeSubmissions should fail if uuid isn't valid", async () => {
       const mockGetInstance = jest.fn().mockResolvedValue(null);
-      DevPortfolioDao.getInstance = mockGetInstance;
+      devPortfolioDao.getInstance = mockGetInstance;
       expect(regradeSubmissions('<fake-uuid>', user)).rejects.toThrow(
         new BadRequestError('Dev portfolio with uuid: <kewl-uuid> does not exist')
       );
@@ -91,8 +92,8 @@ describe('User is lead or admin', () => {
       };
       const mockGetInstance = jest.fn().mockResolvedValue(dp);
       const mockUpdateInstance = jest.fn();
-      DevPortfolioDao.getInstance = mockGetInstance;
-      DevPortfolioDao.updateInstance = mockUpdateInstance;
+      devPortfolioDao.getInstance = mockGetInstance;
+      devPortfolioDao.updateInstance = mockUpdateInstance;
 
       await regradeSubmissions('<kewl-uuid>', user);
       expect(mockValidateSubmission.mock.calls.length).toBeGreaterThan(1);
@@ -103,7 +104,7 @@ describe('User is lead or admin', () => {
   test('getDevPortfolio should be successful', async () => {
     const dp = await getDevPortfolio(devPortfolio.uuid, user);
     expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
-    expect(DevPortfolioDao.getDevPortfolio).toBeCalled();
+    expect(devPortfolioDao.getInstance).toBeCalled();
     expect(dp.uuid).toEqual(devPortfolio.uuid);
   });
 
@@ -113,12 +114,12 @@ describe('User is lead or admin', () => {
     const expectedLateDeadline = new Date(devPortfolio.lateDeadline).setHours(23, 59, 59);
     await createNewDevPortfolio(devPortfolio, user);
     expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
-    expect(DevPortfolioDao.createNewInstance).toBeCalled();
-    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].deadline).toEqual(expectedDeadline);
-    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].earliestValidDate).toEqual(
+    expect(devPortfolioDao.createNewInstance).toBeCalled();
+    expect(devPortfolioDao.createNewInstance.mock.calls[0][0].deadline).toEqual(expectedDeadline);
+    expect(devPortfolioDao.createNewInstance.mock.calls[0][0].earliestValidDate).toEqual(
       expectedEarliestValidDate
     );
-    expect(DevPortfolioDao.createNewInstance.mock.calls[0][0].lateDeadline).toEqual(
+    expect(devPortfolioDao.createNewInstance.mock.calls[0][0].lateDeadline).toEqual(
       expectedLateDeadline
     );
   });
@@ -158,7 +159,7 @@ describe('User is lead or admin', () => {
   test('deleteDevPortfolio should be successful', async () => {
     await deleteDevPortfolio(devPortfolio.uuid, user);
     expect(PermissionsManager.isLeadOrAdmin).toBeCalled();
-    expect(DevPortfolioDao.deleteInstance).toBeCalled();
+    expect(devPortfolioDao.deleteInstance).toBeCalled();
   });
 });
 
@@ -173,7 +174,7 @@ describe('makeDevPortfolioSubmission tests', () => {
 
   it('should throw BadRequestError', async () => {
     const mockGetDevPortfolio = jest.fn().mockResolvedValue(null);
-    DevPortfolioDao.getDevPortfolio = mockGetDevPortfolio;
+    devPortfolioDao.getInstance = mockGetDevPortfolio;
     expect(makeDevPortfolioSubmission(devPortfolio.uuid, dpSubmission)).rejects.toThrow(
       new BadRequestError(`Dev portfolio with uuid ${devPortfolio.uuid} does not exist.`)
     );
@@ -184,7 +185,7 @@ describe('makeDevPortfolioSubmission tests', () => {
 
     beforeAll(() => {
       const mockGetDevPortfolio = jest.fn().mockResolvedValue(devPortfolio);
-      DevPortfolioDao.getDevPortfolio = mockGetDevPortfolio;
+      devPortfolioDao.getInstance = mockGetDevPortfolio;
     });
 
     afterEach(() => {

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -169,7 +169,7 @@ describe('makeDevPortfolioSubmission tests', () => {
 
   beforeAll(() => {
     const mockMakeDevPortfolioSubmission = jest.fn().mockResolvedValue(dpSubmission);
-    DevPortfolioDao.makeDevPortfolioSubmission = mockMakeDevPortfolioSubmission;
+    devPortfolioDao.makeDevPortfolioSubmission = mockMakeDevPortfolioSubmission;
   });
 
   it('should throw BadRequestError', async () => {
@@ -201,7 +201,7 @@ describe('makeDevPortfolioSubmission tests', () => {
         await makeDevPortfolioSubmission(devPortfolio.uuid, dpSubmission);
         expect(mockIsWithinDates.mock.calls[0][1]).toEqual(devPortfolio.earliestValidDate);
         expect(mockIsWithinDates.mock.calls[0][2]).toEqual(devPortfolio.lateDeadline);
-        expect(DevPortfolioDao.makeDevPortfolioSubmission).toBeCalled();
+        expect(devPortfolioDao.makeDevPortfolioSubmission).toBeCalled();
       });
     });
 
@@ -218,7 +218,7 @@ describe('makeDevPortfolioSubmission tests', () => {
             ).toDateString()} and ${new Date(devPortfolio.deadline).toDateString()}.`
           )
         );
-        expect(DevPortfolioDao.makeDevPortfolioSubmission).not.toBeCalled();
+        expect(devPortfolioDao.makeDevPortfolioSubmission).not.toBeCalled();
       });
     });
   });

--- a/backend/tests/DevPortfolioDao.test.ts
+++ b/backend/tests/DevPortfolioDao.test.ts
@@ -6,10 +6,12 @@ const mockDP = fakeDevPortfolio();
 const mockDP2 = fakeDevPortfolio();
 const mockDP3 = fakeDevPortfolio();
 
+const devPortfolioDao = new DevPortfolioDao();
+
 beforeAll(async () => {
-  await DevPortfolioDao.createNewInstance(mockDP);
-  await DevPortfolioDao.createNewInstance(mockDP2);
-  await DevPortfolioDao.createNewInstance(mockDP3);
+  await devPortfolioDao.createNewInstance(mockDP);
+  await devPortfolioDao.createNewInstance(mockDP2);
+  await devPortfolioDao.createNewInstance(mockDP3);
 });
 
 /* Cleanup database after running DevPortfolioDao tests */
@@ -27,7 +29,7 @@ afterAll(async () => {
 // });
 
 test('Get all instances', () =>
-  DevPortfolioDao.getAllInstances().then((allSubmissions) => {
+  devPortfolioDao.getAllInstances().then((allSubmissions) => {
     expect(allSubmissions.some((submission) => submission === mockDP));
     expect(allSubmissions.some((submission) => submission === mockDP2));
     expect(allSubmissions.some((submission) => submission === mockDP3));

--- a/backend/tests/MembersDao.test.ts
+++ b/backend/tests/MembersDao.test.ts
@@ -9,12 +9,14 @@ const mockUsers = {
   mu3: fakeIdolMember()
 };
 
+const membersDao = new MembersDao();
+
 /* Cleanup database after running MembersDao tests */
 afterAll(async () =>
   Promise.all(
     Object.keys(mockUsers).map(async (netid) => {
       const mockUser = mockUsers[netid];
-      await MembersDao.deleteMember(mockUser.email);
+      await membersDao.deleteMember(mockUser.email);
       await approvedMemberCollection.doc(mockUser.email).delete();
       return mockUser;
     })
@@ -23,7 +25,7 @@ afterAll(async () =>
 
 test('Add new member', () => {
   const mockUser = mockUsers.mu1 as IdolMember;
-  return MembersDao.setMember(mockUser.email, mockUser).then(() => {
+  return membersDao.setMember(mockUser.email, mockUser).then(() => {
     MembersDao.getCurrentOrPastMemberByEmail(mockUser.email).then((member) => {
       expect(member).toEqual(mockUser);
     });
@@ -37,7 +39,7 @@ test('Get member from past semester', () =>
 
 test('Approve member information changes', () => {
   const mockUser = mockUsers.mu2 as IdolMember;
-  return MembersDao.setMember(mockUser.email, mockUser).then(() => {
+  return membersDao.setMember(mockUser.email, mockUser).then(() => {
     MembersDao.approveMemberInformationChanges([mockUser.email]).then(() => {
       MembersDao.getAllMembers(true).then((allApprovedMembers) => {
         expect(allApprovedMembers.find((member) => member.email === mockUser.email)).toBeDefined();
@@ -48,9 +50,10 @@ test('Approve member information changes', () => {
 
 test('Revert member information changes', async () => {
   const mockUser = mockUsers.mu3 as IdolMember;
-  const mockUserRef = await MembersDao.setMember(mockUser.email, mockUser).then(() =>
+  const mockUserRef = await membersDao.setMember(mockUser.email, mockUser).then(() =>
     MembersDao.approveMemberInformationChanges([mockUser.email]).then(() =>
-      MembersDao.updateMember(mockUser.email, { ...mockUser, major: 'Information Science' })
+      membersDao
+        .updateMember(mockUser.email, { ...mockUser, major: 'Information Science' })
         .then(() => MembersDao.revertMemberInformationChanges([mockUser.email]))
         .then(() => memberCollection.doc(mockUser.email).get())
     )

--- a/backend/tests/ShoutoutsDao.test.ts
+++ b/backend/tests/ShoutoutsDao.test.ts
@@ -49,7 +49,7 @@ test('Send shoutout', async () => {
 });
 
 test('Get sent shoutout', async () => {
-  const shoutoutsSent = await ShoutoutsDao.getShoutouts(shoutoutData.mu1.email, 'given');
+  const shoutoutsSent = await shoutoutsDao.getShoutouts(shoutoutData.mu1.email, 'given');
   expect(shoutoutsSent).toContainEqual(mockShoutout1);
 });
 

--- a/backend/tests/ShoutoutsDao.test.ts
+++ b/backend/tests/ShoutoutsDao.test.ts
@@ -17,9 +17,12 @@ const mockShoutout1 = {
   uuid: 'xyz'
 };
 
+const membersDao = new MembersDao();
+const shoutoutsDao = new ShoutoutsDao();
+
 /* Adding mock users for testing sign-ins */
 beforeAll(async () => {
-  await MembersDao.setMember(shoutoutData.mu1.email, shoutoutData.mu1);
+  await membersDao.setMember(shoutoutData.mu1.email, shoutoutData.mu1);
 });
 
 /* Cleanup database after running tests */
@@ -27,7 +30,7 @@ afterAll(async () => {
   Promise.all(
     Object.keys(shoutoutData).map(async (netid) => {
       const mockUser = shoutoutData[netid];
-      await MembersDao.deleteMember(mockUser.email);
+      await membersDao.deleteMember(mockUser.email);
       return mockUser;
     })
   );
@@ -40,8 +43,8 @@ afterAll(async () => {
 });
 
 test('Send shoutout', async () => {
-  await ShoutoutsDao.setShoutout(mockShoutout1);
-  const allShoutouts = await ShoutoutsDao.getAllShoutouts();
+  await shoutoutsDao.createShoutout(mockShoutout1);
+  const allShoutouts = await shoutoutsDao.getAllShoutouts();
   expect(allShoutouts).toContainEqual(mockShoutout1);
 });
 
@@ -51,6 +54,6 @@ test('Get sent shoutout', async () => {
 });
 
 test('Hide shoutout', async () => {
-  const hiddenShoutout = await ShoutoutsDao.updateShoutout(mockShoutout1);
+  const hiddenShoutout = await shoutoutsDao.updateShoutout(mockShoutout1);
   expect(hiddenShoutout.hidden === true);
 });

--- a/backend/tests/SignInFormDao.test.ts
+++ b/backend/tests/SignInFormDao.test.ts
@@ -1,6 +1,5 @@
 import MembersDao from '../src/dao/MembersDao';
 import SignInFormDao from '../src/dao/SignInFormDao';
-import { SignInForm } from '../src/types/DataTypes';
 import { approvedMemberCollection } from '../src/firebase';
 import { fakeIdolMember } from './data/createData';
 import mockForms from './data/mock-signin.json';
@@ -9,10 +8,12 @@ const users = {
   mu1: fakeIdolMember()
 };
 
+const membersDao = new MembersDao();
+
 /* Adding mock user for testing sign-ins */
 beforeAll(async () => {
   const mockUser = users.mu1 as IdolMember;
-  await MembersDao.setMember(mockUser.email, mockUser);
+  await membersDao.setMember(mockUser.email, mockUser);
 });
 
 /* Cleanup database after running SignInFormDao tests */
@@ -22,7 +23,7 @@ afterAll(async () => {
       await SignInFormDao.deleteSignIn(id);
     })
   );
-  await MembersDao.deleteMember(users.mu1.email);
+  await membersDao.deleteMember(users.mu1.email);
   await approvedMemberCollection.doc(users.mu1.email).delete();
 });
 


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds a new `BaseDao` class that is intended to serve as a parent class for the other Dao classes by implementing some of the shared CRUD logic. 

Dao classes that inherit from `BaseDao` need to supply the data type, the db data type, a Firestore collection, a function for materializing data from a document, and a function for serializing data into a document. 

```
export default abstract class BaseDao<E, D> {
  readonly collection: firestore.CollectionReference<D>;

  readonly materializeData: (d: D) => Promise<E>;

  readonly serializeData: (e: E) => Promise<D>;

  constructor(
    collection: firestore.CollectionReference<D>,
    materializeData: (d: D) => Promise<E>,
    serializeData: (e: E) => Promise<D>
  ) {
    this.collection = collection;
    this.materializeData = materializeData;
    this.serializeData = serializeData;
  }
```

### Notion/Figma Link <!-- Optional -->

N/A

### Test Plan <!-- Required -->

Did manually testing on IDOL, fixed existing backend test suite and all tests pass. 

### Notes <!-- Optional -->

This PR doesn't change the `SignInFormDao` since the methods' params are different than the other Dao classes so changing `SignInFormDao` to be consistent with the other Daos would require some bigger changes.  
