### PR TITLE
Add Backup Prod DB Script to Backend Workspace

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "tsc": "tsc",
     "build": "tsc",
     "update-dev-db": "esr scripts/update-dev-db.ts",
+    "backup-prod-db": "esr scripts/backup-prod-db.ts",
     "send-idol-notifications": "esr scripts/send-idol-notifications.ts"
   },
   "license": "AGPL-3.0",


### PR DESCRIPTION
Adds the backup prod db script to the backend workspace `package.json`, so we can run
```
yarn workspace backend backup-prod-db
```
in our GitHub actions cron job to run the script.