### PR TITLE
Use Transactions for Candidate Decider Rating and Comment Updates

### DIFF
--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -110,23 +110,6 @@ export const updateCandidateDeciderRatingAndComment = async (
     throw new PermissionError(
       `User with email ${user.email} does not have permission to access this Candidate Decider instance`
     );
-  const updatedInstance: CandidateDeciderInstance = {
-    ...instance,
-    candidates: instance.candidates.map((cd) =>
-      cd.id !== id
-        ? cd
-        : {
-            ...cd,
-            ratings: [
-              ...cd.ratings.filter((rt) => rt.reviewer.email !== user.email),
-              { reviewer: user, rating }
-            ],
-            comments: [
-              ...cd.comments.filter((cmt) => cmt.reviewer.email !== user.email),
-              { reviewer: user, comment }
-            ]
-          }
-    )
-  };
-  candidateDeciderDao.updateInstance(updatedInstance);
+
+  await candidateDeciderDao.updateInstanceWithTransaction(instance, user, id, rating, comment);
 };

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -129,9 +129,9 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           <Button
             className="ui blue button"
             disabled={currentComment === getComment() && currentRating === getRating()}
-            onClick={() =>
-              handleRatingAndCommentChange(currentCandidate, currentRating, currentComment)
-            }
+            onClick={() => {
+              handleRatingAndCommentChange(currentCandidate, currentRating, currentComment);
+            }}
           >
             Save
           </Button>

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -129,9 +129,9 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           <Button
             className="ui blue button"
             disabled={currentComment === getComment() && currentRating === getRating()}
-            onClick={() => {
-              handleRatingAndCommentChange(currentCandidate, currentRating, currentComment);
-            }}
+            onClick={() =>
+              handleRatingAndCommentChange(currentCandidate, currentRating, currentComment)
+            }
           >
             Save
           </Button>


### PR DESCRIPTION
This is a band-aid fix that will hopefully eliminate concurrency issues between users using the candidate decider at the same time, AND from requests from a single user that happen near-simultaneously. 

It uses firestore transactions in order keep the read/write operations atomic so that only they only happen one at a time, instead of in parallel.