### PR TITLE
Add admin TEC dashboard 

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
@@ -1,0 +1,27 @@
+.dashboardContainer {
+  margin: 3%;
+  overflow-x: scroll;
+  width: 100%;
+}
+
+.tableContainer {
+  max-width: 95%;
+  overflow-y: auto;
+}
+
+.eventCell {
+  min-width: 50px;
+}
+
+.nameCell {
+  position: sticky;
+  left: 0;
+  display: block;
+  background-color: white;
+  min-width: 250px
+}
+
+.nameHeaderCell {
+  position: sticky;
+  left: 0;
+}

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
@@ -10,7 +10,7 @@
 }
 
 .eventCell {
-  min-width: 200px;
+  min-width: 50px;
 }
 
 .nameCell {

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
@@ -10,7 +10,7 @@
 }
 
 .eventCell {
-  min-width: 50px;
+  min-width: 200px;
 }
 
 .nameCell {
@@ -18,7 +18,7 @@
   left: 0;
   display: block;
   background-color: white;
-  min-width: 250px
+  min-width: 250px;
 }
 
 .nameHeaderCell {

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -17,14 +17,16 @@ const calculateMemberCreditsForEvent = (
   event: TeamEvent,
   isCommunity: boolean
 ): number =>
-  event.attendees.reduce((val: number, attendee) => {
-    if (attendee.member.email !== member.email || (isCommunity && !event.isCommunity)) {
-      return val;
-    }
-    if (event.hasHours && attendee.hoursAttended)
-      return val + Number(event.numCredits) * attendee.hoursAttended;
-    return val + Number(event.numCredits);
-  }, 0);
+  isCommunity && !event.isCommunity
+    ? 0
+    : event.attendees.reduce((val: number, attendee) => {
+        if (attendee.member.email !== member.email) {
+          return val;
+        }
+        if (event.hasHours && attendee.hoursAttended)
+          return val + Number(event.numCredits) * attendee.hoursAttended;
+        return val + Number(event.numCredits);
+      }, 0);
 
 const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, false);

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import { Table, Header, Loader } from 'semantic-ui-react';
+import { useMembers } from '../../Common/FirestoreDataProvider';
+import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
+import { REQUIRED_LEAD_TEC_CREDITS, REQUIRED_MEMBER_TEC_CREDITS } from '../../../consts';
+import styles from './TeamEventDashboard.module.css';
+
+const calculateMemberCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
+  event.attendees.reduce((val: number, attendee) => {
+    if (attendee.member.email !== member.email) {
+      return val;
+    }
+    if (event.hasHours && attendee.hoursAttended)
+      return val + Number(event.numCredits) * attendee.hoursAttended;
+    return val + Number(event.numCredits);
+  }, 0);
+
+const TeamEventDashboard: React.FC = () => {
+  const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const allMembers = useMembers();
+
+  useEffect(() => {
+    TeamEventsAPI.getAllTeamEvents().then((events) => {
+      setTeamEvents(events);
+      setIsLoading(false);
+    });
+  }, []);
+
+  if (isLoading) return <Loader active>Fetching team event data...</Loader>;
+
+  return (
+    <div className={styles.dashboardContainer}>
+      <Header as="h1" textAlign="center">
+        Team Event Dashboard
+      </Header>
+      <div className={styles.tableContainer}>
+        <Table celled selectable striped classname={styles.dashboardTable}>
+          <Table.Header>
+            <Table.HeaderCell className={styles.nameCell}>Name</Table.HeaderCell>
+            <Table.HeaderCell>Total</Table.HeaderCell>
+            {teamEvents.map((event) => (
+              <Table.HeaderCell>{event.name}</Table.HeaderCell>
+            ))}
+          </Table.Header>
+          <Table.Body>
+            {allMembers.map((member) => {
+              const totalCredits = teamEvents.reduce(
+                (val, event) => val + calculateMemberCreditsForEvent(member, event),
+                0
+              );
+              const requirementMet =
+                totalCredits >=
+                (member.role === 'lead' ? REQUIRED_LEAD_TEC_CREDITS : REQUIRED_MEMBER_TEC_CREDITS);
+
+              return (
+                <Table.Row>
+                  <Table.Cell positive={requirementMet} className={styles.nameCell}>
+                    {member.firstName} {member.lastName} ({member.netid})
+                  </Table.Cell>
+                  <Table.Cell positive={requirementMet}>{totalCredits}</Table.Cell>
+                  {teamEvents.map((event) => {
+                    const numCredits = calculateMemberCreditsForEvent(member, event);
+                    return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                  })}
+                </Table.Row>
+              );
+            })}
+          </Table.Body>
+        </Table>
+      </div>
+    </div>
+  );
+};
+
+export default TeamEventDashboard;

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -2,18 +2,35 @@ import React, { useState, useEffect } from 'react';
 import { Table, Header, Loader } from 'semantic-ui-react';
 import { useMembers } from '../../Common/FirestoreDataProvider';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
