### PR TITLE
Add export to CSV Button for Candidate Decider Admin View

### DIFF
--- a/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
+++ b/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
@@ -4,6 +4,8 @@ import ALL_ROLES from 'common-types/constants';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import { MemberSearch, RoleSearch } from '../Common/Search/Search';
 import styles from './CandidateDeciderEditModal.module.css';
+import { Emitters } from '../../utils';
+import { ExportToCsv, Options } from 'export-to-csv';
 
 const allNonleadRoles: { role: Role }[] = ALL_ROLES.filter((role) => role !== 'lead').map(
   (role) => ({ role })
@@ -50,6 +52,44 @@ const CandidateDeciderEditModal: React.FC<Props> = ({ uuid, setInstances }) => {
       );
       setIsOpen(false);
     }
+  };
+
+  const handleExportToCsv = () => {
+    if (instance === undefined || instance.candidates.length <= 0) {
+      Emitters.generalError.emit({
+        headerMsg: 'Failed to export Candidate Decider Instance to CSV',
+        contentMsg: 'Please make sure there is at least 1 candidate.'
+      });
+      return;
+    }
+    const getHeaderIndex = (_header: string) =>
+    instance.headers.findIndex((header, i) => header === _header);
+    const netIDIndex = getHeaderIndex('NetID');
+    const lastNameIndex = getHeaderIndex('Last Name');
+    const firstNameIndex = getHeaderIndex('First Name');
+
+    const csvData = instance.candidates.map((candidate) => ({
+        name: `${candidate.responses[firstNameIndex]} ${candidate.responses[lastNameIndex]}`,
+        netid: candidate.responses[netIDIndex],
+        comments: candidate.comments.reduce((acc, comment) =>  comment.comment === "" ? "" : `${acc}${comment.reviewer.firstName} ${comment.reviewer.lastName}: ${comment.comment} `, ""),
+        ratings: candidate.ratings.reduce((acc, rating) =>  rating.rating === 0 ? "" : `${acc}${rating.reviewer.firstName} ${rating.reviewer.lastName}: ${rating.rating} `, ""),
+    }));
+
+    const options: Options = {
+      filename: `${instance.name}_Ratings`,
+      fieldSeparator: ',',
+      quoteStrings: '"',
+      decimalSeparator: '.',
+      showLabels: true,
+      showTitle: true,
+      title: `${instance.name} Ratings`,
+      useTextFile: false,
+      useBom: true,
+      useKeysAsHeaders: true
+    };
+
+    const csvExporter = new ExportToCsv(options);
+    csvExporter.generateCsv(csvData);
   };
 
   return (
@@ -126,6 +166,7 @@ const CandidateDeciderEditModal: React.FC<Props> = ({ uuid, setInstances }) => {
       </Modal.Content>
 
       <Modal.Actions>
+        <Button onClick={handleExportToCsv}>Export to CSV</Button>
         <Button negative onClick={() => setIsOpen(false)}>
           Cancel
         </Button>

--- a/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
+++ b/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
@@ -63,16 +63,28 @@ const CandidateDeciderEditModal: React.FC<Props> = ({ uuid, setInstances }) => {
       return;
     }
     const getHeaderIndex = (_header: string) =>
-    instance.headers.findIndex((header, i) => header === _header);
+      instance.headers.findIndex((header, i) => header === _header);
     const netIDIndex = getHeaderIndex('NetID');
     const lastNameIndex = getHeaderIndex('Last Name');
     const firstNameIndex = getHeaderIndex('First Name');
 
     const csvData = instance.candidates.map((candidate) => ({
-        name: `${candidate.responses[firstNameIndex]} ${candidate.responses[lastNameIndex]}`,
-        netid: candidate.responses[netIDIndex],
-        comments: candidate.comments.reduce((acc, comment) =>  comment.comment === "" ? "" : `${acc}${comment.reviewer.firstName} ${comment.reviewer.lastName}: ${comment.comment} `, ""),
-        ratings: candidate.ratings.reduce((acc, rating) =>  rating.rating === 0 ? "" : `${acc}${rating.reviewer.firstName} ${rating.reviewer.lastName}: ${rating.rating} `, ""),
+      name: `${candidate.responses[firstNameIndex]} ${candidate.responses[lastNameIndex]}`,
+      netid: candidate.responses[netIDIndex],
+      comments: candidate.comments.reduce(
+        (acc, comment) =>
+          comment.comment === ''
+            ? ''
+            : `${acc}${comment.reviewer.firstName} ${comment.reviewer.lastName}: ${comment.comment} `,
+        ''
+      ),
+      ratings: candidate.ratings.reduce(
+        (acc, rating) =>
+          rating.rating === 0
+            ? ''
+            : `${acc}${rating.reviewer.firstName} ${rating.reviewer.lastName}: ${rating.rating} `,
+        ''
+      )
     }));
 
     const options: Options = {

--- a/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
+++ b/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Modal, Button, Card, Header, Form, Message } from 'semantic-ui-react';
 import ALL_ROLES from 'common-types/constants';
+import { ExportToCsv, Options } from 'export-to-csv';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import { MemberSearch, RoleSearch } from '../Common/Search/Search';
 import styles from './CandidateDeciderEditModal.module.css';
 import { Emitters } from '../../utils';
-import { ExportToCsv, Options } from 'export-to-csv';
 
 const allNonleadRoles: { role: Role }[] = ALL_ROLES.filter((role) => role !== 'lead').map(
   (role) => ({ role })
@@ -75,14 +75,14 @@ const CandidateDeciderEditModal: React.FC<Props> = ({ uuid, setInstances }) => {
         (acc, comment) =>
           comment.comment === ''
             ? ''
-            : `${acc}${comment.reviewer.firstName} ${comment.reviewer.lastName}: ${comment.comment} `,
+            : `${acc}${comment.reviewer.firstName} ${comment.reviewer.lastName}: ${comment.comment}\n`,
         ''
       ),
       ratings: candidate.ratings.reduce(
         (acc, rating) =>
           rating.rating === 0
             ? ''
-            : `${acc}${rating.reviewer.firstName} ${rating.reviewer.lastName}: ${rating.rating} `,
+            : `${acc}${rating.reviewer.firstName} ${rating.reviewer.lastName}: ${rating.rating}\n`,
         ''
       )
     }));


### PR DESCRIPTION
### Summary <!-- Required -->

To make the candidate decider results easier to view and export, add an "Export to CSV" button for candidate decider's admin view.

### Test Plan <!-- Required -->
Click "Edit" on the candidate decider instance on the admin view, then there will be an "Export to CSV" button.

<img width="669" alt="Screenshot 2023-10-01 at 3 40 47 AM" src="https://github.com/cornell-dti/idol/assets/59291082/19038de6-7c36-4cff-9877-cfc5fe52a63c">


<img width="925" alt="Screenshot 2023-10-01 at 3 29 35 AM" src="https://github.com/cornell-dti/idol/assets/59291082/e6c76944-7f85-44cb-9279-d36d92d701e4">
