### PR TITLE
Allow admin to edit dev portfolios

### DIFF
--- a/backend/src/API/devPortfolioAPI.ts
+++ b/backend/src/API/devPortfolioAPI.ts
@@ -9,6 +9,11 @@ const zonedTime = (timestamp: number, ianatz = 'America/New_York') =>
 
 export const devPortfolioDao = new DevPortfolioDao();
 
+/**
+ * Gets all Dev Portfolios
+ * @param user - The user that is requesting to get all portfolios
+ * @returns - All Dev Portfolios (if the user is a lead or admin)
+ */
 export const getAllDevPortfolios = async (user: IdolMember): Promise<DevPortfolio[]> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
   if (!isLeadOrAdmin)
@@ -18,17 +23,36 @@ export const getAllDevPortfolios = async (user: IdolMember): Promise<DevPortfoli
   return devPortfolioDao.getAllInstances();
 };
 
+/**
+ * Gets all Dev Portfolios without the submissions field
+ */
 export const getAllDevPortfolioInfo = async (): Promise<DevPortfolioInfo[]> =>
   devPortfolioDao.getAllDevPortfolioInfo();
 
+/**
+ * Gets a specific dev portfolio without submissions
+ * @param uuid - DB uuid of the portfolio we want to get information from
+ */
 export const getDevPortfolioInfo = async (uuid: string): Promise<DevPortfolioInfo> =>
   devPortfolioDao.getDevPortfolioInfo(uuid);
 
+/**
+ * Gets a specific member's Dev Portfolio by checking if the member id of a submission
+ * is the user's email
+ * @param uuid - DB uuid of DevPortfolio
+ * @param user - the member we are getting a portfolio from
+ */
 export const getUsersDevPortfolioSubmissions = async (
   uuid: string,
   user: IdolMember
 ): Promise<DevPortfolioSubmission[]> => devPortfolioDao.getUsersDevPortfolioSubmissions(uuid, user);
 
+/**
+ * Gets a specific Dev Portfolio
+ * @param user - The user that is requesting to get all portfolios
+ * @param uuid - DB uuid of DevPortfolio
+ * @returns - The specific Dev Portfolio (if the user is a lead or admin)
+ */
 export const getDevPortfolio = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
   if (!isLeadOrAdmin)
@@ -40,6 +64,12 @@ export const getDevPortfolio = async (uuid: string, user: IdolMember): Promise<D
   return devPortfolio;
 };
 
