### PR TITLE
Filter Candidate Decider Instances Returned from `/candidate-decider` by Permissions

### DIFF
--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -21,11 +21,10 @@ export const getAllCandidateDeciderInstances = async (
     );
   }
 
-  const instanceInfo = filteredInstances.map((instance) => {
+  return filteredInstances.map((instance) => {
     const { name, uuid, isOpen } = instance;
     return { name, uuid, isOpen };
   });
-  return instanceInfo;
 };
 
 export const createNewCandidateDeciderInstance = async (

--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -6,7 +6,27 @@ const candidateDeciderDao = new CandidateDeciderDao();
 
 export const getAllCandidateDeciderInstances = async (
   user: IdolMember
-): Promise<CandidateDeciderInfo[]> => candidateDeciderDao.getAllInstances();
+): Promise<CandidateDeciderInfo[]> => {
+  const instances = await candidateDeciderDao.getAllInstances();
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+
+  let filteredInstances;
+  if (isLeadOrAdmin) {
+    filteredInstances = instances;
+  } else {
+    filteredInstances = instances.filter(
+      (instance) =>
+        instance.authorizedRoles.includes(user.role) ||
+        instance.authorizedMembers.some((member) => member.email === user.email)
+    );
+  }
+
+  const instanceInfo = filteredInstances.map((instance) => {
+    const { name, uuid, isOpen } = instance;
+    return { name, uuid, isOpen };
+  });
+  return instanceInfo;
+};
 
 export const createNewCandidateDeciderInstance = async (
   instance: CandidateDeciderInstance,

--- a/backend/src/dao/CandidateDeciderDao.ts
+++ b/backend/src/dao/CandidateDeciderDao.ts
@@ -66,15 +66,8 @@ export default class CandidateDeciderDao extends BaseDao<
     );
   }
 
-  async getAllInstances(): Promise<CandidateDeciderInfo[]> {
-    const instanceRefs = await this.collection.get();
-
-    return Promise.all(
-      instanceRefs.docs.map(async (instanceRefs) => {
-        const { name, uuid, isOpen } = instanceRefs.data() as DBCandidateDeciderInstance;
-        return { name, uuid, isOpen };
-      })
-    );
+  async getAllInstances(): Promise<CandidateDeciderInstance[]> {
+    return this.getDocuments();
   }
 
   async getInstance(uuid: string): Promise<CandidateDeciderInstance | null> {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR is part of the larger ticket to fix permission handling for the candidate decider.

Filter the candidate decider instances returned by `/candidate-decider` API endpoint to be only the ones that the user has permissions to access.

### Notion/Figma Link <!-- Optional -->

https://www.notion.so/cornelldti/Candidate-Decider-Fix-Permission-Handling-on-the-UI-and-in-Firebase-0c86c35b2f9643ffa37cc43ac0b0920c?pvs=4

### Test Plan <!-- Required -->

I disabled my IDOL admin privileges and gave myself access to only one of the instances.

Before (and if you clicked on the instances you did not have access to, you would get Firestore permissions error):
![Screenshot 2023-09-24 at 1 44 05 PM](https://github.com/cornell-dti/idol/assets/59291082/c7b6ab5a-0a5d-45f6-a329-09b100b470db)



After:

![Screenshot 2023-09-24 at 1 43 33 PM](https://github.com/cornell-dti/idol/assets/59291082/5c312a74-f71e-4178-ae6b-45500d47f4d7)


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
