### PR TITLE
firebase listener in shoutouts

### DIFF
--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
-import { Button, Form, Item, Card, Modal, Header } from 'semantic-ui-react';
+import { Button, Form, Item, Card, Modal, Header, Loader } from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
 import { db } from '../../../firebase';
 import 'react-datepicker/dist/react-datepicker.css';
@@ -33,7 +33,7 @@ const getListTitle = (view: ViewMode): string => {
 
 const HideModal = (props: {
   shoutout: Shoutout;
-  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[]>>;
+  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[] | undefined>>;
 }): JSX.Element => {
   const { shoutout, setAllShoutouts } = props;
 
@@ -41,7 +41,7 @@ const HideModal = (props: {
     const oppHide = !shoutout.hidden;
     ShoutoutsAPI.hideShoutout(shoutout.uuid, oppHide).then(() => {
       setAllShoutouts((shoutouts) =>
-        shoutouts.map((s) => (s.uuid === shoutout.uuid ? { ...s, hidden: oppHide } : s))
+        shoutouts?.map((s) => (s.uuid === shoutout.uuid ? { ...s, hidden: oppHide } : s))
       );
       if (oppHide) {
         Emitters.generalSuccess.emit({
@@ -97,11 +97,14 @@ const DisplayList = ({
   view,
   setAllShoutouts
 }: {
-  displayShoutouts: Shoutout[];
+  displayShoutouts: Shoutout[] | undefined;
   view: ViewMode;
-  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[]>>;
+  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[] | undefined>>;
 }): JSX.Element => {
-  if (displayShoutouts.length === 0)
+  if (displayShoutouts === undefined) {
+    return <Loader active size="big" content="Loading..." />;
+  }
+  if (displayShoutouts?.length === 0)
     return (
       <Card className={styles.noShoutoutsContainer}>
         <Card.Content>No shoutouts in this date range.</Card.Content>
@@ -110,7 +113,7 @@ const DisplayList = ({
   if (view === 'PRESENT')
     return (
       <Item.Group divided>
-        {displayShoutouts.map((shoutout, i) => (
+        {displayShoutouts?.map((shoutout, i) => (
           <Item key={i}>
             <Item.Content>
               <Item.Header
@@ -131,7 +134,7 @@ const DisplayList = ({
     );
   return (
     <Item.Group divided>
-      {displayShoutouts.map((shoutout, i) => (
+      {displayShoutouts?.map((shoutout, i) => (
         <Item key={i}>
           <Item.Content>
             <Item.Group widths="equal" className={styles.shoutoutDetails}>

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Button, Form, Item, Card, Modal, Header, Loader } from 'semantic-ui-react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { Button, Form, Item, Card, Modal, Header } from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
+import { db } from '../../../firebase';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Emitters } from '../../../utils';
 import ShoutoutsAPI from '../../../API/ShoutoutsAPI';
@@ -31,7 +33,7 @@ const getListTitle = (view: ViewMode): string => {
 
 const HideModal = (props: {
   shoutout: Shoutout;
-  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[] | undefined>>;
+  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[]>>;
 }): JSX.Element => {
   const { shoutout, setAllShoutouts } = props;
 
@@ -39,7 +41,7 @@ const HideModal = (props: {
     const oppHide = !shoutout.hidden;
     ShoutoutsAPI.hideShoutout(shoutout.uuid, oppHide).then(() => {
       setAllShoutouts((shoutouts) =>
-        shoutouts?.map((s) => (s.uuid === shoutout.uuid ? { ...s, hidden: oppHide } : s))
+        shoutouts.map((s) => (s.uuid === shoutout.uuid ? { ...s, hidden: oppHide } : s))
       );
       if (oppHide) {
         Emitters.generalSuccess.emit({
@@ -95,13 +97,10 @@ const DisplayList = ({
   view,
   setAllShoutouts
 }: {
-  displayShoutouts: Shoutout[] | undefined;
+  displayShoutouts: Shoutout[];
   view: ViewMode;
-  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[] | undefined>>;
+  setAllShoutouts: React.Dispatch<React.SetStateAction<Shoutout[]>>;
 }): JSX.Element => {
-  if (displayShoutouts === undefined) {
-    return <Loader active size="big" content="Loading..." />;
-  }
   if (displayShoutouts.length === 0)
     return (
       <Card className={styles.noShoutoutsContainer}>
@@ -173,7 +172,26 @@ const AdminShoutouts: React.FC = () => {
 
   useEffect(() => {
     ShoutoutsAPI.getAllShoutouts().then((shoutouts) => setAllShoutouts(shoutouts));
-  }, []);
+
+    const shoutoutCollection = collection(db, 'shoutouts');
+    const unsubscribe = onSnapshot(shoutoutCollection, (snapshot) => {
+      snapshot.docChanges().forEach((document) => {
+        if (document.type === 'added') {
+          const newShoutout = document.doc.data() as Shoutout;
+          setAllShoutouts((oldShoutouts = []) => [...oldShoutouts, newShoutout]);
+        }
+        if (document.type === 'removed') {
+          const removedShoutout = document.doc.data() as Shoutout;
+          setAllShoutouts((updatedList = []) =>
+            updatedList.filter((x) => x.uuid !== removedShoutout.uuid)
+          );
+        }
+      });
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [setAllShoutouts]);
 
   if (lastDate < earlyDate) {
     Emitters.generalError.emit({
@@ -182,18 +200,18 @@ const AdminShoutouts: React.FC = () => {
     });
   }
 
-  const displayShoutouts = allShoutouts
-    ?.filter((shoutout) => {
-      const shoutoutDate = new Date(shoutout.timestamp);
-      return (
-        (view === 'ALL' ||
-          (view === 'PRESENT' && !shoutout.hidden) ||
-          (view === 'HIDDEN' && shoutout.hidden)) &&
-        shoutoutDate >= earlyDate &&
-        shoutoutDate <= lastDate
-      );
-    })
-    .sort((a, b) => a.timestamp - b.timestamp);
+  // const displayShoutouts = allShoutouts
+  // ?.filter((shoutout) => {
+  //   const shoutoutDate = new Date(shoutout.timestamp);
+  //   return (
+  //     (view === 'ALL' ||
+  //       (view === 'PRESENT' && !shoutout.hidden) ||
+  //       (view === 'HIDDEN' && shoutout.hidden)) &&
+  //     shoutoutDate >= earlyDate &&
+  //     shoutoutDate <= lastDate
+  //   );
+  // })
+  // .sort((a, b) => a.timestamp - b.timestamp);
 
   return (
     <div>
@@ -218,9 +236,13 @@ const AdminShoutouts: React.FC = () => {
       <div className={styles.shoutoutsListContainer}>
         <Header className={styles.formTitle} content={getListTitle(view)}></Header>
         <DisplayList
-          displayShoutouts={displayShoutouts}
+          displayShoutouts={allShoutouts?.length ? allShoutouts : []}
           view={view}
-          setAllShoutouts={setAllShoutouts}
+          setAllShoutouts={(shoutouts) => {
+            if (shoutouts) {
+              setAllShoutouts((shoutouts = []) => shoutouts);
+            }
+          }}
         />
       </div>
     </div>

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -198,17 +198,11 @@ const AdminShoutouts: React.FC = () => {
   const displayShoutouts = allShoutouts
     ?.filter((shoutout) => {
       const shoutoutDate = new Date(shoutout.timestamp);
-      const currentDate = new Date();
-      const timeZone = 'America/New_York';
-
-      const shoutoutDateString = shoutoutDate.toLocaleDateString('en-US', { timeZone });
-      const currentDateString = currentDate.toLocaleDateString('en-US', { timeZone });
-
       return (
         (view === 'ALL' ||
           (view === 'PRESENT' && !shoutout.hidden) ||
           (view === 'HIDDEN' && shoutout.hidden)) &&
-        (shoutoutDate >= earlyDate || shoutoutDateString === currentDateString) &&
+        shoutoutDate >= earlyDate &&
         shoutoutDate <= lastDate
       );
     })


### PR DESCRIPTION
added firebase listener on frontend so that we can update allshoutouts lists, 

allows for updating shououts when doc is added and removed



right now, we are updating and removing in real time successfully, **however** it is just showing all shoutouts regardless if hidden or not,

I tried to setup an additional hook  so that once `allshououts` list has changed, then we should change the `displayList` as well to update its content based on the additions to `allshoutouts`, but that approach didn't seem to work. 
Also tried added all the functionality to the same useeffect,and creating a setdisplaylist hook

Any suggestions on a way that i can update  the displayShoutouts list once allShoutouts changes?


https://www.notion.so/cornelldti/Idol-SP23-e65533742dca4f898581cc5c496e821e?p=83f4ec1786ad4cbc8310691000dbe088&pm=s
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

Tested, and updates are happening in realtime minus issues stated above