+/**
+ * Creates a new Dev Portfolio
+ * @param instance - The new Dev Portfolio instance
+ * @param user - The user that is requesting to create a dev portfolio
+ * @returns - The new Dev Portfolio (if successfully created)
+ */
 export const createNewDevPortfolio = async (
   instance: DevPortfolio,
   user: IdolMember
@@ -76,6 +106,30 @@ export const createNewDevPortfolio = async (
   return devPortfolioDao.createNewInstance(modifiedInstance);
 };
 
+/**
+ * Updates a Dev Portfolio
+ * @param devPortfolio - The modified Dev Portfolio instance
+ * @param user - The user that is requesting to modify a dev portfolio
+ * @returns - The updated Dev Portfolio (if successfully modified)
+ */
+export const updateDevPortfolio = async (
+  devPortfolio: DevPortfolio,
+  user: IdolMember
+): Promise<DevPortfolioInfo> => {
+  if (!PermissionsManager.canEditDevPortfolio(user)) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to update dev portfolios`
+    );
+  }
+  const updatedDevPortfolio = await devPortfolioDao.updateInstance(devPortfolio);
+  return updatedDevPortfolio;
+};
+
+/**
+ * Deletes new Dev Portfolio (if the user has permission)
+ * @param uuid - DB uuid of DevPortfolio
+ * @param user - The user that is requesting to delete a dev portfolio
+ */
 export const deleteDevPortfolio = async (uuid: string, user: IdolMember): Promise<void> => {
   const canDeleteDevPortfolio = await PermissionsManager.isLeadOrAdmin(user);
   if (!canDeleteDevPortfolio) {
@@ -86,6 +140,12 @@ export const deleteDevPortfolio = async (uuid: string, user: IdolMember): Promis
   await devPortfolioDao.deleteInstance(uuid);
 };
 
+/**
+ * Makes a Dev Portfolio submission
+ * @param uuid - DB uuid of DevPortfolio
+ * @param submission - The submission that is being made
+ * @returns - The Dev Portfolio submission (if successfully made)
+ */
 export const makeDevPortfolioSubmission = async (
   uuid: string,
   submission: DevPortfolioSubmission
@@ -111,6 +171,13 @@ export const makeDevPortfolioSubmission = async (
   });
 };
 
+/**
+ * Updates Dev Portfolio submissions
+ * @param uuid - DB uuid of DevPortfolio
+ * @param updatedSubmissions - The updated Dev Portfolio submissions
+ * @param user - The user that is requesting to modify submissions
+ * @returns - The updated Dev Portfolio (if the submissions are successfully modified)
+ */
 export const updateSubmissions = async (
   uuid: string,
   updatedSubmissions: DevPortfolioSubmission[],
@@ -137,6 +204,12 @@ export const updateSubmissions = async (
   return updatedDP;
 };
 
+/**
+ * Regrades Dev Portfolio submissions
+ * @param uuid - DB uuid of DevPortfolio
+ * @param user - The user that is requesting to regrade submissions
+ * @returns - The updated Dev Portfolio (if the submissions are successfully regraded)
+ */
 export const regradeSubmissions = async (uuid: string, user: IdolMember): Promise<DevPortfolio> => {
   const canRequestRegrade = await PermissionsManager.isLeadOrAdmin(user);
   if (!canRequestRegrade)

--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -5,9 +5,16 @@ import PermissionsManager from '../utils/permissionsManager';
 
 const teamEventAttendanceDao = new TeamEventAttendanceDao();
 
+/**
+ * Gets all team events and their attendees and requests.
+ * @param user - the user submitting the request
+ * @throws PermissionError if the user does not have permissions to get all team events
+ * @returns a list of the current team events
+ */
 export const getAllTeamEvents = async (user: IdolMember): Promise<TeamEvent[]> => {
   const canEditTeamEvents = await PermissionsManager.canEditTeamEvent(user);
-  if (!canEditTeamEvents) throw new PermissionError('does not have permissions');
+  if (!canEditTeamEvents)
+    throw new PermissionError(`User with email ${user.email} cannot get all team events`);
   const teamEvents = await TeamEventsDao.getAllTeamEvents();
   return Promise.all(
     teamEvents.map(async (event) => ({
@@ -22,25 +29,44 @@ export const getAllTeamEvents = async (user: IdolMember): Promise<TeamEvent[]> =
   );
 };
 
+/**
+ * Gets all team events and their relevant information.
+ * @returns a list of the current team events
+ */
 export const getAllTeamEventInfo = async (): Promise<TeamEventInfo[]> =>
   TeamEventsDao.getAllTeamEventInfo();
 
+/**
+ * Creates a team event from a TeamEventInfo object which contains the name,
+ * date, credits, hours, and whether it is a community event or not.
+ * @param teamEventInfo - the information about the team event
+ * @param user - the user creating the team event
+ * @throws PermissionError if the user does not have permissions to create team events
+ * @returns the created team event
+ */
 export const createTeamEvent = async (
   teamEventInfo: TeamEventInfo,
   user: IdolMember
 ): Promise<TeamEventInfo> => {
   const canCreateTeamEvent = await PermissionsManager.canEditTeamEvent(user);
   if (!canCreateTeamEvent)
-    throw new PermissionError('does not have permissions to create team event');
+    throw new PermissionError(`User with email ${user.email} cannot create team events`);
   await TeamEventsDao.createTeamEvent(teamEventInfo);
   return teamEventInfo;
 };
 
+/**
+ * Deletes a team event and all of its attendees and requests.
+ * @param uuid - the uuid of the team event to delete
+ * @param user - the user deleting the team event
+ * @throws PermissionError if the user does not have permissions to delete team events
+ * @returns the deleted team event
+ */
 export const deleteTeamEvent = async (uuid: string, user: IdolMember): Promise<void> => {
   if (!PermissionsManager.canEditTeamEvent(user)) {
-    throw new PermissionError("You don't have permission to delete a team event!");
+    throw new PermissionError(`User with email ${user.email} cannot delete team events`);
   }
-  const teamEvent = await TeamEventsDao.getTeamEvent(uuid); // TODO: need to make a dao method for getting full team event
+  const teamEvent = await TeamEventsDao.getTeamEvent(uuid);
   if (!teamEvent) return;
 
   const allAttendances = await teamEventAttendanceDao.getTeamEventAttendanceByEventId(uuid);
@@ -53,6 +79,13 @@ export const deleteTeamEvent = async (uuid: string, user: IdolMember): Promise<v
   await TeamEventsDao.deleteTeamEvent(teamEvent);
 };
 
+/**
+ * Updates a team event using a TeamEventInfo object.
+ * @param teamEventInfo - the information about the team event
+ * @param user - the user updating the team event
+ * @throws PermissionError if the user does not have permissions to update team events
+ * @returns the updated team event
+ */
 export const updateTeamEvent = async (
   teamEventInfo: TeamEventInfo,
   user: IdolMember
@@ -66,6 +99,14 @@ export const updateTeamEvent = async (
   return updatedTeamEvent;
 };
 
+/**
+ * Submits a team event attendance request for a user given a TeamEventAttendance
+ * object.
+ * @param request - the TeamEventAttendance object
+ * @param user - the user submitting the request
+ * @throws PermissionError if the user's email does not match the member's email in the request
+ * @returns the created team event attendance
+ */
 export const requestTeamEventCredit = async (
   request: TeamEventAttendance,
   user: IdolMember
@@ -82,6 +123,14 @@ export const requestTeamEventCredit = async (
   return teamEventAttendance;
 };
 
+/**
+ * Gets a team event's informaiton, along with its pending and accepted requests
+ * given its uuid.
+ * @param uuid - the uuid of the team event
+ * @param user - the user submitting the request
+ * @throws PermissionError if the user does not have permissions to get full team events
+ * @returns the team event
+ */
 export const getTeamEvent = async (uuid: string, user: IdolMember): Promise<TeamEvent> => {
   const canEditTeamEvents = await PermissionsManager.canEditTeamEvent(user);
   if (!canEditTeamEvents)
@@ -101,6 +150,11 @@ export const getTeamEvent = async (uuid: string, user: IdolMember): Promise<Team
   };
 };
 
+/**
+ * Deletes all team events and their attendees and requests.
+ * @param user - the user submitting the request
+ * @throws PermissionError if the user does not have permissions to delete all team events
+ */
 export const clearAllTeamEvents = async (user: IdolMember): Promise<void> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
   if (!isLeadOrAdmin)
@@ -111,10 +165,22 @@ export const clearAllTeamEvents = async (user: IdolMember): Promise<void> => {
   await TeamEventsDao.deleteAllTeamEvents();
 };
 
+/**
+ * Gets all the team event attendance requests for a user.
+ * @param user - the user submitting the request
+ * @returns the team event attendance requests submitted by the user
+ */
 export const getTeamEventAttendanceByUser = async (
   user: IdolMember
 ): Promise<TeamEventAttendance[]> => teamEventAttendanceDao.getTeamEventAttendanceByUser(user);
 
+/**
+ * Updates a team event attendance request given a TeamEventAttendance object.
+ * @param teamEventAttendance - the TeamEventAttendance object
+ * @param user - the user submitting the request
+ * @throws PermissionError if the user does not have permissions to update team events attendance
+ * @returns the updated team event attendance
+ */
 export const updateTeamEventAttendance = async (
   teamEventAttendance: TeamEventAttendance,
   user: IdolMember
@@ -129,6 +195,13 @@ export const updateTeamEventAttendance = async (
   return teamEventAttendance;
 };
 
+/**
+ * Deletes a team event attendance request given its uuid.
+ * @param uuid - the uuid of the team event attendance to delete
+ * @param user - the user deleting the team event attendance
+ * @throws PermissionError if the user does not have permissions to delete team events attendance
+ * @returns the deleted team event attendance
+ */
 export const deleteTeamEventAttendance = async (uuid: string, user: IdolMember): Promise<void> => {
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
   const attendance = await teamEventAttendanceDao.getTeamEventAttendance(uuid);

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -70,6 +70,7 @@ import {
 import {
   getAllDevPortfolios,
   createNewDevPortfolio,
+  updateDevPortfolio,
   deleteDevPortfolio,
   makeDevPortfolioSubmission,
   getDevPortfolio,
@@ -395,6 +396,9 @@ loginCheckedGet('/dev-portfolio/:uuid/submission', async (req, user) => ({
 }));
 loginCheckedPost('/dev-portfolio', async (req, user) => ({
   portfolio: await createNewDevPortfolio(req.body, user)
+}));
+loginCheckedPut('/dev-portfolio', async (req, user) => ({
+  portfolio: await updateDevPortfolio(req.body, user)
 }));
 loginCheckedDelete('/dev-portfolio/:uuid', async (req, user) =>
   deleteDevPortfolio(req.params.uuid, user).then(() => ({}))

--- a/backend/src/utils/firebase-utils.ts
+++ b/backend/src/utils/firebase-utils.ts
@@ -1,7 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+/**
+ * Takes service account credentials and populates the private_key_id and private_key fields with data from the .env.
+ * @param serviceAccount - Service Account object containing non-sensitive Firebase credentials.
+ * @param isProd - Whether or not we should use the Firebase prod credentials. If False, the development DB credentials are used.
+ * @returns - Credentials object with private key and private key id.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-export const configureAccount = (sa: any, isProd: boolean) => {
-  const configAcc = sa;
+export const configureAccount = (serviceAccount: any, isProd: boolean) => {
+  const configAcc = serviceAccount;
   let parsedPK;
   try {
     parsedPK = isProd
@@ -17,11 +24,17 @@ export const configureAccount = (sa: any, isProd: boolean) => {
   return configAcc;
 };
 
+/**
+ * Deletes an entire collection by deleting the documents in batches of batchSize.
+ * @param db - The database in which the collection will be deleted.
+ * @param collectionPath - Path associated with the collection to be deleted.
+ * @param batchSize - Whether or not we should use the Firebase prod credentials. If False, the development DB credentials are used.
+ */
 export async function deleteCollection(
   db: FirebaseFirestore.Firestore,
   collectionPath: string,
   batchSize: number
-) {
+): Promise<void> {
   const collectionRef = db.collection(collectionPath);
   const query = collectionRef.orderBy('__name__').limit(batchSize);
 
@@ -30,11 +43,17 @@ export async function deleteCollection(
   });
 }
 
+/**
+ * Recursive function that deletes all documents in the db that match query.
+ * @param db - The database in which the documents will be deleted.
+ * @param query - Query describing the documents that will be deleted.
+ * @param resolve - The callback function called upon deleting all documents that match the query.
+ */
 export async function deleteQueryBatch(
   db: FirebaseFirestore.Firestore,
   query: FirebaseFirestore.Query,
-  resolve
-) {
+  resolve: () => void
+): Promise<void> {
   const snapshot = await query.get();
 
   const batchSize = snapshot.size;

--- a/backend/src/utils/permissionsManager.ts
+++ b/backend/src/utils/permissionsManager.ts
@@ -33,6 +33,10 @@ export default class PermissionsManager {
     return this.isLeadOrAdmin(mem);
   }
 
+  static async canEditDevPortfolio(mem: IdolMember): Promise<boolean> {
+    return this.isLeadOrAdmin(mem);
+  }
+
   public static async isAdmin(mem: IdolMember): Promise<boolean> {
     const member = (await adminCollection.doc(mem.email).get()).data();
     return mem.role === 'lead' || member !== undefined;

--- a/backend/tests/DevPortfolioAPI.test.ts
+++ b/backend/tests/DevPortfolioAPI.test.ts
@@ -46,7 +46,7 @@ describe('User is not lead or admin', () => {
     );
   });
 
-  test('deleteDevPortfolio shoudl throw permission error', async () => {
+  test('deleteDevPortfolio should throw permission error', async () => {
     await expect(deleteDevPortfolio('fake-uuid', user)).rejects.toThrow(
       new PermissionError(
         `User with email: ${user.email} does not have permission to delete dev portfolio!`

--- a/frontend/src/API/DevPortfolioAPI.ts
+++ b/frontend/src/API/DevPortfolioAPI.ts
@@ -23,7 +23,9 @@ export default class DevPortfolioAPI {
   }
 
   public static updateDevPortfolio(devPortfolio: DevPortfolio): Promise<DevPortfolio> {
-    return APIWrapper.put(`${backendURL}/dev-portfolio`, devPortfolio).then((res) => res.data.portfolio);
+    return APIWrapper.put(`${backendURL}/dev-portfolio`, devPortfolio).then(
+      (res) => res.data.portfolio
+    );
   }
 
   public static async makeDevPortfolioSubmission(

--- a/frontend/src/API/DevPortfolioAPI.ts
+++ b/frontend/src/API/DevPortfolioAPI.ts
@@ -22,6 +22,10 @@ export default class DevPortfolioAPI {
     );
   }
 
+  public static updateDevPortfolio(devPortfolio: DevPortfolio): Promise<DevPortfolio> {
+    return APIWrapper.put(`${backendURL}/dev-portfolio`, devPortfolio).then((res) => res.data.portfolio);
+  }
+
   public static async makeDevPortfolioSubmission(
     uuid: string,
     submission: DevPortfolioSubmission

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.module.css
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.module.css
@@ -19,3 +19,8 @@
   display: flex;
   flex-direction: column;
 }
+
+.buttonsWrapper {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
@@ -30,9 +30,9 @@ const AdminDevPortfolio: React.FC = () => {
   };
 
   useEffect(() => {
-    Emitters.devPortfolioUpdated.subscribe(() => fullReset());
+    Emitters.devPortfolioUpdated.subscribe(fullReset);
     return () => {
-      Emitters.devPortfolioUpdated.unsubscribe(() => fullReset());
+      Emitters.devPortfolioUpdated.unsubscribe(fullReset);
     };
   });
 

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
@@ -1,25 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import {
-  Container,
-  Loader,
-  Form,
-  Button,
-  Header,
-  Label,
-  Divider,
-  Message,
-  Card
-} from 'semantic-ui-react';
-import DatePicker from 'react-datepicker';
+import { Container, Loader, Divider, Card } from 'semantic-ui-react';
 import 'react-datepicker/dist/react-datepicker.css';
 import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
 import styles from './AdminDevPortfolio.module.css';
 import DevPortfolioDeleteModal from '../../Modals/DevPortfolioDeleteModal';
-
-const isSameDay = (d1: Date, d2: Date) =>
-  d1.getFullYear() === d2.getFullYear() &&
-  d1.getMonth() === d2.getMonth() &&
-  d1.getDate() === d2.getDate();
+import AdminDevPortfolioForm from './AdminDevPortfolioForm';
+import EditDevPortfolio from './EditDevPortfolio';
+import { Emitters } from '../../../utils';
 
 const AdminDevPortfolio: React.FC = () => {
   const [devPortfolios, setDevPortfolios] = useState<DevPortfolio[]>([]);
@@ -61,7 +48,8 @@ const AdminDevPortfolio: React.FC = () => {
   return (
     <Container className={styles.container}>
       <Container>
-        <AdminDevPortfolioForm setDevPortfolios={setDevPortfolios} />
+        <h1>Create a Dev Portfolio</h1>
+        <AdminDevPortfolioForm setDevPortfolios={setDevPortfolios} formType="create" />
       </Container>
       <Divider />
       <DevPortfolioDashboard
@@ -100,11 +88,17 @@ export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
             <Card key={portfolio.uuid}>
               <Card.Content>
                 {isAdminView ? (
-                  <DevPortfolioDeleteModal
-                    uuid={portfolio.uuid}
-                    name={portfolio.name}
-                    setDevPortfolios={setDevPortfolios}
-                  />
+                  <>
+                    <EditDevPortfolio
+                      devPortfolio={portfolio}
+                      setDevPortfolios={setDevPortfolios}
+                    />
+                    <DevPortfolioDeleteModal
+                      uuid={portfolio.uuid}
+                      name={portfolio.name}
+                      setDevPortfolios={setDevPortfolios}
+                    />
+                  </>
                 ) : (
                   <></>
                 )}
@@ -143,96 +137,5 @@ export const DevPortfolioDashboard: React.FC<DevPortfolioDashboardProps> = ({
     )}
   </Container>
 );
-
-type AdminDevPortfolioFormProps = {
-  readonly setDevPortfolios: React.Dispatch<React.SetStateAction<DevPortfolio[]>>;
-};
-
-const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({ setDevPortfolios }) => {
-  const [name, setName] = useState<string>('');
-  const [nameError, setNameError] = useState<boolean>(false);
-  const [dateError, setDateError] = useState<boolean>(false);
-  const [dateErrorMsg, setDateErrorMsg] = useState<string>('');
-  const [deadline, setDeadline] = useState<Date>(new Date());
-  const [earliestDate, setEarliestDate] = useState<Date>(new Date());
-  const [lateDeadline, setLateDeadline] = useState<Date | null>(null);
-  const [success, setSuccess] = useState<boolean>(false);
-
-  const handleSubmit = () => {
-    if (name === '') {
-      setNameError(true);
-      return;
-    }
-    setNameError(false);
-    if (deadline < earliestDate) {
-      setDateError(true);
-      setDateErrorMsg('Deadline must be after earliest possible date.');
-      return;
-    }
-    if (deadline < new Date() && !isSameDay(deadline, new Date())) {
-      setDateError(true);
-      setDateErrorMsg('Deadline cannot be before today.');
-      return;
-    }
-    if (lateDeadline && deadline > lateDeadline && !isSameDay(deadline, lateDeadline)) {
-      setDateError(true);
-      setDateErrorMsg('Late deadline cannot be before the regular deadline');
-      return;
-    }
-    setNameError(false);
-    setDateErrorMsg('');
-    const portfolio = {
-      name,
-      deadline: deadline.getTime(),
-      earliestValidDate: earliestDate.getTime(),
-      lateDeadline: lateDeadline ? lateDeadline.getTime() : null,
-      submissions: [],
-      uuid: ''
-    };
-    DevPortfolioAPI.createDevPortfolio(portfolio).then((portfolio) => {
-      setDevPortfolios((portfolios) => [...portfolios, portfolio]);
-      setSuccess(true);
-    });
-  };
-
-  return (
-    <Form success={success}>
-      <Header as="h3">Name</Header>
-      <Form.Input error={nameError} value={name} onChange={(e) => setName(e.target.value)} />
-      <Header as="h3">Earliest Date</Header>
-      <DatePicker
-        selected={earliestDate}
-        dateFormat="MMMM do yyyy"
-        onChange={(date: Date) => setEarliestDate(date)}
-      />
-      <Header as="h3">Deadline</Header>
-      <DatePicker
-        selected={deadline}
-        dateFormat="MMMM do yyyy"
-        onChange={(date: Date) => setDeadline(date)}
-      />
-      <Header as="h3">Late Deadline (optional)</Header>
-      <DatePicker
-        selected={lateDeadline}
-        dateFormat="MMMM do yyyy"
-        onChange={(date: Date) => setLateDeadline(date)}
-      />
-      {dateError ? (
-        <Label
-          pointing
-        >{`The dates for the deadline and earliest date are invalid: ${dateErrorMsg}`}</Label>
-      ) : undefined}
-      <Divider />
-      <Button id={styles.submitButton} onClick={() => handleSubmit()}>
-        Create Assignment
-      </Button>
-      <Message
-        success
-        header="Dev Portfolio Created"
-        content={`${name} was successfully created and will be due on ${deadline.toDateString()}`}
-      />
-    </Form>
-  );
-};
 
 export default AdminDevPortfolio;

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolio.tsx
@@ -37,6 +37,27 @@ const AdminDevPortfolio: React.FC = () => {
     getAllDevPortfolios();
   }, []);
 
+  const fullReset = () => {
+    setIsLoading(true);
+    setDevPortfolios([]);
+  };
+
+  useEffect(() => {
+    Emitters.devPortfolioUpdated.subscribe(() => fullReset());
+    return () => {
+      Emitters.devPortfolioUpdated.unsubscribe(() => fullReset());
+    };
+  });
+
+  useEffect(() => {
+    if (isLoading) {
+      DevPortfolioAPI.getAllDevPortfolios().then((devPortfolios) => {
+        setDevPortfolios(devPortfolios);
+        setIsLoading(false);
+      });
+    }
+  }, [isLoading]);
+
   return (
     <Container className={styles.container}>
       <Container>

--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolioForm.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolioForm.tsx
@@ -1,0 +1,160 @@
+import DatePicker from 'react-datepicker';
+import React, { useState } from 'react';
+import { Form, Header, Label, Divider, Message } from 'semantic-ui-react';
+import 'react-datepicker/dist/react-datepicker.css';
+import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
+import styles from './AdminDevPortfolio.module.css';
+
+const isSameDay = (d1: Date, d2: Date) =>
+  d1.getFullYear() === d2.getFullYear() &&
+  d1.getMonth() === d2.getMonth() &&
+  d1.getDate() === d2.getDate();
+
+type AdminDevPortfolioFormProps = {
+  formType: 'create' | 'edit';
+  readonly setDevPortfolios: React.Dispatch<React.SetStateAction<DevPortfolio[]>>;
+  devPortfolio?: DevPortfolio;
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>;
+  editDevPortfolio?: (portfolio: DevPortfolio) => void;
+};
+
+const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({
+  setDevPortfolios,
+  formType,
+  setOpen,
+  editDevPortfolio,
+  devPortfolio
+}) => {
+  const [name, setName] = useState(devPortfolio?.name || '');
+  const [nameError, setNameError] = useState<boolean>(false);
+  const [dateError, setDateError] = useState<boolean>(false);
+  const [dateErrorMsg, setDateErrorMsg] = useState<string>('');
+  const [success, setSuccess] = useState<boolean>(false);
+  let deadlineDate = new Date();
+  let earliestValidDate = new Date();
+  let lateDeadlineDate = null;
+  if (devPortfolio) {
+    deadlineDate = new Date(devPortfolio.deadline as number);
+    earliestValidDate = new Date(devPortfolio.earliestValidDate as number);
+    if (devPortfolio.lateDeadline) {
+      lateDeadlineDate = new Date(devPortfolio.lateDeadline as number);
+    }
+  }
+  const [deadline, setDeadline] = useState<Date>(deadlineDate);
+  const [earliestDate, setEarliestDate] = useState<Date>(earliestValidDate);
+  const [lateDeadline, setLateDeadline] = useState(lateDeadlineDate);
+
+  const handleSubmit = () => {
+    if (name === '') {
+      setNameError(true);
+      return;
+    }
+    setNameError(false);
+    if (deadline < earliestDate) {
+      setDateError(true);
+      setDateErrorMsg('Deadline must be after earliest possible date.');
+      return;
+    }
+    if (deadline < new Date() && !isSameDay(deadline, new Date())) {
+      setDateError(true);
+      setDateErrorMsg('Deadline cannot be before today.');
+      return;
+    }
+    if (lateDeadline && deadline > lateDeadline && !isSameDay(deadline, lateDeadline)) {
+      setDateError(true);
+      setDateErrorMsg('Late deadline cannot be before the regular deadline');
+      return;
+    }
+
+    if (formType === 'edit' && devPortfolio && editDevPortfolio && setOpen) {
+      const editedDevPortfolio: DevPortfolio = {
+        ...devPortfolio,
+        // eslint-disable-next-line object-shorthand
+        name: name,
+        deadline: deadline.getTime(),
+        earliestValidDate: earliestDate.getTime(),
+        lateDeadline: lateDeadline ? lateDeadline.getTime() : null,
+        submissions: devPortfolio.submissions
+      };
+      editDevPortfolio(editedDevPortfolio);
+      setSuccess(true);
+      setOpen(false);
+    } else {
+      const newPortfolio = {
+        name,
+        deadline: deadline.getTime(),
+        earliestValidDate: earliestDate.getTime(),
+        lateDeadline: lateDeadline ? lateDeadline.getTime() : null,
+        submissions: [],
+        uuid: ''
+      };
+      DevPortfolioAPI.createDevPortfolio(newPortfolio).then((portfolio) => {
+        setDevPortfolios((portfolios) => [...portfolios, portfolio]);
+        setSuccess(true);
+      });
+    }
+    setNameError(false);
+    setDateErrorMsg('');
+  };
+
+  return (
+    <Form success={success}>
+      <Header as="h3">Name</Header>
+      <Form.Input error={nameError} value={name} onChange={(e) => setName(e.target.value)} />
+      <Header as="h3">Earliest Date</Header>
+      <DatePicker
+        selected={earliestDate}
+        dateFormat="MMMM do yyyy"
+        onChange={(date: Date) => setEarliestDate(date)}
+      />
+      <Header as="h3">Deadline</Header>
+      <DatePicker
+        selected={deadline}
+        dateFormat="MMMM do yyyy"
+        onChange={(date: Date) => setDeadline(date)}
+      />
+      <Header as="h3">Late Deadline (optional)</Header>
+      <DatePicker
+        selected={lateDeadline}
+        dateFormat="MMMM do yyyy"
+        onChange={(date: Date) => setLateDeadline(date)}
+      />
+      {dateError ? (
+        <Label pointing>
+          {`The dates for the deadline and earliest date are invalid: ${dateErrorMsg}`}
+        </Label>
+      ) : undefined}
+      <Divider />
+
+      {formType === 'create' && (
+        <>
+          <Form.Button id={styles.submitButton} onClick={() => handleSubmit()}>
+            Create Assignment
+          </Form.Button>
+          <Message
+            success
+            header="Dev Portfolio Created"
+            content={`${name} was successfully created and will be due on ${deadline.toDateString()}`}
+          />
+        </>
+      )}
+
+      {formType === 'edit' && setOpen && (
+        <div className={styles.buttonsWrapper}>
+          <Form.Button onClick={() => setOpen(false)}>Cancel</Form.Button>
+          <Form.Button
+            content="Save"
+            labelPosition="right"
+            icon="checkmark"
+            onClick={() => {
+              handleSubmit();
+            }}
+            positive
+          />
+        </div>
+      )}
+    </Form>
+  );
+};
+
+export default AdminDevPortfolioForm;

--- a/frontend/src/components/Admin/DevPortfolio/EditDevPortfolio.module.css
+++ b/frontend/src/components/Admin/DevPortfolio/EditDevPortfolio.module.css
@@ -1,0 +1,4 @@
+.MdOutlineModeEditOutline {
+  position: absolute;
+  right: 8%;
+}

--- a/frontend/src/components/Admin/DevPortfolio/EditDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/EditDevPortfolio.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Modal, Icon } from 'semantic-ui-react';
+import AdminDevPortfolioForm from './AdminDevPortfolioForm';
+import styles from './EditDevPortfolio.module.css';
+import DevPortfolioAPI from '../../../API/DevPortfolioAPI';
+import { Emitters } from '../../../utils';
+
+const EditDevPortfolio = (props: {
+  devPortfolio: DevPortfolio;
+  setDevPortfolios: React.Dispatch<React.SetStateAction<DevPortfolio[]>>;
+}): JSX.Element => {
+  const { devPortfolio, setDevPortfolios } = props;
+  const [open, setOpen] = useState(false);
+
+  const editDevPortfolio = (portfolio: DevPortfolio) => {
+    DevPortfolioAPI.updateDevPortfolio(portfolio).then((val) => {
+        Emitters.generalSuccess.emit({
+          headerMsg: 'Dev Portfolio Edited!',
+          contentMsg: 'The dev portfolio was successfully edited!'
+        });
+        Emitters.devPortfolioUpdated.emit();
+    });
+  };
+
+  return (
+    <Modal
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
+      open={open}
+      trigger={<Icon className={styles.MdOutlineModeEditOutline} name="edit" color="grey" />}
+    >
+      <Modal.Header>Edit Dev Portfolio</Modal.Header>
+      <Modal.Content>
+        <AdminDevPortfolioForm
+          formType={'edit'}
+          devPortfolio={devPortfolio}
+          editDevPortfolio={editDevPortfolio}
+          setOpen={setOpen}
+          setDevPortfolios={setDevPortfolios}
+        />
+      </Modal.Content>
+    </Modal>
+  );
+};
+export default EditDevPortfolio;

--- a/frontend/src/components/Admin/DevPortfolio/EditDevPortfolio.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/EditDevPortfolio.tsx
@@ -14,11 +14,11 @@ const EditDevPortfolio = (props: {
 
   const editDevPortfolio = (portfolio: DevPortfolio) => {
     DevPortfolioAPI.updateDevPortfolio(portfolio).then((val) => {
-        Emitters.generalSuccess.emit({
-          headerMsg: 'Dev Portfolio Edited!',
-          contentMsg: 'The dev portfolio was successfully edited!'
-        });
-        Emitters.devPortfolioUpdated.emit();
+      Emitters.generalSuccess.emit({
+        headerMsg: 'Dev Portfolio Edited!',
+        contentMsg: 'The dev portfolio was successfully edited!'
+      });
+      Emitters.devPortfolioUpdated.emit();
     });
   };
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -80,4 +80,7 @@ export class Emitters {
 
   // Team Events
   static teamEventsUpdated: EventEmitter<void> = new EventEmitter();
+
+  // Dev Portfolio
+  static devPortfolioUpdated: EventEmitter<void> = new EventEmitter();
 }


### PR DESCRIPTION
### Summary

Notion ticket: https://www.notion.so/DP-Allow-Admins-to-Edit-Assignments-2307db13393c4f358e377e75f8bd6fea?pvs=4

Admins can now edit a dev portfolio without having to delete and replace an assignment with a new version (which was not feasible once submissions have been made). 

Frontend changes include adding an edit button for each portfolio that opens an edit modal, a success message if an edit is made, and error messages if conditions are violated. 

Backend changes include adding a new update endpoint, and documenting the Dev Portfolio API.

### Test Plan

I tested if a dev portfolio is successfully edited by looking at the firebase database, and checking that it updated correctly.

Each portfolio card now has an edit button, which opens a form to edit the portfolio.
![Screen Shot 2023-10-21 at 4 24 22 PM](https://github.com/cornell-dti/idol/assets/125151386/58de69d8-98a1-432d-b9c4-8d6c8b2713e7)

The form has pre-populated values depending on the original portfolio.
![Screen Shot 2023-10-21 at 4 24 49 PM](https://github.com/cornell-dti/idol/assets/125151386/99737e03-2a5b-46d2-a075-c5254954daa3)

If a portfolio is successfully edited, a success message will appear and the original page will automatically rerender in the background to show the updated portfolio.
![Screen Shot 2023-10-21 at 4 27 14 PM](https://github.com/cornell-dti/idol/assets/125151386/9a4f10cc-757f-445e-95d0-0ad37a06c088)

An error message will appear if certain conditions are violated.
![Screen Shot 2023-10-21 at 4 28 33 PM](https://github.com/cornell-dti/idol/assets/125151386/68db1fb0-bfc2-4637-9bc4-197fb2c42958)
