### PR TITLE
Fix REST Method Typo in CandidateDeciderAPI

### DIFF
--- a/frontend/src/API/CandidateDeciderAPI.ts
+++ b/frontend/src/API/CandidateDeciderAPI.ts
@@ -28,7 +28,7 @@ export default class CandidateDeciderAPI {
   }
 
   static async updateRating(uuid: string, id: number, rating: number): Promise<void> {
-    APIWrapper.post(`${backendURL}/candidate-decider/${uuid}/rating`, { uuid, id, rating });
+    APIWrapper.put(`${backendURL}/candidate-decider/${uuid}/rating`, { uuid, id, rating });
   }
 
   static async updateComment(uuid: string, id: number, comment: string): Promise<void> {


### PR DESCRIPTION
### Summary <!-- Required -->

The `/candidate-decider/${uuid}/rating` endpoint was updated to PUT instead of POST, but I missed this when getting this change in https://github.com/cornell-dti/idol/pull/472. 