### PR TITLE
Refactor admin shoutouts

### DIFF
--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,74 +1,46 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Form, Item, Card, Modal, Header, SemanticCOLORS } from 'semantic-ui-react';
+import React, { useState, useEffect } from 'react';
+import { Button, Form, Item, Card, Modal, Header } from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Emitters } from '../../../utils';
 import ShoutoutsAPI from '../../../API/ShoutoutsAPI';
 import styles from './AdminShoutouts.module.css';
 
-const AdminShoutouts: React.FC = () => {
-  const [allShoutouts, setAllShoutouts] = useState<Shoutout[]>([]);
-  const [displayShoutouts, setDisplayShoutouts] = useState<Shoutout[]>([]);
-  const [earlyDate, setEarlyDate] = useState<Date>(new Date(Date.now() - 86400000 * 13.5));
-  const [lastDate, setLastDate] = useState<Date>(new Date());
-  const [hide, setHide] = useState(false);
+type ViewMode = 'ALL' | 'PRESENT' | 'HIDDEN';
 
-  type ViewMode = 'ALL' | 'PRESENT' | 'HIDDEN';
-  const [view, setView] = useState<ViewMode>('ALL');
+const fromString = (shoutout: Shoutout): string => {
+  if (!shoutout.isAnon) {
+    const { giver } = shoutout;
+    return ` (From: ${giver?.firstName} ${giver?.lastName})`;
+  }
+  return ` (From: Anonymous)`;
+};
 
-  const updateShoutouts = useCallback(() => {
-    if (lastDate < earlyDate) {
-      Emitters.generalError.emit({
-        headerMsg: 'Invalid Date Range',
-        contentMsg: 'Please make sure the latest shoutout date is after the earliest shoutout date.'
-      });
-    }
-    if (allShoutouts.length === 0) {
-      ShoutoutsAPI.getAllShoutouts().then((shoutouts) => {
-        setAllShoutouts(shoutouts);
-      });
-    } else {
-      const filteredShoutouts = allShoutouts
-        .filter((shoutout) => {
-          const shoutoutDate = new Date(shoutout.timestamp);
-          return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
-        })
-        .sort((a, b) => a.timestamp - b.timestamp);
-      if (view === 'PRESENT')
-        setDisplayShoutouts(filteredShoutouts.filter((shoutout) => !shoutout.hidden));
-      else if (view === 'HIDDEN')
-        setDisplayShoutouts(filteredShoutouts.filter((shoutout) => shoutout.hidden));
-      else setDisplayShoutouts(filteredShoutouts);
-      setHide(false);
-    }
-  }, [allShoutouts, earlyDate, lastDate, view]);
+const dateString = (shoutout: Shoutout): string => `${new Date(shoutout.timestamp).toDateString()}`;
 
-  useEffect(() => {
-    updateShoutouts();
-  }, [earlyDate, lastDate, hide, updateShoutouts]);
+const getListTitle = (view: ViewMode): string => {
+  switch (view) {
+    case 'ALL':
+      return 'All Shoutouts';
+    case 'HIDDEN':
+      return 'Hidden Shoutouts';
+    default:
+      return '';
+  }
+};
 
-  const ListTitle = (): JSX.Element => {
-    let title = 'All Shoutouts';
-    if (view === 'HIDDEN') title = 'Hidden Shoutouts';
-    if (view === 'PRESENT') title = '';
-    return <Header className={styles.formTitle} content={title}></Header>;
-  };
-
-  const fromString = (shoutout: Shoutout): string => {
-    if (!shoutout.isAnon) {
-      const { giver } = shoutout;
-      return ` (From: ${giver?.firstName} ${giver?.lastName})`;
-    }
-    return ` (From: Anonymous)`;
-  };
-
-  const dateString = (shoutout: Shoutout): string =>
-    `${new Date(shoutout.timestamp).toDateString()}`;
+const HideModal = (props: {
+  shoutout: Shoutout;
+  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[]>>;
+}): JSX.Element => {
+  const { shoutout, setAllShoutouts } = props;
 
   const onHide = (shoutout: Shoutout) => {
-    setHide(true);
     const oppHide = !shoutout.hidden;
     ShoutoutsAPI.hideShoutout(shoutout.uuid, oppHide).then(() => {
+      setAllShoutouts((shoutouts) =>
+        shoutouts.map((s) => (s.uuid === shoutout.uuid ? { ...s, hidden: oppHide } : s))
+      );
       if (oppHide) {
         Emitters.generalSuccess.emit({
           headerMsg: 'Shoutout Hidden',
@@ -83,122 +55,142 @@ const AdminShoutouts: React.FC = () => {
     });
   };
 
-  const HideModal = (props: { shoutout: Shoutout }): JSX.Element => {
-    const { shoutout } = props;
-    if (!shoutout.hidden)
-      return (
-        <Modal
-          trigger={<Button icon="eye" size="tiny" />}
-          header="Hide Shoutout"
-          content="Are you sure that you want to hide this shoutout?"
-          actions={[
-            'Cancel',
-            {
-              key: 'hideShoutouts',
-              content: 'Hide Shoutout',
-              color: 'red',
-              onClick: () => onHide(shoutout)
-            }
-          ]}
-        />
-      );
+  if (!shoutout.hidden)
     return (
       <Modal
-        trigger={<Button icon="eye slash" size="tiny" />}
-        header="Unhide Shoutout"
-        content="Are you sure that you want to show this shoutout?"
+        trigger={<Button icon="eye" size="tiny" />}
+        header="Hide Shoutout"
+        content="Are you sure that you want to hide this shoutout?"
         actions={[
           'Cancel',
           {
-            key: 'unhideShoutouts',
-            content: 'Unhide Shoutout',
+            key: 'hideShoutouts',
+            content: 'Hide Shoutout',
             color: 'red',
             onClick: () => onHide(shoutout)
           }
         ]}
       />
     );
-  };
+  return (
+    <Modal
+      trigger={<Button icon="eye slash" size="tiny" />}
+      header="Unhide Shoutout"
+      content="Are you sure that you want to show this shoutout?"
+      actions={[
+        'Cancel',
+        {
+          key: 'unhideShoutouts',
+          content: 'Unhide Shoutout',
+          color: 'red',
+          onClick: () => onHide(shoutout)
+        }
+      ]}
+    />
+  );
+};
 
-  const DisplayList = (): JSX.Element => {
-    if (displayShoutouts.length === 0)
-      return (
-        <Card className={styles.noShoutoutsContainer}>
-          <Card.Content>No shoutouts in this date range.</Card.Content>
-        </Card>
-      );
-    if (view === 'PRESENT')
-      return (
-        <Item.Group divided>
-          {displayShoutouts.map((shoutout, i) => (
-            <Item key={i}>
-              <Item.Content>
-                <Item.Header
-                  className={styles.presentShoutoutTo}
-                >{`${shoutout.receiver}`}</Item.Header>
-                <Item.Meta
-                  className={styles.presentShoutoutFrom}
-                  content={` ${fromString(shoutout)}`}
-                />
-                <Item.Description
-                  className={styles.presentShoutoutMessage}
-                  content={shoutout.message}
-                />
-              </Item.Content>
-            </Item>
-          ))}
-        </Item.Group>
-      );
+const DisplayList = ({
+  displayShoutouts,
+  view,
+  setAllShoutouts
+}: {
+  displayShoutouts: Shoutout[];
+  view: ViewMode;
+  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[]>>;
+}): JSX.Element => {
+  if (displayShoutouts.length === 0)
+    return (
+      <Card className={styles.noShoutoutsContainer}>
+        <Card.Content>No shoutouts in this date range.</Card.Content>
+      </Card>
+    );
+  if (view === 'PRESENT')
     return (
       <Item.Group divided>
         {displayShoutouts.map((shoutout, i) => (
           <Item key={i}>
             <Item.Content>
-              <Item.Group widths="equal" className={styles.shoutoutDetails}>
-                <Item.Header className={styles.shoutoutTo}>{`${shoutout.receiver}`}</Item.Header>
-                <Item.Meta className={styles.shoutoutDate} content={dateString(shoutout)} />
-              </Item.Group>
-              <Item.Group widths="equal" className={styles.shoutoutHide}>
-                <Item.Meta className={styles.shoutoutFrom} content={fromString(shoutout)} />
-                <HideModal shoutout={shoutout} />
-              </Item.Group>
-              <Item.Description className={styles.shoutoutMessage} content={shoutout.message} />
+              <Item.Header
+                className={styles.presentShoutoutTo}
+              >{`${shoutout.receiver}`}</Item.Header>
+              <Item.Meta
+                className={styles.presentShoutoutFrom}
+                content={` ${fromString(shoutout)}`}
+              />
+              <Item.Description
+                className={styles.presentShoutoutMessage}
+                content={shoutout.message}
+              />
             </Item.Content>
           </Item>
         ))}
       </Item.Group>
     );
-  };
+  return (
+    <Item.Group divided>
+      {displayShoutouts.map((shoutout, i) => (
+        <Item key={i}>
+          <Item.Content>
+            <Item.Group widths="equal" className={styles.shoutoutDetails}>
+              <Item.Header className={styles.shoutoutTo}>{`${shoutout.receiver}`}</Item.Header>
+              <Item.Meta className={styles.shoutoutDate} content={dateString(shoutout)} />
+            </Item.Group>
+            <Item.Group widths="equal" className={styles.shoutoutHide}>
+              <Item.Meta className={styles.shoutoutFrom} content={fromString(shoutout)} />
+              <HideModal shoutout={shoutout} setAllShoutouts={setAllShoutouts} />
+            </Item.Group>
+            <Item.Description className={styles.shoutoutMessage} content={shoutout.message} />
+          </Item.Content>
+        </Item>
+      ))}
+    </Item.Group>
+  );
+};
 
-  const ButtonPiece = (props: { shoutoutList: Shoutout[]; buttonText: ViewMode }): JSX.Element => {
-    const { shoutoutList, buttonText } = props;
-    let currColor: SemanticCOLORS = 'grey';
-    if (buttonText === view) currColor = 'blue';
-    return (
-      <Button
-        color={currColor}
-        onClick={() => {
-          setView(buttonText);
-          setDisplayShoutouts(shoutoutList);
-        }}
-        content={buttonText}
-      />
-    );
-  };
+const ChooseDate = (props: {
+  dateField: Date;
+  dateFunction: (value: React.SetStateAction<Date>) => void;
+}): JSX.Element => {
+  const { dateField, dateFunction } = props;
+  return (
+    <DatePicker
+      selected={dateField}
+      dateFormat="MMMM do yyyy"
+      onChange={(date: Date) => dateFunction(date)}
+    />
+  );
+};
 
-  const ChooseDate = (props: {
-    dateField: Date;
-    dateFunction: (value: React.SetStateAction<Date>) => void;
-  }): JSX.Element => {
-    const { dateField, dateFunction } = props;
-    return (
-      <DatePicker
-        selected={dateField}
-        dateFormat="MMMM do yyyy"
-        onChange={(date: Date) => dateFunction(date)}
-      />
-    );
-  };
+const AdminShoutouts: React.FC = () => {
+  const [allShoutouts, setAllShoutouts] = useState<Shoutout[]>([]);
+  const [earlyDate, setEarlyDate] = useState<Date>(new Date(Date.now() - 86400000 * 13.5));
+  const [lastDate, setLastDate] = useState<Date>(new Date());
+  const [view, setView] = useState<ViewMode>('ALL');
+
+  useEffect(() => {
+    ShoutoutsAPI.getAllShoutouts().then((shoutouts) => setAllShoutouts(shoutouts));
+  }, []);
+
+  if (lastDate < earlyDate) {
+    Emitters.generalError.emit({
+      headerMsg: 'Invalid Date Range',
+      contentMsg: 'Please make sure the latest shoutout date is after the earliest shoutout date.'
+    });
+  }
+
+  const displayShoutouts = allShoutouts
+    .filter((shoutout) => {
+      const shoutoutDate = new Date(shoutout.timestamp);
+      return (
+        (view === 'ALL' ||
+          (view === 'PRESENT' && !shoutout.hidden) ||
+          (view === 'HIDDEN' && shoutout.hidden)) &&
+        shoutoutDate >= earlyDate &&
+        shoutoutDate <= lastDate
+      );
+    })
+    .sort((a, b) => a.timestamp - b.timestamp);
 
   return (
     <div>
@@ -208,21 +200,25 @@ const AdminShoutouts: React.FC = () => {
           <ChooseDate dateField={earlyDate} dateFunction={setEarlyDate} />
           <ChooseDate dateField={lastDate} dateFunction={setLastDate} />
           <Button.Group className={styles.buttonGroup}>
-            <ButtonPiece shoutoutList={allShoutouts} buttonText={'ALL'} />
-            <ButtonPiece
-              shoutoutList={allShoutouts.filter((shoutout) => shoutout.hidden)}
-              buttonText={'HIDDEN'}
-            />
-            <ButtonPiece
-              shoutoutList={allShoutouts.filter((shoutout) => !shoutout.hidden)}
-              buttonText={'PRESENT'}
-            />
+            <Button color={view === 'ALL' ? 'blue' : 'grey'} onClick={() => setView('ALL')}>
+              ALL
+            </Button>
+            <Button color={view === 'HIDDEN' ? 'blue' : 'grey'} onClick={() => setView('HIDDEN')}>
+              HIDDEN
+            </Button>
+            <Button color={view === 'PRESENT' ? 'blue' : 'grey'} onClick={() => setView('PRESENT')}>
+              PRESENT
+            </Button>
           </Button.Group>
         </Form.Group>
       </Form>
       <div className={styles.shoutoutsListContainer}>
-        <ListTitle />
-        <DisplayList />
+        <Header className={styles.formTitle} content={getListTitle(view)}></Header>;
+        <DisplayList
+          displayShoutouts={displayShoutouts}
+          view={view}
+          setAllShoutouts={setAllShoutouts}
+        />
       </div>
     </div>
   );

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -213,7 +213,7 @@ const AdminShoutouts: React.FC = () => {
         </Form.Group>
       </Form>
       <div className={styles.shoutoutsListContainer}>
-        <Header className={styles.formTitle} content={getListTitle(view)}></Header>;
+        <Header className={styles.formTitle} content={getListTitle(view)}></Header>
         <DisplayList
           displayShoutouts={displayShoutouts}
           view={view}


### PR DESCRIPTION
### Summary <!-- Required -->

This PR refactors admin shoutouts to reduce unnecessary complexity:
- Changed `displayShoutouts` from component state and instead just derived from `allShoutouts`, `view`, `earlyDate`, and `lateDate`
- Moved the definitions of child components of `AdminShoutouts` outside of the definition of `AdminShoutouts`
- Moved general helper functions outside of definition of `AdminShoutouts`
- Removed complex dependency arrays for `useEffect` and `useCallback` (removed this altogether) 
- Removed `ButtonPiece` component 

This PR also fixes an issue where the updated state of hidden shoutouts isn't updated unless the page is refreshed. 

### Notion/Figma Link <!-- Optional -->

N/A
### Test Plan <!-- Required -->
Manual testing:
- Existing functionality should stay the same 
- Hiding shoutouts should be updated without refreshing page 
### Note
I think backend tests are failing bc dev db exceed quota for the day again 💀 

