### PR TITLE
Fix CSV Ratings to be Strings Instead of Numerical Value

### DIFF
--- a/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
+++ b/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
@@ -6,6 +6,7 @@ import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import { MemberSearch, RoleSearch } from '../Common/Search/Search';
 import styles from './CandidateDeciderEditModal.module.css';
 import { Emitters } from '../../utils';
+import { ratingToString } from '../Candidate-Decider/ratings-utils';
 
 const allNonleadRoles: { role: Role }[] = ALL_ROLES.filter((role) => role !== 'lead').map(
   (role) => ({ role })
@@ -82,7 +83,9 @@ const CandidateDeciderEditModal: React.FC<Props> = ({ uuid, setInstances }) => {
         (acc, rating) =>
           rating.rating === 0
             ? ''
-            : `${acc}${rating.reviewer.firstName} ${rating.reviewer.lastName}: ${rating.rating}\n`,
+            : `${acc}${rating.reviewer.firstName} ${rating.reviewer.lastName}: ${ratingToString(
+                rating.rating
+              )}\n`,
         ''
       )
     }));


### PR DESCRIPTION
In the CSV, switch out the numbers for the ratings to be strings instead.

Before:
<img width="669" alt="Screenshot 2023-10-01 at 3 40 47 AM" src="https://github.com/cornell-dti/idol/assets/59291082/cfff98c1-6d50-47bf-93ec-735930f7d05d">


After:
<img width="669" alt="Screenshot 2023-10-01 at 3 50 03 AM" src="https://github.com/cornell-dti/idol/assets/59291082/dd96c1cd-7d39-4096-a3c7-bddf929e63fd">