-import { REQUIRED_LEAD_TEC_CREDITS, REQUIRED_MEMBER_TEC_CREDITS } from '../../../consts';
+import {
+  REQUIRED_LEAD_TEC_CREDITS,
+  REQUIRED_MEMBER_TEC_CREDITS,
+  REQUIRED_COMMUNITY_CREDITS
+} from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 
-const calculateMemberCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
+// remove this and its usage if/when community events are released
+const COMMUNITY_EVENTS = false;
+
+const calculateMemberCreditsForEvent = (
+  member: IdolMember,
+  event: TeamEvent,
+  isCommunity: boolean
+): number =>
   event.attendees.reduce((val: number, attendee) => {
-    if (attendee.member.email !== member.email) {
+    if (attendee.member.email !== member.email || (isCommunity && !event.isCommunity)) {
       return val;
     }
     if (event.hasHours && attendee.hoursAttended)
       return val + Number(event.numCredits) * attendee.hoursAttended;
     return val + Number(event.numCredits);
   }, 0);
+
+const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
+  calculateMemberCreditsForEvent(member, event, false);
+
+const calculateCommunityCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
+  calculateMemberCreditsForEvent(member, event, true);
 
 const TeamEventDashboard: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
@@ -40,6 +57,7 @@ const TeamEventDashboard: React.FC = () => {
           <Table.Header>
             <Table.HeaderCell className={styles.nameCell}>Name</Table.HeaderCell>
             <Table.HeaderCell>Total</Table.HeaderCell>
+            {COMMUNITY_EVENTS && <Table.HeaderCell>Total Community Credits</Table.HeaderCell>}
             {teamEvents.map((event) => (
               <Table.HeaderCell>{event.name}</Table.HeaderCell>
             ))}
@@ -47,21 +65,29 @@ const TeamEventDashboard: React.FC = () => {
           <Table.Body>
             {allMembers.map((member) => {
               const totalCredits = teamEvents.reduce(
-                (val, event) => val + calculateMemberCreditsForEvent(member, event),
+                (val, event) => val + calculateTotalCreditsForEvent(member, event),
                 0
               );
-              const requirementMet =
+              const communityCredits = teamEvents.reduce(
+                (val, event) => calculateCommunityCreditsForEvent(member, event),
+                0
+              );
+              const totalCreditsMet =
                 totalCredits >=
                 (member.role === 'lead' ? REQUIRED_LEAD_TEC_CREDITS : REQUIRED_MEMBER_TEC_CREDITS);
+              const communityCreditsMet = communityCredits >= REQUIRED_COMMUNITY_CREDITS;
 
               return (
                 <Table.Row>
-                  <Table.Cell positive={requirementMet} className={styles.nameCell}>
+                  <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
                     {member.firstName} {member.lastName} ({member.netid})
                   </Table.Cell>
-                  <Table.Cell positive={requirementMet}>{totalCredits}</Table.Cell>
+                  <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
+                  {COMMUNITY_EVENTS && (
+                    <Table.Cell positive={communityCreditsMet}>{communityCredits}</Table.Cell>
+                  )}
                   {teamEvents.map((event) => {
-                    const numCredits = calculateMemberCreditsForEvent(member, event);
+                    const numCredits = calculateTotalCreditsForEvent(member, event);
                     return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
                   })}
                 </Table.Row>

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.module.css
@@ -17,6 +17,8 @@
   border-radius: 4px 4px 4px 4px;
 }
 
-.resetButtonContainer {
+.buttonContainer {
   margin-top: 2rem;
+  display: flex;
+  justify-content: space-between;
 }

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -88,7 +88,6 @@ const TeamEvents: React.FC = () => {
           </Button>
           <ClearTeamEventsModal setTeamEvents={setTeamEvents} />
         </div>
-        <div></div>
       </div>
     </div>
   );

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Message, Loader } from 'semantic-ui-react';
+import { Card, Message, Loader, Button } from 'semantic-ui-react';
 import Link from 'next/link';
 import TeamEventForm from './TeamEventForm';
 import styles from './TeamEvents.module.css';
@@ -82,9 +82,13 @@ const TeamEvents: React.FC = () => {
           <h2>View All Team Events</h2>
           <TeamEventsDisplay isLoading={isLoading} teamEvents={teamEvents} />
         </div>
-        <div className={styles.resetButtonContainer}>
+        <div className={styles.buttonContainer}>
+          <Button>
+            <Link href="/admin/team-events/dashboard">View Team Events Dashboard</Link>
+          </Button>
           <ClearTeamEventsModal setTeamEvents={setTeamEvents} />
         </div>
+        <div></div>
       </div>
     </div>
   );

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDasboard.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { Form, Card, Message } from 'semantic-ui-react';
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import styles from './TeamEventCreditsForm.module.css';
-
-const REQUIRED_COMMUNITY_CREDITS = 1;
-const REQUIRED_MEMBER_TEC_CREDITS = 3;
-const REQUIRED_LEAD_TEC_CREDITS = 6;
+import {
+  REQUIRED_COMMUNITY_CREDITS,
+  REQUIRED_LEAD_TEC_CREDITS,
+  REQUIRED_MEMBER_TEC_CREDITS
+} from '../../../consts';
 
 const TeamEventCreditDashboard = (props: {
   approvedTEC: TeamEventInfo[];

--- a/frontend/src/consts.ts
+++ b/frontend/src/consts.ts
@@ -1,0 +1,4 @@
+// Team Event constants
+export const REQUIRED_COMMUNITY_CREDITS = 1;
+export const REQUIRED_MEMBER_TEC_CREDITS = 3;
+export const REQUIRED_LEAD_TEC_CREDITS = 6;

--- a/frontend/src/pages/admin/team-events.tsx
+++ b/frontend/src/pages/admin/team-events.tsx
@@ -1,3 +1,0 @@
-import TeamEvents from '../../components/Admin/TeamEvent/TeamEvents';
-
-export default TeamEvents;

--- a/frontend/src/pages/admin/team-events/dashboard.tsx
+++ b/frontend/src/pages/admin/team-events/dashboard.tsx
@@ -1,0 +1,3 @@
+import TeamEventDashboard from '../../../components/Admin/TeamEvent/TeamEventDashboard';
+
+export default TeamEventDashboard;

--- a/frontend/src/pages/admin/team-events/index.tsx
+++ b/frontend/src/pages/admin/team-events/index.tsx
@@ -1,0 +1,3 @@
+import TeamEvents from '../../../components/Admin/TeamEvent/TeamEvents';
+
+export default TeamEvents;


### PR DESCRIPTION
### Summary <!-- Required -->

Add admin TEC dashboard to show all attendance for all events and all members. 
<img width="1783" alt="image" src="https://user-images.githubusercontent.com/65922473/231887162-cab388a3-206c-478e-9420-a1535cc02980.png">

The name column on the left is sticky if the number of columns overflows: 
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/65922473/231887393-21de86a2-da63-4179-89f5-ca86811e2af9.png">

If a member has completed their TEC requirement, their name and total credit cells are highlighted green. 

### Notion/Figma Link <!-- Optional -->

[Notion link](https://www.notion.so/cornelldti/TEC-Admin-dashboard-to-glance-at-users-credits-49105c8ae1d64b179266e41d52357dbe?pvs=4)
### Test Plan <!-- Required -->
👀
