### PR TITLE
TEC - Polishing and Bug Fixes for Release

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
@@ -29,6 +29,7 @@ const TeamEventCreditReview = (props: {
           headerMsg: 'Team Event Attendance Approved!',
           contentMsg: 'The team event attendance was successfully approved!'
         });
+        Emitters.teamEventsUpdated.emit();
       })
       .catch((error) => {
         Emitters.generalError.emit({
@@ -46,6 +47,7 @@ const TeamEventCreditReview = (props: {
           contentMsg: 'The team event attendance was successfully rejected!'
         });
         ImagesAPI.deleteEventProofImage(teamEventAttendance.image);
+        Emitters.teamEventsUpdated.emit();
       })
       .catch((error) => {
         Emitters.generalError.emit({
@@ -80,7 +82,6 @@ const TeamEventCreditReview = (props: {
           basic
           color="green"
           onClick={() => {
-            Emitters.teamEventsUpdated.emit();
             approveCreditRequest(teamEventAttendance);
             setOpen(false);
           }}
@@ -91,7 +92,6 @@ const TeamEventCreditReview = (props: {
           basic
           color="red"
           onClick={() => {
-            Emitters.teamEventsUpdated.emit();
             rejectCreditRequest();
             setOpen(false);
           }}

--- a/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
@@ -80,6 +80,7 @@ const TeamEventCreditReview = (props: {
           basic
           color="green"
           onClick={() => {
+            Emitters.teamEventsUpdated.emit();
             approveCreditRequest(teamEventAttendance);
             setOpen(false);
           }}
@@ -90,6 +91,7 @@ const TeamEventCreditReview = (props: {
           basic
           color="red"
           onClick={() => {
+            Emitters.teamEventsUpdated.emit();
             rejectCreditRequest();
             setOpen(false);
           }}

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.module.css
@@ -22,3 +22,8 @@
   display: flex;
   justify-content: space-between;
 }
+
+.alertPendingRequests {
+  font-weight: bold;
+  color: green;
+}

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -27,7 +27,13 @@ const TeamEventsDisplay: React.FC<TeamEventsDisplayProps> = ({ isLoading, teamEv
                 <Card.Content>
                   <Card.Header>{teamEvent.name} </Card.Header>
                   <Card.Meta>{teamEvent.date}</Card.Meta>
-                  <Card.Meta>{teamEvent.requests.length} pending requests</Card.Meta>
+                  <Card.Meta>
+                    {teamEvent.requests.length > 0 ? (
+                      <b>{teamEvent.requests.length} pending requests</b>
+                    ) : (
+                      `${teamEvent.requests.length} pending requests`
+                    )}
+                  </Card.Meta>
                   {COMMUNITY_EVENTS && (
                     <Card.Meta>Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
                   )}

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -29,7 +29,9 @@ const TeamEventsDisplay: React.FC<TeamEventsDisplayProps> = ({ isLoading, teamEv
                   <Card.Meta>{teamEvent.date}</Card.Meta>
                   <Card.Meta>
                     {teamEvent.requests.length > 0 ? (
-                      <b>{teamEvent.requests.length} pending requests</b>
+                      <p className={styles.alertPendingRequests}>
+                        {teamEvent.requests.length} pending requests
+                      </p>
                     ) : (
                       `${teamEvent.requests.length} pending requests`
                     )}

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -17,12 +17,14 @@ const TeamEventCreditForm: React.FC = () => {
   const [teamEventInfoList, setTeamEventInfoList] = useState<TeamEventInfo[]>([]);
   const [approvedAttendance, setApprovedAttendance] = useState<TeamEventAttendance[]>([]);
   const [pendingAttendance, setPendingAttendance] = useState<TeamEventAttendance[]>([]);
+  const [isAttendanceLoading, setIsAttendanceLoading] = useState<boolean>(true);
 
   useEffect(() => {
     TeamEventsAPI.getAllTeamEventInfo().then((teamEvents) => setTeamEventInfoList(teamEvents));
     TeamEventsAPI.getTeamEventAttendanceByUser().then((attendance) => {
       setApprovedAttendance(attendance.filter((attendee) => attendee.pending === false));
       setPendingAttendance(attendance.filter((attendee) => attendee.pending === true));
+      setIsAttendanceLoading(false);
     });
   }, []);
 
@@ -199,6 +201,7 @@ const TeamEventCreditForm: React.FC = () => {
           allTEC={teamEventInfoList}
           approvedAttendance={approvedAttendance}
           pendingAttendance={pendingAttendance}
+          isAttendanceLoading={isAttendanceLoading}
         />
       </Form>
     </div>

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Message } from 'semantic-ui-react';
+import { Card, Loader, Message } from 'semantic-ui-react';
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import styles from './TeamEventCreditsForm.module.css';
 import {
@@ -12,8 +12,9 @@ const TeamEventCreditDashboard = (props: {
   allTEC: TeamEventInfo[];
   approvedAttendance: TeamEventAttendance[];
   pendingAttendance: TeamEventAttendance[];
+  isAttendanceLoading: boolean;
 }): JSX.Element => {
-  const { allTEC, approvedAttendance, pendingAttendance } = props;
+  const { allTEC, approvedAttendance, pendingAttendance, isAttendanceLoading } = props;
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const userRole = useSelf()!.role;
@@ -40,15 +41,15 @@ const TeamEventCreditDashboard = (props: {
     }
   });
 
+  // remove this variable and usage when community events ready to be released
+  const COMMUNITY_EVENTS = false;
+
   // Calculate the remaining credits
   let remainingCredits;
   if (requiredCredits - approvedCredits > 0) remainingCredits = requiredCredits - approvedCredits;
-  else if (approvedCommunityCredits < REQUIRED_COMMUNITY_CREDITS)
+  else if (COMMUNITY_EVENTS && approvedCommunityCredits < REQUIRED_COMMUNITY_CREDITS)
     remainingCredits = REQUIRED_COMMUNITY_CREDITS - approvedCommunityCredits;
   else remainingCredits = 0;
-
-  // remove this variable and usage when community events ready to be released
-  const COMMUNITY_EVENTS = false;
 
   let headerString;
   if (userRole !== 'lead')
@@ -107,45 +108,52 @@ const TeamEventCreditDashboard = (props: {
       <h1>Check Team Event Credits</h1>
       <p>{headerString}</p>
 
-      <div className={styles.inline}>
-        <label className={styles.bold}>
-          Your Approved Credits: <span className={styles.dark_grey_color}>{approvedCredits}</span>
-        </label>
-      </div>
+      {isAttendanceLoading ? (
+        <Loader active inline />
+      ) : (
+        <div>
+          <div className={styles.inline}>
+            <label className={styles.bold}>
+              Your Approved Credits:{' '}
+              <span className={styles.dark_grey_color}>{approvedCredits}</span>
+            </label>
+          </div>
 
-      {COMMUNITY_EVENTS && (
-        <div className={styles.inline}>
-          <label className={styles.bold}>
-            Your Approved Community Credits:{' '}
-            <span className={styles.dark_grey_color}>{approvedCommunityCredits}</span>
-          </label>
+          {COMMUNITY_EVENTS && (
+            <div className={styles.inline}>
+              <label className={styles.bold}>
+                Your Approved Community Credits:{' '}
+                <span className={styles.dark_grey_color}>{approvedCommunityCredits}</span>
+              </label>
+            </div>
+          )}
+
+          <div className={styles.inline}>
+            <label className={styles.bold}>
+              Remaining Credits Needed:{' '}
+              <span className={styles.dark_grey_color}>{remainingCredits}</span>
+            </label>
+          </div>
+
+          <div className={styles.inline}>
+            <label className={styles.bold}>Approved Events:</label>
+            {approvedAttendance.length !== 0 ? (
+              <TecDetailsDisplay attendanceList={approvedAttendance} />
+            ) : (
+              <Message>You have not been approved for any team events yet.</Message>
+            )}
+          </div>
+
+          <div className={styles.inline}>
+            <label className={styles.bold}>Pending Approval For:</label>
+            {pendingAttendance.length !== 0 ? (
+              <TecDetailsDisplay attendanceList={pendingAttendance} />
+            ) : (
+              <Message>You are not currently pending approval for any team events.</Message>
+            )}
+          </div>
         </div>
       )}
-
-      <div className={styles.inline}>
-        <label className={styles.bold}>
-          Remaining Credits Needed:{' '}
-          <span className={styles.dark_grey_color}>{remainingCredits}</span>
-        </label>
-      </div>
-
-      <div className={styles.inline}>
-        <label className={styles.bold}>Approved Events:</label>
-        {approvedAttendance.length !== 0 ? (
-          <TecDetailsDisplay attendanceList={approvedAttendance} />
-        ) : (
-          <Message>You have not been approved for any team events yet.</Message>
-        )}
-      </div>
-
-      <div className={styles.inline}>
-        <label className={styles.bold}>Pending Approval For:</label>
-        {pendingAttendance.length !== 0 ? (
-          <TecDetailsDisplay attendanceList={pendingAttendance} />
-        ) : (
-          <Message>You are not currently pending approval for any team events.</Message>
-        )}
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
### Summary <!-- Required -->
- Admin view: emphasize when event has >0 pending requests through bolding, color, etc.
- Admin view: automatically refresh pending/approved columns after approving/rejecting a TEC request
- Member view: Add loading for event cards and everything under the header text (i.e. "Your Approved Credits", "Remaining Credit Needed", and below)
- Member view: Fix remaining credits being calculated incorrectly. This was related to community events. If you completed all team event credit requirements, you would always have 1 remaining credit left to complete, and that would be the community event credit. I've hidden this logic for now using the `COMMUNITY_EVENTS` flag.

### Notion/Figma Link <!-- Optional -->

https://www.notion.so/cornelldti/TEC-Polishing-and-Bug-Fixes-for-Release-594270005d4246908460deff2480c949?pvs=4

### Test Plan <!-- Required -->

Manual testing.

### Notes <!-- Optional -->

This is more of a discussion for if/when we enable community events again, but I find it confusing that any community event credits needed are listed under "Remaining Credits Needed." I feel that community event credits should be completely separated into its own section, so it's clear if the user finished their 3 total credit requirement, but did not finish their community requirement. I expect there to be some confusing when using this if we don't change this.

### Breaking Changes <!-- Optional -->

First change:
<img width="980" alt="Screen Shot 2023-05-01 at 12 15 58 AM" src="https://user-images.githubusercontent.com/59291082/235421887-5bd14bde-9e51-424d-a605-933b7d818e00.png">


This video shows all the changes except for the first one.



https://user-images.githubusercontent.com/59291082/235421944-cb112a3b-586b-4690-85ad-bdc97b93fc07.mov



