### PR TITLE
add fa23 contributors list to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ All the common types used by the packages are defined [here](./common-types/inde
 
 ## Contributors
 
+### Fall 2023
+
+- **Jason Mun** - PM
+- **Andrew Chen** - TPM
+- **Hope Zheng** - Designer
+- **Oscar Wang** - Developer
+- **Alyssa Zhang** - Developer
+
 ### Spring 2023
 
 - **Alyssa Zhang** - PM


### PR DESCRIPTION
### Summary 

-  Creates the Fall 2023 Idol contributors list with current members on README 

