### PR TITLE
Only Load From Firestore Once for User's Rating and Comments

### DIFF
--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -41,7 +41,11 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
 
   useEffect(() => {
     // Only set the currentRating and currentComment once when the instance first loads in
-    if (instance.candidates[currentCandidate] && currentRating === undefined && currentComment === undefined) {
+    if (
+      instance.candidates[currentCandidate] &&
+      currentRating === undefined &&
+      currentComment === undefined
+    ) {
       setCurrentRating(getRating(currentCandidate));
       setCurrentComment(getComment(currentCandidate));
     }
@@ -56,7 +60,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
       setCurrentComment(getComment(nextCandidate));
       return nextCandidate;
     });
-    
   };
 
   const previous = () => {
@@ -140,9 +143,16 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           </Button.Group>
           <Button
             className="ui blue button"
-            disabled={currentComment === getComment(currentCandidate) && currentRating === getRating(currentCandidate)}
+            disabled={
+              currentComment === getComment(currentCandidate) &&
+              currentRating === getRating(currentCandidate)
+            }
             onClick={() => {
-              handleRatingAndCommentChange(currentCandidate, currentRating ?? 0, currentComment ?? '');
+              handleRatingAndCommentChange(
+                currentCandidate,
+                currentRating ?? 0,
+                currentComment ?? ''
+              );
             }}
           >
             Save

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -38,6 +38,8 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
 
   const [currentRating, setCurrentRating] = useState<Rating>();
   const [currentComment, setCurrentComment] = useState<string>();
+  const [defaultCurrentRating, setDefaultCurrentRating] = useState<Rating>();
+  const [defaultCurrentComment, setDefaultCurrentComment] = useState<string>();
 
   useEffect(() => {
     // Only set the currentRating and currentComment once when the instance first loads in
@@ -46,8 +48,13 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
       currentRating === undefined &&
       currentComment === undefined
     ) {
-      setCurrentRating(getRating(currentCandidate));
-      setCurrentComment(getComment(currentCandidate));
+      const rating = getRating(currentCandidate);
+      const comment = getComment(currentCandidate);
+
+      setCurrentRating(rating);
+      setCurrentComment(comment);
+      setDefaultCurrentRating(rating);
+      setDefaultCurrentComment(comment);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentCandidate, instance.candidates]);
@@ -56,8 +63,13 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
     if (currentCandidate === instance.candidates.length - 1) return;
     setCurrentCandidate((prev) => {
       const nextCandidate = prev + 1;
-      setCurrentRating(getRating(nextCandidate));
-      setCurrentComment(getComment(nextCandidate));
+      const rating = getRating(nextCandidate);
+      const comment = getComment(nextCandidate);
+
+      setCurrentRating(rating);
+      setCurrentComment(comment);
+      setDefaultCurrentRating(rating);
+      setDefaultCurrentComment(comment);
       return nextCandidate;
     });
   };
@@ -66,8 +78,13 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
     if (currentCandidate === 0) return;
     setCurrentCandidate((prev) => {
       const prevCandidate = prev - 1;
-      setCurrentRating(getRating(prevCandidate));
-      setCurrentComment(getComment(prevCandidate));
+      const rating = getRating(prevCandidate);
+      const comment = getComment(prevCandidate);
+
+      setCurrentRating(rating);
+      setCurrentComment(comment);
+      setDefaultCurrentRating(rating);
+      setDefaultCurrentComment(comment);
       return prevCandidate;
     });
   };
@@ -75,6 +92,8 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const handleRatingAndCommentChange = (id: number, rating: Rating, comment: string) => {
     CandidateDeciderAPI.updateRatingAndComment(instance.uuid, id, rating, comment);
     if (userInfo) {
+      setDefaultCurrentRating(rating);
+      setDefaultCurrentComment(comment);
       setInstance((instance) => ({
         ...instance,
         candidates: instance.candidates.map((candidate) =>
@@ -144,8 +163,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           <Button
             className="ui blue button"
             disabled={
-              currentComment === getComment(currentCandidate) &&
-              currentRating === getRating(currentCandidate)
+              currentComment === defaultCurrentComment && currentRating === defaultCurrentRating
             }
             onClick={() => {
               handleRatingAndCommentChange(

--- a/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
@@ -6,9 +6,9 @@ type Props = {
   headers: string[];
   responses: string[];
   currentRating: Rating;
-  setCurrentRating: Dispatch<SetStateAction<Rating>>;
+  setCurrentRating: Dispatch<SetStateAction<Rating | undefined>>;
   currentComment: string;
-  setCurrentComment: Dispatch<SetStateAction<string>>;
+  setCurrentComment: Dispatch<SetStateAction<string | undefined>>;
 };
 
 const ratings = [
@@ -57,7 +57,7 @@ const ResponsesPanel: React.FC<Props> = ({
 
 type CommentEditorProps = {
   currentComment: string;
-  setCurrentComment: Dispatch<SetStateAction<string>>;
+  setCurrentComment: Dispatch<SetStateAction<string | undefined>>;
 };
 
 const CommentEditor: React.FC<CommentEditorProps> = ({ currentComment, setCurrentComment }) => (


### PR DESCRIPTION
Previously, we would update the rating and comment UI elements each time we pulled (using the Firestore listener) a new change from the candidate decider. This caused the UI to appear buggy because the comments and rating would get overridden due to the delayed update in the frontend state.

Make the comment/rating UI elements only get populated once from the DB's data. Since we are already maintaining comments and ratings in the frontend state in real-time, we won't need to pull after the initial ratings/comments are loaded in.