### PR TITLE
Abstract firestore filtering in BaseDao 

### DIFF
--- a/backend/src/dao/BaseDao.ts
+++ b/backend/src/dao/BaseDao.ts
@@ -1,5 +1,11 @@
 import { firestore } from 'firebase-admin';
 
+/**
+ * Interface representing Firestore query filters.
+ * field -- the field to filter by (e.g. user)
+ * comparisonOperator -- the comparison operator to use for comparison/filtering
+ * value -- the value to compare the field to
+ */
 interface FirestoreFilter {
   field: string;
   comparisonOperator: FirebaseFirestore.WhereFilterOp;
@@ -37,7 +43,10 @@ export default abstract class BaseDao<E, D> {
   }
 
   /**
-   * @returns All documents in the collection
+   * Gets documents from the Firestore collection
+   * @param filters -- list of filters to filter documents by
+   * @returns Documents in the collection that satifsy the filters.
+   *          Returns all documents if no filters are provided.
    */
   protected async getDocuments(filters: FirestoreFilter[] = []): Promise<E[]> {
     const query = this.collection as firestore.Query<D>;

--- a/backend/src/dao/BaseDao.ts
+++ b/backend/src/dao/BaseDao.ts
@@ -3,7 +3,7 @@ import { firestore } from 'firebase-admin';
 /**
  * Interface representing Firestore query filters.
  * field -- the field to filter by (e.g. user)
- * comparisonOperator -- the comparison operator to use for comparison/filtering
+ * comparisonOperator -- the comparison operator to use for comparison/filtering (https://cloud.google.com/firestore/docs/query-data/queries)
  * value -- the value to compare the field to
  */
 interface FirestoreFilter {

--- a/backend/src/dao/DevPortfolioDao.ts
+++ b/backend/src/dao/DevPortfolioDao.ts
@@ -69,7 +69,7 @@ export default class DevPortfolioDao extends BaseDao<DevPortfolio, DBDevPortfoli
   }
 
   async getAllInstances(): Promise<DevPortfolio[]> {
-    return this.getAllDocuments();
+    return this.getDocuments();
   }
 
   async getAllDevPortfolioInfo(): Promise<DevPortfolioInfo[]> {

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -29,12 +29,13 @@ export default class ShoutoutsDao extends BaseDao<Shoutout, DBShoutout> {
 
   async getShoutouts(email: string, type: 'given' | 'received'): Promise<Shoutout[]> {
     const givenOrReceived = type === 'given' ? 'giver' : 'receiver';
-    const shoutoutRefs = await this.collection
-      .where(givenOrReceived, '==', memberCollection.doc(email))
-      .get();
-    return Promise.all(
-      shoutoutRefs.docs.map(async (shoutoutRef) => materializeShoutout(shoutoutRef.data()))
-    );
+    return this.getDocuments([
+      {
+        field: givenOrReceived,
+        comparisonOperator: '==',
+        value: memberCollection.doc(email)
+      }
+    ]);
   }
 
   async getShoutout(uuid: string): Promise<Shoutout | null> {

--- a/backend/src/dao/ShoutoutsDao.ts
+++ b/backend/src/dao/ShoutoutsDao.ts
@@ -24,7 +24,7 @@ export default class ShoutoutsDao extends BaseDao<Shoutout, DBShoutout> {
   }
 
   async getAllShoutouts(): Promise<Shoutout[]> {
-    return this.getAllDocuments();
+    return this.getDocuments();
   }
 
   async getShoutouts(email: string, type: 'given' | 'received'): Promise<Shoutout[]> {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds an abstraction to `BaseDao` for filtering Firestore queries. 

We have a new interface that defines a filter:
```
interface FirestoreFilter {
  field: string;
  comparisonOperator: FirebaseFirestore.WhereFilterOp
  value: any
}
```
These filters can be passed to `BaseDao.getDocuments` as a list to perform filtering. 

e.g. instead of 
```
async getShoutouts(email: string, type: 'given' | 'received'): Promise<Shoutout[]> {
    const givenOrReceived = type === 'given' ? 'giver' : 'receiver';
    const shoutoutRefs = await this.collection
      .where(givenOrReceived, '==', memberCollection.doc(email))
      .get();
    return Promise.all(
      shoutoutRefs.docs.map(async (shoutoutRef) => materializeShoutout(shoutoutRef.data()))
    );
  }
```

we can have
```
async getShoutouts(email: string, type: 'given' | 'received'): Promise<Shoutout[]> {
  const givenOrReceived = type === 'given' ? 'giver' : 'receiver';
  return this.getDocuments([{
    field: givenOrReceived,
    comparisonOperator: '==',
    value: memberCollection.doc(email)
  }])
```

We can still get all documents by calling `BaseDao.getDocuments()` without any parameters. 

### Notion/Figma Link <!-- Optional -->
N/A
### Test Plan <!-- Required -->

Existing functionality works 
### Notes <!-- Optional -->
~~Will update the other dao methods to use this if we think this is useful.~~

Will make the changes to team event related daos in a later PR since those haven't been changed to extend `BaseDao` yet. 