### PR TITLE
Configure Backup DB

### DIFF
--- a/.github/workflows/backup-prod-db.yml
+++ b/.github/workflows/backup-prod-db.yml
@@ -1,0 +1,32 @@
+name: Back Up Prod Database
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs script at 1AM UTC (8PM or 9PM ET) everyday.
+    - cron: '0 1 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: .node-version
+      - name: Use Yarn Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+          restore-keys: yarn-
+      - name: Install
+        run: yarn
+      - name: Back Up Prod Database
+        env:
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          FIREBASE_BACKUP_PRIVATE_KEY: ${{ secrets.FIREBASE_BACKUP_PRIVATE_KEY }}
+          FIREBASE_PRIVATE_KEY_ID: ${{ secrets.FIREBASE_PRIVATE_KEY_ID }}
+          FIREBASE_BACKUP_PRIVATE_KEY_ID: ${{ secrets.FIREBASE_BACKUP_PRIVATE_KEY_ID }}
+        run: yarn workspace backend backup-prod-db

--- a/backend/resources/cornelldti-idol-backup-9d909d7b0efc.json
+++ b/backend/resources/cornelldti-idol-backup-9d909d7b0efc.json
@@ -1,0 +1,13 @@
+{
+  "type": "service_account",
+  "project_id": "cornelldti-idol-backup",
+  "private_key_id": "",
+  "private_key": "",
+  "client_email": "firebase-adminsdk-ctm2t@cornelldti-idol-backup.iam.gserviceaccount.com",
+  "client_id": "114853423399255274659",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-ctm2t%40cornelldti-idol-backup.iam.gserviceaccount.com",
+  "universe_domain": "googleapis.com"
+}

--- a/backend/scripts/backup-prod-db.ts
+++ b/backend/scripts/backup-prod-db.ts
@@ -4,7 +4,7 @@ import { configureAccount, readDbData, rewriteDbData } from '../src/utils/fireba
 require('dotenv').config();
 
 const prodServiceAccount = require('../resources/idol-b6c68-firebase-adminsdk-h4e6t-40e4bd5536.json');
