### PR TITLE
Change shoutouts admin view date range to 13.5 days

### DIFF
--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -9,7 +9,7 @@ import styles from './AdminShoutouts.module.css';
 const AdminShoutouts: React.FC = () => {
   const [allShoutouts, setAllShoutouts] = useState<Shoutout[]>([]);
   const [displayShoutouts, setDisplayShoutouts] = useState<Shoutout[]>([]);
-  const [earlyDate, setEarlyDate] = useState<Date>(new Date(Date.now() - 12096e5));
+  const [earlyDate, setEarlyDate] = useState<Date>(new Date(Date.now() - 86400000 * 13.5));
   const [lastDate, setLastDate] = useState<Date>(new Date());
   const [hide, setHide] = useState(false);
 


### PR DESCRIPTION
### Summary <!-- Required -->
This pull request changes the default date range on admin view of shoutouts to 13.5 days instead of 14 days, ensuring no overlap between separate All-Hands shoutouts. 

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/cornelldti/Idol-SP23-e65533742dca4f898581cc5c496e821e?p=fe6e981c03e84cf4a3ca46e84096b7f8&pm=s

### Test Plan <!-- Required -->
The date range shows 13 days instead of 14 days. 
<img width="908" alt="Screenshot 2023-04-18 at 1 59 16 PM" src="https://user-images.githubusercontent.com/70241445/232879880-36e3cebf-7935-46be-a572-b06ffee0d9bb.png">
