### PR TITLE
Reduce db reads on login 

### DIFF
--- a/backend/src/API/memberAPI.ts
+++ b/backend/src/API/memberAPI.ts
@@ -24,6 +24,9 @@ export const setMember = async (body: IdolMember, user: IdolMember): Promise<Ido
   return MembersDao.setMember(body.email, body);
 };
 
+export const getMember = async (email: string): Promise<IdolMember | undefined> =>
+  MembersDao.getMember(email);
+
 export const updateMember = async (
   req: Request,
   body: IdolMember,

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -22,7 +22,8 @@ import {
   deleteMember,
   updateMember,
   getUserInformationDifference,
-  reviewUserInformationChange
+  reviewUserInformationChange,
+  getMember
 } from './API/memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './API/imageAPI';
 import { allTeams, setTeam, deleteTeam } from './API/teamAPI';
@@ -182,9 +183,9 @@ router.get('/membersFromAllSemesters', async (_, res) => {
   res.status(200).json(await MembersDao.getMembersFromAllSemesters());
 });
 router.get('/isIDOLMember/:email', async (req, res) => {
-  const members = await allMembers();
+  const member = await getMember(req.params.email);
   res.status(200).json({
-    isIDOLMember: members.find((member) => member.email === req.params.email) !== undefined
+    isIDOLMember: member !== undefined
   });
 });
 

--- a/backend/src/dao/MembersDao.ts
+++ b/backend/src/dao/MembersDao.ts
@@ -16,6 +16,13 @@ export default class MembersDao {
     };
   }
 
+  static async getMember(email: string): Promise<IdolMember | undefined> {
+    return memberCollection
+      .doc(email)
+      .get()
+      .then((docRef) => docRef.data());
+  }
+
   static async getCurrentOrPastMemberByEmail(email: string): Promise<IdolMember | undefined> {
     // Although it might require an extra async lookup, this is necessary for correctness,
     // because we want to get the latest info of the member that are also a member in the past.


### PR DESCRIPTION
### Summary <!-- Required -->

This PR attempts to reduce the number of db reads when a user is logging in from the frontend. Previously, when a user logins in, the client hits the `/isIDOLMember/:email` endpoint which reads all documents from the `members` collection. This PR changes the endpoint to only read a single document with the user's email. 

### Notion/Figma Link <!-- Optional -->
N/A

### Test Plan <!-- Required -->

Should still be able to login with your @cornell.edu email and see error message with non-@cornell.edu email.
