### PR TITLE
Clear dev portfolio form inputs upon submission

### DIFF
--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -117,12 +117,7 @@ const DevPortfolioForm: React.FC = () => {
         status: 'pending',
         ...(text && { text })
       };
-      sendSubmissionRequest(newDevPortfolioSubmission, devPortfolio).then(() => {
-        setDevPortfolio(undefined);
-        setOpenPRs(['']);
-        setReviewedPRs(['']);
-        setText('');
-      });
+      sendSubmissionRequest(newDevPortfolioSubmission, devPortfolio);
     }
   };
 
@@ -149,7 +144,7 @@ const DevPortfolioForm: React.FC = () => {
                 fluid
                 search
                 selection
-                value={devPortfolio?.name}
+                value={devPortfolio?.uuid}
                 options={devPortfolios
                   .sort((a, b) => a.deadline - b.deadline)
                   .map((assignment) => ({

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -19,17 +19,17 @@ const DevPortfolioForm: React.FC = () => {
   const [openPRs, setOpenPRs] = useState(['']);
   const [reviewPRs, setReviewedPRs] = useState(['']);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [text, setText] = useState<string | null>(null);
+  const [text, setText] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     refreshDevPortfolios();
   }, []);
 
-  const sendSubmissionRequest = (
+  const sendSubmissionRequest = async (
     devPortfolioRequest: DevPortfolioSubmission,
     devPortfolio: DevPortfolio
   ) => {
-    DevPortfolioAPI.makeDevPortfolioSubmission(devPortfolio.uuid, devPortfolioRequest).then(
+    await DevPortfolioAPI.makeDevPortfolioSubmission(devPortfolio.uuid, devPortfolioRequest).then(
       (val) => {
         if (val.error) {
           Emitters.generalError.emit({
@@ -117,11 +117,12 @@ const DevPortfolioForm: React.FC = () => {
         status: 'pending',
         ...(text && { text })
       };
-      sendSubmissionRequest(newDevPortfolioSubmission, devPortfolio);
-      setDevPortfolio(undefined);
-      setOpenPRs(['']);
-      setReviewedPRs(['']);
-      setText(null);
+      sendSubmissionRequest(newDevPortfolioSubmission, devPortfolio).then(() => {
+        setDevPortfolio(undefined);
+        setOpenPRs(['']);
+        setReviewedPRs(['']);
+        setText('');
+      });
     }
   };
 
@@ -148,6 +149,7 @@ const DevPortfolioForm: React.FC = () => {
                 fluid
                 search
                 selection
+                value={devPortfolio?.name}
                 options={devPortfolios
                   .sort((a, b) => a.deadline - b.deadline)
                   .map((assignment) => ({
@@ -183,10 +185,7 @@ const DevPortfolioForm: React.FC = () => {
                 2. What did the team do the past two weeks?
               </p>
 
-              <TextArea
-                value={text || undefined}
-                onInput={(e) => setText(e.currentTarget.value)}
-              ></TextArea>
+              <TextArea value={text} onChange={(e) => setText(e.target.value)}></TextArea>
 
               <p>
                 In addition, if you have created and/or reviewed pull requests, please include those


### PR DESCRIPTION
### Summary <!-- Required -->

~~This PR fixes a couple of small issues with the dev portfolio form regarding submission:
- ~~Clears the dropdown for selecting dev portfolio after submission~~ 
- ~~Clears the text area after submission~~ 
- ~~Clears form state only after the submission request is successful~~

This PR removes clearing the dev portfolio form after submission. 

### Notion/Figma Link <!-- Optional -->

N/A - From #idol-support (https://cornelldti.slack.com/archives/C044T59JD34/p1681666314088999)
### Test Plan <!-- Required -->
The dev portfolio form should not be cleared after submission. It should be possible to re-submit the form by just clicking on the submit button a second time. 