### PR TITLE
Fix typo in shoutout DELETE endpoint

### DIFF
--- a/frontend/src/API/ShoutoutsAPI.ts
+++ b/frontend/src/API/ShoutoutsAPI.ts
@@ -49,6 +49,6 @@ export default class ShoutoutsAPI {
   }
 
   public static async deleteShoutout(uuid: string): Promise<void> {
-    await APIWrapper.delete(`${backendURL}/deleteShoutout/${uuid}`);
+    await APIWrapper.delete(`${backendURL}/shoutout/${uuid}`);
   }
 }


### PR DESCRIPTION
### Summary <!-- Required -->

As part of the API refactor, introduced a typo for the shoutout DELETE endpoint, which has been changed from `deleteShoutout` to `shoutout/:uuid`.

### Test Plan <!-- Required -->

Manually verified that deleting shoutouts works now.