### PR TITLE
Remove Extraneous } in ShoutoutsAPI call

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -252,9 +252,13 @@ router.get('/member-image', async (_, res) => {
 });
 
 // Shoutouts
-loginCheckedGet('/shoutout/:email', async (req, user) => ({
+loginCheckedGet('/shoutout/:email', async (req, user) => {
+  console.log(req.query.type)
+  console.log(req.query)
+  return ({
   shoutouts: await getShoutouts(req.params.email, req.query.type as 'given' | 'received', user)
-}));
+})}
+);
 
 loginCheckedGet('/shoutout', async () => ({
   shoutouts: await getAllShoutouts()

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -252,13 +252,9 @@ router.get('/member-image', async (_, res) => {
 });
 
 // Shoutouts
-loginCheckedGet('/shoutout/:email', async (req, user) => {
-  console.log(req.query.type)
-  console.log(req.query)
-  return ({
+loginCheckedGet('/shoutout/:email', async (req, user) => ({
   shoutouts: await getShoutouts(req.params.email, req.query.type as 'given' | 'received', user)
-})}
-);
+}));
 
 loginCheckedGet('/shoutout', async () => ({
   shoutouts: await getAllShoutouts()

--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -24,7 +24,7 @@ export default class ShoutoutsAPI {
   }
 
   public static getShoutouts(email: string, type: 'given' | 'received'): Promise<Shoutout[]> {
-    const responseProm = APIWrapper.get(`${backendURL}/shoutout/${email}?type=${type}}`).then(
+    const responseProm = APIWrapper.get(`${backendURL}/shoutout/${email}?type=${type}`).then(
       (res) => res.data
     );
     return responseProm.then((val) => {


### PR DESCRIPTION
Remove typo in ShoutoutsAPI call, an extraneous "}" that was accidentally introduced.

This should make "given" shoutouts visible again. Thanks @oscarwang20 for catching that!

(This PR might win the smallest PR award)