### PR TITLE
Add Workaround for Loader Showing up Properly inside Modal

### DIFF
--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -22,3 +22,14 @@
   margin: 0;
   padding: 0;
 }
+
+/* Workaround for an unfixed bug with Loaders not showing up properly in Modals
+ * https://github.com/Semantic-Org/Semantic-UI-React/issues/3133 
+ */
+.ui.dimmer .ui.workaround.loader:before {
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.ui.dimmer .ui.workaround.loader:after {
+  border-color: #767676 transparent transparent;
+}


### PR DESCRIPTION
This PR adds a workaround to `App.css` to allow for SemanticUI `Loader` component to show up properly inside `Modal`s.

This is a known issue, and since SemanticUI is on longer being maintained, will not be fixed: https://github.com/Semantic-Org/Semantic-UI/issues/4014.

We use a workaround recommended here: https://github.com/Semantic-Org/Semantic-UI-React/issues/3133#
issuecomment-418766748

Before (example of attempting to place a loader in a modal, which doesn't show up):

![Screenshot 2023-09-17 at 9 08 33 PM](https://github.com/cornell-dti/idol/assets/59291082/f83f82b6-006c-4e4e-b985-2f25b83efb5b)


After:
![Screenshot 2023-09-17 at 9 07 07 PM](https://github.com/cornell-dti/idol/assets/59291082/c913fa89-80d4-42e5-859a-73d3b2b735cb)

