### PR TITLE
Candidate Decider Concurrency Issue

### DIFF
--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -89,11 +89,12 @@ export const getCandidateDeciderInstance = async (
   return instance;
 };
 
-export const updateCandidateDeciderRating = async (
+export const updateCandidateDeciderRatingAndComment = async (
   user: IdolMember,
   uuid: string,
   id: number,
-  rating: Rating
+  rating: Rating,
+  comment: string
 ): Promise<void> => {
   const instance = await candidateDeciderDao.getInstance(uuid);
   if (!instance) {
@@ -119,40 +120,7 @@ export const updateCandidateDeciderRating = async (
             ratings: [
               ...cd.ratings.filter((rt) => rt.reviewer.email !== user.email),
               { reviewer: user, rating }
-            ]
-          }
-    )
-  };
-  candidateDeciderDao.updateInstance(updatedInstance);
-};
-
-export const updateCandidateDeciderComment = async (
-  user: IdolMember,
-  uuid: string,
-  id: number,
-  comment: string
-): Promise<void> => {
-  const instance = await candidateDeciderDao.getInstance(uuid);
-  if (!instance) {
-    throw new NotFoundError(`Instance with uuid ${uuid} does not exist`);
-  }
-  if (
-    !(
-      (await PermissionsManager.isAdmin(user)) ||
-      instance.authorizedMembers.includes(user) ||
-      instance.authorizedRoles.includes(user.role)
-    )
-  )
-    throw new PermissionError(
-      `User with email ${user.email} does not have permission to access this Candidate Decider instance`
-    );
-  const updatedInstance: CandidateDeciderInstance = {
-    ...instance,
-    candidates: instance.candidates.map((cd) =>
-      cd.id !== id
-        ? cd
-        : {
-            ...cd,
+            ],
             comments: [
               ...cd.comments.filter((cmt) => cmt.reviewer.email !== user.email),
               { reviewer: user, comment }

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -60,8 +60,7 @@ import {
   createNewCandidateDeciderInstance,
   deleteCandidateDeciderInstance,
   getCandidateDeciderInstance,
-  updateCandidateDeciderRating,
-  updateCandidateDeciderComment,
+  updateCandidateDeciderRatingAndComment,
   updateCandidateDeciderInstance
 } from './API/candidateDeciderAPI';
 import {
@@ -367,13 +366,14 @@ loginCheckedPut('/candidate-decider', async (req, user) => ({
 loginCheckedDelete('/candidate-decider/:uuid', async (req, user) =>
   deleteCandidateDeciderInstance(req.params.uuid, user).then(() => ({}))
 );
-loginCheckedPut('/candidate-decider/:uuid/rating', (req, user) =>
-  updateCandidateDeciderRating(user, req.params.uuid, req.body.id, req.body.rating).then(() => ({}))
-);
-loginCheckedPost('/candidate-decider/:uuid/comment', (req, user) =>
-  updateCandidateDeciderComment(user, req.params.uuid, req.body.id, req.body.comment).then(
-    () => ({})
-  )
+loginCheckedPut('/candidate-decider/:uuid', (req, user) =>
+  updateCandidateDeciderRatingAndComment(
+    user,
+    req.params.uuid,
+    req.body.id,
+    req.body.rating,
+    req.body.comment
+  ).then(() => ({}))
 );
 
 loginCheckedPost('/sendMail', async (req, user) => ({

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -366,10 +366,10 @@ loginCheckedPut('/candidate-decider', async (req, user) => ({
 loginCheckedDelete('/candidate-decider/:uuid', async (req, user) =>
   deleteCandidateDeciderInstance(req.params.uuid, user).then(() => ({}))
 );
-loginCheckedPut('/candidate-decider/:uuid', (req, user) =>
+loginCheckedPut('/candidate-decider/rating-and-comment', (req, user) =>
   updateCandidateDeciderRatingAndComment(
     user,
-    req.params.uuid,
+    req.body.uuid,
     req.body.id,
     req.body.rating,
     req.body.comment

--- a/frontend/src/API/CandidateDeciderAPI.ts
+++ b/frontend/src/API/CandidateDeciderAPI.ts
@@ -35,6 +35,6 @@ export default class CandidateDeciderAPI {
     rating: number,
     comment: string
   ): Promise<void> {
-    APIWrapper.put(`${backendURL}/candidate-decider/${uuid}`, { uuid, id, rating, comment });
+    APIWrapper.put(`${backendURL}/candidate-decider/rating-and-comment`, { uuid, id, rating, comment });
   }
 }

--- a/frontend/src/API/CandidateDeciderAPI.ts
+++ b/frontend/src/API/CandidateDeciderAPI.ts
@@ -29,11 +29,12 @@ export default class CandidateDeciderAPI {
     APIWrapper.delete(`${backendURL}/candidate-decider/${uuid}`);
   }
 
-  static async updateRating(uuid: string, id: number, rating: number): Promise<void> {
-    APIWrapper.put(`${backendURL}/candidate-decider/${uuid}/rating`, { uuid, id, rating });
-  }
-
-  static async updateComment(uuid: string, id: number, comment: string): Promise<void> {
-    APIWrapper.post(`${backendURL}/candidate-decider/${uuid}/comment`, { uuid, id, comment });
+  static async updateRatingAndComment(
+    uuid: string,
+    id: number,
+    rating: number,
+    comment: string
+  ): Promise<void> {
+    APIWrapper.put(`${backendURL}/candidate-decider/${uuid}`, { uuid, id, rating, comment });
   }
 }

--- a/frontend/src/API/CandidateDeciderAPI.ts
+++ b/frontend/src/API/CandidateDeciderAPI.ts
@@ -35,6 +35,11 @@ export default class CandidateDeciderAPI {
     rating: number,
     comment: string
   ): Promise<void> {
-    APIWrapper.put(`${backendURL}/candidate-decider/rating-and-comment`, { uuid, id, rating, comment });
+    APIWrapper.put(`${backendURL}/candidate-decider/rating-and-comment`, {
+      uuid,
+      id,
+      rating,
+      comment
+    });
   }
 }

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -57,8 +57,8 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
     setCurrentCandidate((prev) => prev - 1);
   };
 
-  const handleRatingChange = (id: number, rating: Rating) => {
-    CandidateDeciderAPI.updateRating(instance.uuid, id, rating);
+  const handleRatingAndCommentChange = (id: number, rating: Rating, comment: string) => {
+    CandidateDeciderAPI.updateRatingAndComment(instance.uuid, id, rating, comment);
     if (userInfo) {
       setInstance((instance) => ({
         ...instance,
@@ -74,23 +74,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
                         ? { rating, reviewer: userInfo }
                         : currRating
                     )
-                  : [...candidate.ratings, { rating, reviewer: userInfo }]
-              }
-            : candidate
-        )
-      }));
-    }
-  };
-
-  const handleCommentChange = (id: number, comment: string) => {
-    CandidateDeciderAPI.updateComment(instance.uuid, id, comment);
-    if (userInfo) {
-      setInstance((instance) => ({
-        ...instance,
-        candidates: instance.candidates.map((candidate) =>
-          candidate.id === id
-            ? {
-                ...candidate,
+                  : [...candidate.ratings, { rating, reviewer: userInfo }],
                 comments: candidate.comments.find(
                   (currComment) => currComment.reviewer.email === userInfo.email
                 )
@@ -146,8 +130,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
             className="ui blue button"
             disabled={currentComment === getComment() && currentRating === getRating()}
             onClick={() => {
-              handleRatingChange(currentCandidate, currentRating);
-              handleCommentChange(currentCandidate, currentComment);
+              handleRatingAndCommentChange(currentCandidate, currentRating, currentComment);
             }}
           >
             Save


### PR DESCRIPTION
Fixes a concurrency issue found on candidate decider caused by two separate endpoints, update comment and update rating, which depending on the order in which they complete in, will overwrite each other. Because we now save comment and rating at the same time, this causes a race condition, so we should combine them as one `/rating-and-comment` endpoint.

