### PR TITLE
Remove Candidate Decider Infinite Rendering Loop

### DIFF
--- a/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
@@ -181,7 +181,6 @@ const CandidateDeciderInstanceList = ({
 }: CandidateDeciderInstancelistProps): JSX.Element => {
   useEffect(() => {
     getAllInstances().then(() => setIsLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const toggleIsOpen = (uuid: string) => {

--- a/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
@@ -181,6 +181,7 @@ const CandidateDeciderInstanceList = ({
 }: CandidateDeciderInstancelistProps): JSX.Element => {
   useEffect(() => {
     getAllInstances().then(() => setIsLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const toggleIsOpen = (uuid: string) => {

--- a/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
@@ -181,7 +181,8 @@ const CandidateDeciderInstanceList = ({
 }: CandidateDeciderInstancelistProps): JSX.Element => {
   useEffect(() => {
     getAllInstances().then(() => setIsLoading(false));
-  }, [instances, getAllInstances, setIsLoading]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const toggleIsOpen = (uuid: string) => {
     const updatedInstances = instances.map((instance) =>


### PR DESCRIPTION
### Summary <!-- Required -->

While working on the candidate decider, I checked the network tab to debug something unrelated and noticed an infinite rendering loop that has been sitting there for awhile now that spams lots and lots of API calls!

 Note for future users of the `useEffect` hook: if you're just trying to run some function/fetch once when the component mounts/page loads in, just leave the dependency array as empty. 

ESLint tends to be extra picky at times with adding functions used to the dependency array, but this can lead to infinite rendering loops (and a lot of Firebase reads!).

![Screenshot 2023-09-19 at 2 27 42 AM](https://github.com/cornell-dti/idol/assets/59291082/52594cb8-0cb1-4fad-a040-c98b9d076293)

