### PR TITLE
Restrict staging to only IDOL admins

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -80,6 +80,7 @@ import {
   updateSubmissions
 } from './API/devPortfolioAPI';
 import DPSubmissionRequestLogDao from './dao/DPSubmissionRequestLogDao';
+import AdminsDao from './dao/AdminsDao';
 
 // Constants and configurations
 const app = express();
@@ -189,10 +190,15 @@ router.get('/allApprovedMembers', async (_, res) => {
 router.get('/membersFromAllSemesters', async (_, res) => {
   res.status(200).json(await MembersDao.getMembersFromAllSemesters());
 });
-router.get('/isIDOLMember/:email', async (req, res) => {
+router.get('/hasIDOLAccess/:email', async (req, res) => {
   const members = await allMembers();
+  const adminEmails = await AdminsDao.getAllAdminEmails();
+
+  if (env === 'staging' && !adminEmails.includes(req.params.email)) {
+    res.status(200).json({ hasIDOLAccess: false });
+  }
   res.status(200).json({
-    isIDOLMember: members.find((member) => member.email === req.params.email) !== undefined
+    hasIDOLAccess: members.find((member) => member.email === req.params.email) !== undefined
   });
 });
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -4,7 +4,7 @@ import cors from 'cors';
 import admin from 'firebase-admin';
 import * as winston from 'winston';
 import * as expressWinston from 'express-winston';
-import { app as adminApp } from './firebase';
+import { app as adminApp, env } from './firebase';
 import PermissionsManager from './utils/permissionsManager';
 import { HandlerError } from './utils/errors';
 import {
@@ -86,7 +86,7 @@ const app = express();
 const router = express.Router();
 const PORT = process.env.PORT || 9000;
 const allowAllOrigins = false;
-export const isProd: boolean = process.env.ENV === 'staging' || process.env.ENV === 'prod';
+export const isProd: boolean = env === 'staging' || env === 'prod';
 
 export const enforceSession = true;
 // eslint-disable-next-line no-nested-ternary
@@ -147,6 +147,9 @@ const loginCheckedHandler =
     if (!user) {
       res.status(401).send({ error: `No user with email: ${userEmail}` });
       return;
+    }
+    if (env === 'staging' && !(await PermissionsManager.isAdmin(user))) {
+      res.status(401).json({ error: 'Only admins users have permismsions to the staging API!' });
     }
     try {
       res.status(200).send(await handler(req, user));

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -15,7 +15,8 @@ require('dotenv').config();
 const useProdDb: boolean = process.env.USE_PROD_DB
   ? JSON.parse(process.env.USE_PROD_DB as string)
   : true;
-const env: string | undefined = process.env.ENV;
+
+export const env: string | undefined = process.env.ENV;
 
 const useProdFirebaseConfig = !(env === 'prod' || env === 'staging') ? useProdDb : env === 'prod';
 

--- a/frontend/src/API/MembersAPI.ts
+++ b/frontend/src/API/MembersAPI.ts
@@ -25,8 +25,8 @@ export class MembersAPI {
     return APIWrapper.post(`${backendURL}/updateMember`, member).then((res) => res.data);
   }
 
-  public static isIDOLMember(email: string): Promise<boolean> {
-    return APIWrapper.get(`${backendURL}/isIDOLMember/${email}`).then(
+  public static hasIDOLAccess(email: string): Promise<boolean> {
+    return APIWrapper.get(`${backendURL}/hasIDOLAccess/${email}`).then(
       (res) => res.data.isIDOLMember
     );
   }

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../firebase';
 import { useUserEmail } from './UserProvider/UserProvider';
 import { Team } from '../../API/TeamsAPI';
-import { isProduction, allowAdmin } from '../../environment';
+import { isProduction, allowAdmin, environment } from '../../environment';
 import { MembersAPI } from '../../API/MembersAPI';
 
 type ListenedFirestoreData = {
@@ -88,7 +88,7 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
   const [adminEmails, setAdminEmails] = useState<readonly string[] | undefined>();
   const [members, setMembers] = useState<readonly IdolMember[] | undefined>();
   const [approvedMembers, setApprovedMembers] = useState<readonly IdolMember[] | undefined>();
-  const [isIDOLMember, setIsIDOLMember] = useState(true);
+  const [hasIDOLAccess, setHasIDOLAccess] = useState(true);
 
   const userEmail = useUserEmail();
 
@@ -98,7 +98,7 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
         // Do not run firestore listeners in test environment.
       };
     }
-    MembersAPI.isIDOLMember(userEmail).then((isIDOLMember) => setIsIDOLMember(isIDOLMember));
+    MembersAPI.hasIDOLAccess(userEmail).then((hasIDOLAccess) => setHasIDOLAccess(hasIDOLAccess));
     const unsubscriberOfAdminEmails = onSnapshot(adminsCollection, (snapshot) => {
       setAdminEmails(snapshot.docs.map((it) => it.id));
     });
@@ -115,6 +115,11 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
     };
   }, [userEmail]);
 
+  const errorMessage =
+    environment === 'staging'
+      ? "It looks like you've found IDOL's staging site by accident. Unless you're an IDOL admin, you don't have access to the staging site. Please visit https://idol.cornelldti.org to access IDOL's live site."
+      : 'You do not appear to be registered as a user within the IDOL system. Only DTI members should have access to this site. If you are a DTI member, please make sure that you are logged in with your @cornell.edu email address. If you are logged in with your @cornell.edu email address and are still seeing this message, please use the #idol-support channel in Slack to get in touch with the IDOL team and receive assistance.';
+
   return (
     <FirestoreDataContext.Provider value={{ adminEmails, members, approvedMembers }}>
       {
@@ -124,16 +129,12 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
       {adminEmails == null || members == null || approvedMembers == null ? (
         <div>
           <Loader active size="massive" />
-          {!isIDOLMember && (
+          {!hasIDOLAccess && (
             <Modal
               basic
-              open={!isIDOLMember}
+              open={!hasIDOLAccess}
               header="Hey there :)"
-              content="You do not appear to be registered as a user within the IDOL system. Only DTI members should
-            have access to this site. If you are a DTI member, please make sure that you are logged in
-            with your @cornell.edu email address. If you are logged in with your @cornell.edu email
-            address and are still seeing this message, please use the #idol-support channel in Slack to
-            get in touch with the IDOL team and receive assistance."
+              content={errorMessage}
               actions={[{ key: 'sign-out', content: 'Sign out', onClick: () => auth.signOut() }]}
             />
           )}


### PR DESCRIPTION
### Summary <!-- Required -->
This PR restricts access to the staging API to only admins.


### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/Staging-Env-Only-allow-admins-to-access-the-staging-site-4ed8bac0895845b18790d25bfe8179c9?pvs=4)
### Test Plan <!-- Required -->
If you remove yourself from the cornelldti-idol-dev `admins` collection, you shouldn't be able to access staging anymore and should see a staging specific error message.  
### Notes <!-- Optional -->

I also edited Firestore rules to limit reading members to only admins 