-const devServiceAccount = require('../resources/cornelldti-idol-firebase-adminsdk-ifi28-9aaca97159.json');
+const backupServiceAccount = require('../resources/cornelldti-idol-backup-9d909d7b0efc.json');
 
 const main = async () => {
   const prodApp = admin.initializeApp(
@@ -15,19 +15,19 @@ const main = async () => {
     },
     'prod'
   );
-  const devApp = admin.initializeApp(
+  const backupApp = admin.initializeApp(
     {
-      credential: admin.credential.cert(configureAccount(devServiceAccount, 'dev')),
+      credential: admin.credential.cert(configureAccount(backupServiceAccount, 'backup')),
       databaseURL: 'https://idol-b6c68.firebaseio.com',
       storageBucket: 'gs://cornelldti-idol.appspot.com'
     },
-    'dev'
+    'backup'
   );
-  const devDb = devApp.firestore();
+  const backupDb = backupApp.firestore();
   const prodDb = admin.firestore(prodApp);
 
   const prodData = await readDbData(prodDb);
-  return rewriteDbData(devDb, prodData);
+  return rewriteDbData(backupDb, prodData);
 };
 
 main();

--- a/backend/scripts/send-idol-notifications.ts
+++ b/backend/scripts/send-idol-notifications.ts
@@ -12,7 +12,7 @@ import { configureAccount } from '../src/utils/firebase-utils';
 const serviceAcc = require('../resources/idol-b6c68-firebase-adminsdk-h4e6t-40e4bd5536.json');
 
 admin.initializeApp({
-  credential: admin.credential.cert(configureAccount(serviceAcc, true)),
+  credential: admin.credential.cert(configureAccount(serviceAcc, 'prod')),
   databaseURL: 'https://idol-b6c68.firebaseio.com',
   storageBucket: 'gs://cornelldti-idol.appspot.com'
 });

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -25,7 +25,9 @@ const devServiceAccount = require('../resources/cornelldti-idol-firebase-adminsd
 const serviceAccount = useProdFirebaseConfig ? prodServiceAccount : devServiceAccount;
 
 export const app = admin.initializeApp({
-  credential: admin.credential.cert(configureAccount(serviceAccount, useProdFirebaseConfig)),
+  credential: admin.credential.cert(
+    configureAccount(serviceAccount, useProdFirebaseConfig ? 'prod' : 'dev')
+  ),
   databaseURL: 'https://idol-b6c68.firebaseio.com',
   storageBucket: useProdFirebaseConfig
     ? 'gs://idol-b6c68.appspot.com'

--- a/backend/src/utils/firebase-utils.ts
+++ b/backend/src/utils/firebase-utils.ts
@@ -136,6 +136,8 @@ export const rewriteDbData = async (
 
   await Promise.all(allCollections.map((collection) => deleteCollection(db, collection, 10)));
   return data.map((collection) =>
-    collection.docs.forEach((doc) => db.doc(`${collection.id}/${doc.id}`).set(doc.data))
+    collection.docs.forEach((doc) =>
+      db.doc(`${collection.id}/${doc.id}`).set(doc.data as FirebaseFirestore.DocumentData)
+    )
   );
 };

--- a/backend/src/utils/firebase-utils.ts
+++ b/backend/src/utils/firebase-utils.ts
@@ -1,5 +1,15 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
+type DbType = 'prod' | 'dev' | 'backup';
+
+type DbData = {
+  id: string;
+  docs: {
+    id: string;
+    data: unknown;
+  }[];
+}[];
+
 /**
  * Takes service account credentials and populates the private_key_id and private_key fields with data from the .env.
  * @param serviceAccount - Service Account object containing non-sensitive Firebase credentials.
@@ -7,20 +17,34 @@
  * @returns - Credentials object with private key and private key id.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-export const configureAccount = (serviceAccount: any, isProd: boolean) => {
+export const configureAccount = (serviceAccount: any, dbType: DbType) => {
   const configAcc = serviceAccount;
   let parsedPK;
   try {
-    parsedPK = isProd
-      ? JSON.parse(process.env.FIREBASE_PRIVATE_KEY as string)
-      : JSON.parse(process.env.FIREBASE_DEV_PRIVATE_KEY as string);
+    if (dbType === 'prod') {
+      parsedPK = JSON.parse(process.env.FIREBASE_PRIVATE_KEY as string);
+    } else if (dbType === 'dev') {
+      parsedPK = JSON.parse(process.env.FIREBASE_DEV_PRIVATE_KEY as string);
+    } else if (dbType === 'backup') {
+      parsedPK = JSON.parse(process.env.FIREBASE_BACKUP_PRIVATE_KEY as string);
+    }
   } catch (err) {
-    parsedPK = isProd ? process.env.FIREBASE_PRIVATE_KEY : process.env.FIREBASE_DEV_PRIVATE_KEY;
+    if (dbType === 'prod') {
+      parsedPK = process.env.FIREBASE_PRIVATE_KEY;
+    } else if (dbType === 'dev') {
+      parsedPK = process.env.FIREBASE_DEV_PRIVATE_KEY;
+    } else if (dbType === 'backup') {
+      parsedPK = process.env.FIREBASE_BACKUP_PRIVATE_KEY;
+    }
   }
   configAcc.private_key = parsedPK;
-  configAcc.private_key_id = isProd
-    ? process.env.FIREBASE_PRIVATE_KEY_ID
-    : process.env.FIREBASE_DEV_PRIVATE_KEY_ID;
+  if (dbType === 'prod') {
+    configAcc.private_key_id = process.env.FIREBASE_PRIVATE_KEY_ID;
+  } else if (dbType === 'dev') {
+    configAcc.private_key_id = process.env.FIREBASE_DEV_PRIVATE_KEY_ID;
+  } else if (dbType === 'backup') {
+    configAcc.private_key_id = process.env.FIREBASE_BACKUP_PRIVATE_KEY_ID;
+  }
   return configAcc;
 };
 
@@ -76,3 +100,42 @@ export async function deleteQueryBatch(
     deleteQueryBatch(db, query, resolve);
   });
 }
+
+/**
+ * Reads all data in the collections from the DB and returns it.
+ * @param db - The database in which the collections will be read from.
+ * @returns The data from the DB as a DbData object.
+ */
+export const readDbData = async (db: FirebaseFirestore.Firestore): Promise<DbData> => {
+  const allCollections = await db.listCollections();
+  return Promise.all(
+    allCollections.map(async (collection) => {
+      const docRefs = (await collection.get()).docs;
+      const docs = docRefs.map((docRef) => ({ id: docRef.id, data: docRef.data() }));
+      return {
+        id: collection.id,
+        docs
+      };
+    })
+  );
+};
+
+/**
+ * Writes all data in the collections from the DB and returns it as DbData object.
+ * @param db - The database in which the data will be written to.
+ * @param data - The data to be written to db.
+ * @returns - A promise that is resolved once all the data is written to the DB.
+ */
+export const rewriteDbData = async (
+  db: FirebaseFirestore.Firestore,
+  data: DbData
+): Promise<void[]> => {
+  const allCollections = await db
+    .listCollections()
+    .then((collections) => collections.map((collection) => collection.id));
+
+  await Promise.all(allCollections.map((collection) => deleteCollection(db, collection, 10)));
+  return data.map((collection) =>
+    collection.docs.forEach((doc) => db.doc(`${collection.id}/${doc.id}`).set(doc.data))
+  );
+};


### PR DESCRIPTION
### Summary <!-- Required -->
Add script and corresponding and GitHub Actions cron job for backing up the Dev DB.

I'm deliberately not changing the `.env.example` file, since we should not be working with the backup DB ever, except for backing up the data periodically, which will be done through the job.

Factored these methods to be shared between `update-dev-db` and `backup-prod-db` scripts.

### Notion/Figma Link <!-- Optional -->

https://www.notion.so/Add-Firebase-backup-DB-9962ea595ead417bb40bd53fad94388a?pvs=4

### Test Plan <!-- Required -->

Ran cron job, and the data matches the prod DB.
