### PR TITLE
Fix mock data in createData.ts

### DIFF
--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -7,9 +7,7 @@ const getRandomInt = (a, b) => {
   return Math.floor(Math.random() * (max - min + 1) + min);
 };
 
-const getRandomBoolean = () => {
-  return getRandomInt(0, 1) === 0;
-};
+const getRandomBoolean = () => getRandomInt(0, 1) === 0;
 
 /** Get year string. Ex. "2023" */
 const fakeYear = (): string => {

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -68,7 +68,7 @@ export const fakeTeamEventAttendance = (): TeamEventAttendance => {
   const TEA = {
     member: fakeIdolMember(),
     hoursAttended: getRandomInt(1, 5),
-    image: null,
+    image: '',
     eventUuid: faker.datatype.uuid(),
     pending: true,
     uuid: faker.datatype.uuid()
@@ -108,7 +108,7 @@ const fakePRs = (): PullRequestSubmission[] => {
 
 /** Create a fake Dev Submission */
 export const fakeDevPortfolioSubmission = (): DevPortfolioSubmission => {
-  const DPSub = {
+  const DPSub: DevPortfolioSubmission = {
     member: fakeIdolMember(),
     openedPRs: fakePRs(),
     reviewedPRs: fakePRs(),

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { TeamEventAttendance, TeamEvent } from '../../src/types/DataTypes';
 
 /** Get random number in range [`a`,`b`], inclusive. */
 const getRandomInt = (a, b) => {
@@ -7,6 +6,10 @@ const getRandomInt = (a, b) => {
   const max = Math.floor(b);
   return Math.floor(Math.random() * (max - min + 1) + min);
 };
+
+const getRandomBoolean = () => {
+  return getRandomInt(0, 1) === 0;
+}
 
 /** Get year string. Ex. "2023" */
 const fakeYear = (): string => {
@@ -81,10 +84,11 @@ export const fakeTeamEvent = (): TeamEvent => {
     name: 'testteamevent', // to easily be able to tell fake TeamEvents if needed
     date: faker.date.past().toLocaleDateString(),
     numCredits: getRandomInt(1, 3).toString(),
-    hasHours: getRandomInt(0, 1) === 0,
+    hasHours: getRandomBoolean(),
     requests: [fakeTeamEventAttendance()],
     attendees: [],
-    uuid: faker.datatype.uuid()
+    uuid: faker.datatype.uuid(),
+    isCommunity: getRandomBoolean(),
   };
   return TE;
 };
@@ -109,7 +113,8 @@ export const fakeDevPortfolioSubmission = (): DevPortfolioSubmission => {
   const DPSub = {
     member: fakeIdolMember(),
     openedPRs: fakePRs(),
-    reviewedPRs: fakePRs()
+    reviewedPRs: fakePRs(),
+    status: 'pending'
   };
   return DPSub;
 };

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -9,7 +9,7 @@ const getRandomInt = (a, b) => {
 
 const getRandomBoolean = () => {
   return getRandomInt(0, 1) === 0;
-}
+};
 
 /** Get year string. Ex. "2023" */
 const fakeYear = (): string => {
@@ -88,7 +88,7 @@ export const fakeTeamEvent = (): TeamEvent => {
     requests: [fakeTeamEventAttendance()],
     attendees: [],
     uuid: faker.datatype.uuid(),
-    isCommunity: getRandomBoolean(),
+    isCommunity: getRandomBoolean()
   };
   return TE;
 };


### PR DESCRIPTION
### Summary <!-- Required -->

- createData should have all mock data align with the current types defined in `index.d.ts`
- VSCode has no "compilation errors" anymore for `createData.ts`


### Notion/Figma Link <!-- Optional -->

[<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->](https://www.notion.so/cornelldti/Idol-SP23-e65533742dca4f898581cc5c496e821e?p=365deb41d6e64398a51ed9acd4e99fd8&pm=s)

### Test Plan <!-- Required -->

Unit tests still pass.

### Notes <!-- Optional -->

- In the future, we should figure out a way to catch these type errors in general so the types in `index.d.ts` don't become out of sync with the mock data. Right now, when we see "compilation errors" in `createData.ts` we seem to just ignore them.

### Breaking Changes <!-- Optional -->
