### PR TITLE
add loading wheel, shoutouts

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
+/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,5 +1,15 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Form, Item, Card, Modal, Header, SemanticCOLORS, Image, Loader } from 'semantic-ui-react';
+import {
+  Button,
+  Form,
+  Item,
+  Card,
+  Modal,
+  Header,
+  SemanticCOLORS,
+  Image,
+  Loader
+} from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Emitters } from '../../../utils';
@@ -15,7 +25,6 @@ const AdminShoutouts: React.FC = () => {
   const [hide, setHide] = useState(false);
   const [loading, setLoading] = useState<boolean>(false);
 
-
   type ViewMode = 'ALL' | 'PRESENT' | 'HIDDEN';
   const [view, setView] = useState<ViewMode>('ALL');
 
@@ -27,13 +36,15 @@ const AdminShoutouts: React.FC = () => {
         contentMsg: 'Please make sure the latest shoutout date is after the earliest shoutout date.'
       });
       setLoading(false);
-      return; 
+      return;
     }
     if (allShoutouts.length === 0) {
-      ShoutoutsAPI.getAllShoutouts().then((shoutouts) => {
-        setAllShoutouts(shoutouts);
-        setLoading(false);
-      }).catch(() => setLoading(false));
+      ShoutoutsAPI.getAllShoutouts()
+        .then((shoutouts) => {
+          setAllShoutouts(shoutouts);
+          setLoading(false);
+        })
+        .catch(() => setLoading(false));
     } else {
       const filteredShoutouts = allShoutouts
         .filter((shoutout) => {
@@ -41,13 +52,13 @@ const AdminShoutouts: React.FC = () => {
           return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
         })
         .sort((a, b) => a.timestamp - b.timestamp);
-  
+
       if (view === 'PRESENT')
         setDisplayShoutouts(filteredShoutouts.filter((shoutout) => !shoutout.hidden));
       else if (view === 'HIDDEN')
         setDisplayShoutouts(filteredShoutouts.filter((shoutout) => shoutout.hidden));
       else setDisplayShoutouts(filteredShoutouts);
-  
+
       setHide(false);
       setLoading(false);
     }
@@ -222,34 +233,34 @@ const AdminShoutouts: React.FC = () => {
   return (
     <div>
       {loading ? (
-        <Loader active inline='centered' />
+        <Loader active inline="centered" />
       ) : (
-      <div>
-        <Form className={styles.shoutoutForm}>
-          <h2>Filter shoutouts:</h2>
-          <Form.Group width="equals">
-            <ChooseDate dateField={earlyDate} dateFunction={setEarlyDate} />
-            <ChooseDate dateField={lastDate} dateFunction={setLastDate} />
-            <Button.Group className={styles.buttonGroup}>
-              <ButtonPiece shoutoutList={displayShoutouts} buttonText={'ALL'} />
-              <ButtonPiece
-                shoutoutList={displayShoutouts.filter((shoutout) => shoutout.hidden)}
-                buttonText={'HIDDEN'}
-              />
-              <ButtonPiece
-                shoutoutList={displayShoutouts.filter((shoutout) => !shoutout.hidden)}
-                buttonText={'PRESENT'}
-              />
-            </Button.Group>
-          </Form.Group>
-        </Form>
-        <div className={styles.shoutoutsListContainer}>
-          <ListTitle />
-          <DisplayList />
+        <div>
+          <Form className={styles.shoutoutForm}>
+            <h2>Filter shoutouts:</h2>
+            <Form.Group width="equals">
+              <ChooseDate dateField={earlyDate} dateFunction={setEarlyDate} />
+              <ChooseDate dateField={lastDate} dateFunction={setLastDate} />
+              <Button.Group className={styles.buttonGroup}>
+                <ButtonPiece shoutoutList={displayShoutouts} buttonText={'ALL'} />
+                <ButtonPiece
+                  shoutoutList={displayShoutouts.filter((shoutout) => shoutout.hidden)}
+                  buttonText={'HIDDEN'}
+                />
+                <ButtonPiece
+                  shoutoutList={displayShoutouts.filter((shoutout) => !shoutout.hidden)}
+                  buttonText={'PRESENT'}
+                />
+              </Button.Group>
+            </Form.Group>
+          </Form>
+          <div className={styles.shoutoutsListContainer}>
+            <ListTitle />
+            <DisplayList />
+          </div>
         </div>
-      </div>
       )}
-  </div>
+    </div>
   );
 };
 

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,5 +1,15 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Form, Item, Card, Modal, Header, SemanticCOLORS, Image, Loader } from 'semantic-ui-react';
+import {
+  Button,
+  Form,
+  Item,
+  Card,
+  Modal,
+  Header,
+  SemanticCOLORS,
+  Image,
+  Loader
+} from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Emitters } from '../../../utils';
@@ -13,7 +23,7 @@ const AdminShoutouts: React.FC = () => {
   const [earlyDate, setEarlyDate] = useState<Date>(new Date(Date.now() - 86400000 * 13.5));
   const [lastDate, setLastDate] = useState<Date>(new Date());
   const [hide, setHide] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   type ViewMode = 'ALL' | 'PRESENT' | 'HIDDEN';
   const [view, setView] = useState<ViewMode>('ALL');
@@ -236,7 +246,7 @@ const AdminShoutouts: React.FC = () => {
       </Form>
       <div className={styles.shoutoutsListContainer}>
         {loading ? (
-          <Loader active inline='centered' />
+          <Loader active inline="centered" />
         ) : (
           <>
             <ListTitle />

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Form, Item, Card, Modal, Header, SemanticCOLORS, Image } from 'semantic-ui-react';
+import { Button, Form, Item, Card, Modal, Header, SemanticCOLORS, Image, Loader } from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Emitters } from '../../../utils';
@@ -13,21 +13,27 @@ const AdminShoutouts: React.FC = () => {
   const [earlyDate, setEarlyDate] = useState<Date>(new Date(Date.now() - 86400000 * 13.5));
   const [lastDate, setLastDate] = useState<Date>(new Date());
   const [hide, setHide] = useState(false);
+  const [loading, setLoading] = useState<boolean>(false);
+
 
   type ViewMode = 'ALL' | 'PRESENT' | 'HIDDEN';
   const [view, setView] = useState<ViewMode>('ALL');
 
   const updateShoutouts = useCallback(() => {
+    setLoading(true);
     if (lastDate < earlyDate) {
       Emitters.generalError.emit({
         headerMsg: 'Invalid Date Range',
         contentMsg: 'Please make sure the latest shoutout date is after the earliest shoutout date.'
       });
+      setLoading(false);
+      return; 
     }
     if (allShoutouts.length === 0) {
       ShoutoutsAPI.getAllShoutouts().then((shoutouts) => {
         setAllShoutouts(shoutouts);
-      });
+        setLoading(false);
+      }).catch(() => setLoading(false));
     } else {
       const filteredShoutouts = allShoutouts
         .filter((shoutout) => {
@@ -35,12 +41,15 @@ const AdminShoutouts: React.FC = () => {
           return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
         })
         .sort((a, b) => a.timestamp - b.timestamp);
+  
       if (view === 'PRESENT')
         setDisplayShoutouts(filteredShoutouts.filter((shoutout) => !shoutout.hidden));
       else if (view === 'HIDDEN')
         setDisplayShoutouts(filteredShoutouts.filter((shoutout) => shoutout.hidden));
       else setDisplayShoutouts(filteredShoutouts);
+  
       setHide(false);
+      setLoading(false);
     }
   }, [allShoutouts, earlyDate, lastDate, view]);
 
@@ -212,29 +221,35 @@ const AdminShoutouts: React.FC = () => {
 
   return (
     <div>
-      <Form className={styles.shoutoutForm}>
-        <h2>Filter shoutouts:</h2>
-        <Form.Group width="equals">
-          <ChooseDate dateField={earlyDate} dateFunction={setEarlyDate} />
-          <ChooseDate dateField={lastDate} dateFunction={setLastDate} />
-          <Button.Group className={styles.buttonGroup}>
-            <ButtonPiece shoutoutList={displayShoutouts} buttonText={'ALL'} />
-            <ButtonPiece
-              shoutoutList={displayShoutouts.filter((shoutout) => shoutout.hidden)}
-              buttonText={'HIDDEN'}
-            />
-            <ButtonPiece
-              shoutoutList={displayShoutouts.filter((shoutout) => !shoutout.hidden)}
-              buttonText={'PRESENT'}
-            />
-          </Button.Group>
-        </Form.Group>
-      </Form>
-      <div className={styles.shoutoutsListContainer}>
-        <ListTitle />
-        <DisplayList />
+      {loading ? (
+        <Loader active inline='centered' />
+      ) : (
+      <div>
+        <Form className={styles.shoutoutForm}>
+          <h2>Filter shoutouts:</h2>
+          <Form.Group width="equals">
+            <ChooseDate dateField={earlyDate} dateFunction={setEarlyDate} />
+            <ChooseDate dateField={lastDate} dateFunction={setLastDate} />
+            <Button.Group className={styles.buttonGroup}>
+              <ButtonPiece shoutoutList={displayShoutouts} buttonText={'ALL'} />
+              <ButtonPiece
+                shoutoutList={displayShoutouts.filter((shoutout) => shoutout.hidden)}
+                buttonText={'HIDDEN'}
+              />
+              <ButtonPiece
+                shoutoutList={displayShoutouts.filter((shoutout) => !shoutout.hidden)}
+                buttonText={'PRESENT'}
+              />
+            </Button.Group>
+          </Form.Group>
+        </Form>
+        <div className={styles.shoutoutsListContainer}>
+          <ListTitle />
+          <DisplayList />
+        </div>
       </div>
-    </div>
+      )}
+  </div>
   );
 };
 

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -1,15 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import {
-  Button,
-  Form,
-  Item,
-  Card,
-  Modal,
-  Header,
-  SemanticCOLORS,
-  Image,
-  Loader
-} from 'semantic-ui-react';
+import { Button, Form, Item, Card, Modal, Header, SemanticCOLORS, Image, Loader } from 'semantic-ui-react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Emitters } from '../../../utils';
@@ -23,7 +13,7 @@ const AdminShoutouts: React.FC = () => {
   const [earlyDate, setEarlyDate] = useState<Date>(new Date(Date.now() - 86400000 * 13.5));
   const [lastDate, setLastDate] = useState<Date>(new Date());
   const [hide, setHide] = useState(false);
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState(true);
 
   type ViewMode = 'ALL' | 'PRESENT' | 'HIDDEN';
   const [view, setView] = useState<ViewMode>('ALL');
@@ -35,16 +25,12 @@ const AdminShoutouts: React.FC = () => {
         headerMsg: 'Invalid Date Range',
         contentMsg: 'Please make sure the latest shoutout date is after the earliest shoutout date.'
       });
-      setLoading(false);
-      return;
     }
     if (allShoutouts.length === 0) {
-      ShoutoutsAPI.getAllShoutouts()
-        .then((shoutouts) => {
-          setAllShoutouts(shoutouts);
-          setLoading(false);
-        })
-        .catch(() => setLoading(false));
+      ShoutoutsAPI.getAllShoutouts().then((shoutouts) => {
+        setAllShoutouts(shoutouts);
+        setLoading(false);
+      });
     } else {
       const filteredShoutouts = allShoutouts
         .filter((shoutout) => {
@@ -52,13 +38,11 @@ const AdminShoutouts: React.FC = () => {
           return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
         })
         .sort((a, b) => a.timestamp - b.timestamp);
-
       if (view === 'PRESENT')
         setDisplayShoutouts(filteredShoutouts.filter((shoutout) => !shoutout.hidden));
       else if (view === 'HIDDEN')
         setDisplayShoutouts(filteredShoutouts.filter((shoutout) => shoutout.hidden));
       else setDisplayShoutouts(filteredShoutouts);
-
       setHide(false);
       setLoading(false);
     }
@@ -232,34 +216,34 @@ const AdminShoutouts: React.FC = () => {
 
   return (
     <div>
-      {loading ? (
-        <Loader active inline="centered" />
-      ) : (
-        <div>
-          <Form className={styles.shoutoutForm}>
-            <h2>Filter shoutouts:</h2>
-            <Form.Group width="equals">
-              <ChooseDate dateField={earlyDate} dateFunction={setEarlyDate} />
-              <ChooseDate dateField={lastDate} dateFunction={setLastDate} />
-              <Button.Group className={styles.buttonGroup}>
-                <ButtonPiece shoutoutList={displayShoutouts} buttonText={'ALL'} />
-                <ButtonPiece
-                  shoutoutList={displayShoutouts.filter((shoutout) => shoutout.hidden)}
-                  buttonText={'HIDDEN'}
-                />
-                <ButtonPiece
-                  shoutoutList={displayShoutouts.filter((shoutout) => !shoutout.hidden)}
-                  buttonText={'PRESENT'}
-                />
-              </Button.Group>
-            </Form.Group>
-          </Form>
-          <div className={styles.shoutoutsListContainer}>
+      <Form className={styles.shoutoutForm}>
+        <h2>Filter shoutouts:</h2>
+        <Form.Group width="equals">
+          <ChooseDate dateField={earlyDate} dateFunction={setEarlyDate} />
+          <ChooseDate dateField={lastDate} dateFunction={setLastDate} />
+          <Button.Group className={styles.buttonGroup}>
+            <ButtonPiece shoutoutList={displayShoutouts} buttonText={'ALL'} />
+            <ButtonPiece
+              shoutoutList={displayShoutouts.filter((shoutout) => shoutout.hidden)}
+              buttonText={'HIDDEN'}
+            />
+            <ButtonPiece
+              shoutoutList={displayShoutouts.filter((shoutout) => !shoutout.hidden)}
+              buttonText={'PRESENT'}
+            />
+          </Button.Group>
+        </Form.Group>
+      </Form>
+      <div className={styles.shoutoutsListContainer}>
+        {loading ? (
+          <Loader active inline='centered' />
+        ) : (
+          <>
             <ListTitle />
             <DisplayList />
-          </div>
-        </div>
-      )}
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Form, TextArea, Checkbox } from 'semantic-ui-react';
+import { Form, TextArea, Checkbox, Loader } from 'semantic-ui-react';
 import { useUserEmail } from '../../Common/UserProvider/UserProvider';
 import { Emitters } from '../../../utils';
 import ShoutoutsAPI from '../../../API/ShoutoutsAPI';
@@ -17,8 +17,10 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
   const [receiver, setReceiver] = useState('');
   const [message, setMessage] = useState('');
   const [isAnon, setIsAnon] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const giveShoutout = () => {
+    setIsSubmitting(true);
     if (!receiver) {
       Emitters.generalError.emit({
         headerMsg: 'No Member Selected',
@@ -35,6 +37,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
         uuid: ''
       };
       ShoutoutsAPI.giveShoutout(shoutout).then((val) => {
+        setIsSubmitting(false);
         if (val.error) {
           Emitters.generalError.emit({
             headerMsg: "Couldn't send shoutout!",
@@ -83,8 +86,8 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
         />
       </div>
 
-      <Form.Button floated="right" onClick={giveShoutout}>
-        Send
+      <Form.Button floated="right" onClick={giveShoutout} disabled={isSubmitting}>
+        {isSubmitting ? <Loader active inline size='small' /> : 'Send'} 
       </Form.Button>
     </Form>
   );

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -87,7 +87,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
       </div>
 
       <Form.Button floated="right" onClick={giveShoutout} disabled={isSubmitting}>
-        {isSubmitting ? <Loader active inline size='small' /> : 'Send'} 
+        {isSubmitting ? <Loader active inline size="small" /> : 'Send'}
       </Form.Button>
     </Form>
   );

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable no-nested-ternary */
 import React, { useState, useEffect, useCallback } from 'react';
-import { Message } from 'semantic-ui-react';
+import { Message, Loader } from 'semantic-ui-react';
 import { useUserEmail } from '../../Common/UserProvider/UserProvider';
 import { Emitters } from '../../../utils';
 import ShoutoutForm from './ShoutoutForm';
@@ -7,21 +8,28 @@ import ShoutoutList from './ShoutoutList';
 import styles from './ShoutoutsPage.module.css';
 import ShoutoutsAPI from '../../../API/ShoutoutsAPI';
 
+
 const ShoutoutsPage: React.FC = () => {
   const userEmail = useUserEmail();
   const [givenShoutouts, setGivenShoutouts] = useState<Shoutout[]>([]);
-
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  
   const getGivenShoutouts = useCallback(() => {
+    setIsLoading(true);
     ShoutoutsAPI.getShoutouts(userEmail, 'given')
-      .then((given) => setGivenShoutouts(given))
+      .then((given) => {
+        setGivenShoutouts(given);
+        setIsLoading(false);
+      })
       .catch((error) => {
         Emitters.generalError.emit({
           headerMsg: `Couldn't get given shoutouts!`,
           contentMsg: `Error was: ${error}`
         });
+        setIsLoading(false);
       });
   }, [userEmail]);
-
+  
   useEffect(() => {
     getGivenShoutouts();
   }, [userEmail, getGivenShoutouts]);
@@ -34,7 +42,9 @@ const ShoutoutsPage: React.FC = () => {
 
       <div className={styles.shoutoutListContainer}>
         <h2>Given Shoutouts</h2>
-        {givenShoutouts.length > 0 ? (
+        {isLoading ? ( 
+          <Loader active inline='centered' />
+        ) : givenShoutouts.length > 0 ? (
           <ShoutoutList
             shoutouts={givenShoutouts.sort((a, b) => a.timestamp - b.timestamp)}
             setGivenShoutouts={setGivenShoutouts}

--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutsPage.tsx
@@ -8,12 +8,11 @@ import ShoutoutList from './ShoutoutList';
 import styles from './ShoutoutsPage.module.css';
 import ShoutoutsAPI from '../../../API/ShoutoutsAPI';
 
-
 const ShoutoutsPage: React.FC = () => {
   const userEmail = useUserEmail();
   const [givenShoutouts, setGivenShoutouts] = useState<Shoutout[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  
+
   const getGivenShoutouts = useCallback(() => {
     setIsLoading(true);
     ShoutoutsAPI.getShoutouts(userEmail, 'given')
@@ -29,7 +28,7 @@ const ShoutoutsPage: React.FC = () => {
         setIsLoading(false);
       });
   }, [userEmail]);
-  
+
   useEffect(() => {
     getGivenShoutouts();
   }, [userEmail, getGivenShoutouts]);
@@ -42,8 +41,8 @@ const ShoutoutsPage: React.FC = () => {
 
       <div className={styles.shoutoutListContainer}>
         <h2>Given Shoutouts</h2>
-        {isLoading ? ( 
-          <Loader active inline='centered' />
+        {isLoading ? (
+          <Loader active inline="centered" />
         ) : givenShoutouts.length > 0 ? (
           <ShoutoutList
             shoutouts={givenShoutouts.sort((a, b) => a.timestamp - b.timestamp)}


### PR DESCRIPTION
Ticket: "Shoutouts - Fix How Shoutouts Are Loaded In on Admin View"
Notion: https://www.notion.so/cornelldti/Idol-FA23-08f1aac52a364b1dad8cde77ebc1c027?p=c402189001014a1798a22db9286d4566&pm=s

implemented Loader from Semantic UI into "Shoutouts" - Previously, users were presented with empty space while waiting for shoutouts to load, leading to confusion regarding the application's state. The incorporation of a loading indicator serves to improve the user experience by providing real-time feedback and a more intuitive interaction.

![shoutoutLoader](https://github.com/cornell-dti/idol/assets/69252747/bf36cda6-bd04-4d34-b34b-03c35de3f1ab)
