### PR TITLE
Add Documentation Field for Dev and TPM Portfolios

### DIFF
--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -81,6 +81,9 @@ export type DBDevPortfolioSubmission = {
   member: firestore.DocumentReference;
   openedPRs: PullRequestSubmission[];
   reviewedPRs: PullRequestSubmission[];
+  isLate?: boolean;
+  text?: string;
+  documentationText?: string;
   status: SubmissionStatus;
 };
 

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -162,6 +162,7 @@ interface DevPortfolioSubmission {
   reviewedPRs: PullRequestSubmission[];
   isLate?: boolean;
   text?: string;
+  documentationText?: string;
   status: SubmissionStatus;
 }
 

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -186,6 +186,7 @@ const DetailsTable: React.FC<DevPortfolioDetailsTableProps> = ({ portfolio, isAd
           <Table.HeaderCell>Name</Table.HeaderCell>
           <Table.HeaderCell>Opened PRs</Table.HeaderCell>
           <Table.HeaderCell>Reviewed PRs</Table.HeaderCell>
+          <Table.HeaderCell>Documentation</Table.HeaderCell>
           <Table.HeaderCell>Status</Table.HeaderCell>
           {sortedSubmissions.some((submission) => submission.text) && (
             <Table.HeaderCell></Table.HeaderCell>
@@ -256,6 +257,9 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
             prSubmission={submission.reviewedPRs.length > 0 ? submission.reviewedPRs[0] : undefined}
           />
         </Table.Cell>
+        <Table.Cell>
+          {submission.documentationText ?? ""}
+        </Table.Cell>
 
         {isAdminView ? (
           <Table.Cell rowSpan={`${numRows}`}>
@@ -320,6 +324,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
           prSubmission={i >= remainingReviewedPRs.length ? undefined : remainingReviewedPRs[i]}
         />
       </Table.Cell>
+      <Table.Cell />
       {!submission.text ? <div></div> : <></>}
     </Table.Row>
   ));

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -257,9 +257,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
             prSubmission={submission.reviewedPRs.length > 0 ? submission.reviewedPRs[0] : undefined}
           />
         </Table.Cell>
-        <Table.Cell>
-          {submission.documentationText ?? ""}
-        </Table.Cell>
+        <Table.Cell>{submission.documentationText ?? ''}</Table.Cell>
 
         {isAdminView ? (
           <Table.Cell rowSpan={`${numRows}`}>

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -257,7 +257,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
             prSubmission={submission.reviewedPRs.length > 0 ? submission.reviewedPRs[0] : undefined}
           />
         </Table.Cell>
-        <Table.Cell>{submission.documentationText ?? ''}</Table.Cell>
+        <Table.Cell>{submission.documentationText}</Table.Cell>
 
         {isAdminView ? (
           <Table.Cell rowSpan={`${numRows}`}>

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -12,7 +12,7 @@ const DevPortfolioForm: React.FC = () => {
   // When the user is logged in, `useSelf` always return non-null data.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const userInfo = useSelf()!;
-  const isTpm = userInfo.role === 'tpm';
+  const isTpm = false;
 
   const [devPortfolio, setDevPortfolio] = useState<DevPortfolio | undefined>(undefined);
   const [devPortfolios, setDevPortfolios] = useState<DevPortfolio[]>([]);
@@ -20,7 +20,7 @@ const DevPortfolioForm: React.FC = () => {
   const [reviewPRs, setReviewedPRs] = useState(['']);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [text, setText] = useState<string | undefined>(undefined);
-  const [documentationText, setDocumentationText] = useState<string | undefined>(undefined);
+  const [documentationText, setDocumentationText] = useState<string>('');
 
   useEffect(() => {
     refreshDevPortfolios();
@@ -198,12 +198,6 @@ const DevPortfolioForm: React.FC = () => {
           ) : (
             <></>
           )}
-          <br />
-          <label className={styles.bold}>
-            Documentation: <span className={styles.red_color}>*</span>
-          </label>
-          <p>Please provide a link to at least one piece of documentation you added/updated.</p>
-          <TextArea value={text} onChange={(e) => setDocumentationText(e.target.value)} />
           <PRInputs
             prs={openPRs}
             setPRs={setOpenPRs}
@@ -217,6 +211,10 @@ const DevPortfolioForm: React.FC = () => {
             placeholder="Reviewed PR"
             label="Reviewed Pull Request Github Link:"
             isTpm={isTpm}
+          />
+          <DocumentationInput
+            setDocumentationText={setDocumentationText}
+            documentationText={documentationText}
           />
         </div>
         <Message info>
@@ -242,6 +240,22 @@ const DevPortfolioForm: React.FC = () => {
     </div>
   );
 };
+
+const DocumentationInput = ({
+  documentationText,
+  setDocumentationText
+}: {
+  documentationText: string;
+  setDocumentationText: React.Dispatch<React.SetStateAction<string>>;
+}) => (
+  <div>
+    <label className={styles.bold}>
+      Documentation: <span className={styles.red_color}>*</span>
+    </label>
+    <p>Please provide a link to at least one piece of documentation you added/updated.</p>
+    <TextArea value={documentationText} onChange={(e) => setDocumentationText(e.target.value)} />
+  </div>
+);
 
 const PRInputs = ({
   prs,

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -199,12 +199,10 @@ const DevPortfolioForm: React.FC = () => {
             <></>
           )}
           <br />
-                        <label className={styles.bold}>
-                Documentation: <span className={styles.red_color}>*</span>
-              </label>
-              <p>
-                Please provide a link to at least one piece of documentation you added/updated.
-              </p>
+          <label className={styles.bold}>
+            Documentation: <span className={styles.red_color}>*</span>
+          </label>
+          <p>Please provide a link to at least one piece of documentation you added/updated.</p>
           <TextArea value={text} onChange={(e) => setDocumentationText(e.target.value)} />
           <PRInputs
             prs={openPRs}

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -20,6 +20,7 @@ const DevPortfolioForm: React.FC = () => {
   const [reviewPRs, setReviewedPRs] = useState(['']);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [text, setText] = useState<string | undefined>(undefined);
+  const [documentationText, setDocumentationText] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     refreshDevPortfolios();
@@ -93,6 +94,11 @@ const DevPortfolioForm: React.FC = () => {
         headerMsg: 'Paragraph Submission Empty',
         contentMsg: 'Please write something for the paragraph section of the assignment.'
       });
+    } else if (!documentationText) {
+      Emitters.generalError.emit({
+        headerMsg: 'Documentation Empty',
+        contentMsg: 'Please write something for the documentation section of the assignment.'
+      });
     } else if (new Date(latestDeadline) < new Date()) {
       Emitters.generalError.emit({
         headerMsg: 'The deadline for this dev portfolio has passed',
@@ -115,6 +121,7 @@ const DevPortfolioForm: React.FC = () => {
           status: 'pending'
         })),
         status: 'pending',
+        documentationText,
         ...(text && { text })
       };
       sendSubmissionRequest(newDevPortfolioSubmission, devPortfolio);
@@ -180,7 +187,7 @@ const DevPortfolioForm: React.FC = () => {
                 2. What did the team do the past two weeks?
               </p>
 
-              <TextArea value={text} onChange={(e) => setText(e.target.value)}></TextArea>
+              <TextArea value={text} onChange={(e) => setText(e.target.value)} />
 
               <p>
                 In addition, if you have created and/or reviewed pull requests, please include those
@@ -191,6 +198,14 @@ const DevPortfolioForm: React.FC = () => {
           ) : (
             <></>
           )}
+          <br />
+                        <label className={styles.bold}>
+                Documentation: <span className={styles.red_color}>*</span>
+              </label>
+              <p>
+                Please provide a link to at least one piece of documentation you added/updated.
+              </p>
+          <TextArea value={text} onChange={(e) => setDocumentationText(e.target.value)} />
           <PRInputs
             prs={openPRs}
             setPRs={setOpenPRs}

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -12,7 +12,7 @@ const DevPortfolioForm: React.FC = () => {
   // When the user is logged in, `useSelf` always return non-null data.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const userInfo = useSelf()!;
-  const isTpm = false;
+  const isTpm = userInfo.role === 'tpm';
 
   const [devPortfolio, setDevPortfolio] = useState<DevPortfolio | undefined>(undefined);
   const [devPortfolios, setDevPortfolios] = useState<DevPortfolio[]>([]);

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -252,7 +252,12 @@ const DocumentationInput = ({
     <label className={styles.bold}>
       Documentation: <span className={styles.red_color}>*</span>
     </label>
-    <p>Please provide a link to at least one piece of documentation you added/updated.</p>
+    <p>
+      Please provide a link to at least one piece of documentation you added/updated. If it's
+      included in the PRs you added above, you may simply write "Documentation located in PR (insert
+      PR number here)". If you made a separate PR updating documentation in the codebase, please
+      link that PR here.
+    </p>
     <TextArea value={documentationText} onChange={(e) => setDocumentationText(e.target.value)} />
   </div>
 );


### PR DESCRIPTION
### Summary <!-- Required -->

In response to the updated expectations for TPM and Dev portfolios, we're adding a new field for "Documentation" for both Devs and TPM views. This way, Devs and TPMs are reminded to include documentation, and they have a way of specifying the documentation they updated, whether or not it's in the PRs they submitted.

Update this in the DB schema and add a UI element.

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/cornelldti/Add-Blurb-about-Linking-Documentation-for-TPM-Portfolio-bbcc3f76ec5844f981e90a7921083e17?pvs=4

### Test Plan <!-- Required -->

Admin view:

![Screenshot 2023-09-26 at 12 55 42 AM](https://github.com/cornell-dti/idol/assets/59291082/76c74af3-ed43-489c-bf59-713d03e98ebd)


Developer view:
![Screenshot 2023-09-26 at 1 29 32 AM](https://github.com/cornell-dti/idol/assets/59291082/454aac34-dd83-4a91-964a-4a12d50f4e64)


![Screenshot 2023-09-26 at 12 51 30 AM](https://github.com/cornell-dti/idol/assets/59291082/d1ca758d-216b-4e75-b685-74452497d04f)


TPM view:

![Screenshot 2023-09-26 at 1 29 03 AM](https://github.com/cornell-dti/idol/assets/59291082/0b2171cb-a5cd-4d3d-a5ef-d6845b8c6f6d)
