### PR TITLE
Rebrand to "Cornell Digital Technology & Innovation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ All the common types used by the packages are defined [here](./common-types/inde
 
 ## DTI
 
-We are a team within the **Cornell Design & Tech Initiative**. For more information, see
+We are a team within **Cornell Digital Technology & Innovation**. For more information, see
 [our website](https://cornelldti.org/).
 
 [![Cornell DTI](https://raw.githubusercontent.com/cornell-dti/design/master/Branding/Wordmark/Dark%20Text/Transparent/Wordmark-Dark%20Text-Transparent%403x.png)](https://cornelldti.org/)

--- a/dti-website-redesign/src/components/Footer.tsx
+++ b/dti-website-redesign/src/components/Footer.tsx
@@ -66,7 +66,7 @@ const Footer: React.FC = () => (
           </a>
         ))}
       </div>
-      <div className={styles.copyrightContainer}>Cornell Design & Tech Initiative &copy; 2022</div>
+      <div className={styles.copyrightContainer}>Cornell Digital Technology & Innovation &copy; 2023</div>
     </div>
   </div>
 );

--- a/dti-website-redesign/src/components/Footer.tsx
+++ b/dti-website-redesign/src/components/Footer.tsx
@@ -66,7 +66,9 @@ const Footer: React.FC = () => (
           </a>
         ))}
       </div>
-      <div className={styles.copyrightContainer}>Cornell Digital Technology & Innovation &copy; 2023</div>
+      <div className={styles.copyrightContainer}>
+        Cornell Digital Technology & Innovation &copy; 2023
+      </div>
     </div>
   </div>
 );

--- a/dti-website-redesign/src/pages/team/index.tsx
+++ b/dti-website-redesign/src/pages/team/index.tsx
@@ -95,7 +95,7 @@ const IndexPage = (): JSX.Element => (
               className={styles.paragraph}
               style={{ left: '-365px', top: '60px', width: '370px' }}
             >
-              We are Cornell Design & Tech Initiative. But individually, we are a <b>talented</b>,{' '}
+              We are Cornell Digital Technology and Innovation. But individually, we are a <b>talented</b>,{' '}
               <b>diverse</b> group of students from different colleges and countries striving to
               make a difference in our <b>community</b>.
             </div>

--- a/dti-website-redesign/src/pages/team/index.tsx
+++ b/dti-website-redesign/src/pages/team/index.tsx
@@ -95,9 +95,9 @@ const IndexPage = (): JSX.Element => (
               className={styles.paragraph}
               style={{ left: '-365px', top: '60px', width: '370px' }}
             >
-              We are Cornell Digital Technology and Innovation. But individually, we are a <b>talented</b>,{' '}
-              <b>diverse</b> group of students from different colleges and countries striving to
-              make a difference in our <b>community</b>.
+              We are Cornell Digital Technology and Innovation. But individually, we are a{' '}
+              <b>talented</b>, <b>diverse</b> group of students from different colleges and
+              countries striving to make a difference in our <b>community</b>.
             </div>
           </div>
           <img className={styles.leftShapes} src={'/static/team/left_shapes.svg'} alt={'Shapes'} />


### PR DESCRIPTION
### Summary <!-- Required -->
As part of the rebranding, update README and two spots on the new website that contain the old team name with "Cornell Digital Technology & Innovation".

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Manual. Did a Git grep to check for any instances of "Cornell Design & Tech Initiative", "Design & Tech", "Design and Tech", and "Initiative" and only found these three. Devs, feel free to put up a PR if you find any other ones.

### Notes <!-- Optional -->
We need to change the image on the new website. But that project is in progress, not public, and won't be released during Fall 2023.

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
