### PR TITLE
Fix `sendMail` API endpoint

### DIFF
--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -3,10 +3,20 @@ import { Request } from 'express';
 import getEmailTransporter from '../nodemailer';
 import { isProd } from '../api';
 import AdminsDao from '../dao/AdminsDao';
+import PermissionsManager from '../utils/permissionsManager';
+import { PermissionError } from '../utils/errors';
 
-export const sendMail = async (to: string, subject: string, text: string): Promise<unknown> => {
+export const sendMail = async (
+  to: string,
+  subject: string,
+  text: string,
+  user: IdolMember
+): Promise<unknown> => {
+  if (!(await PermissionsManager.isAdmin(user)))
+    throw new PermissionError('User does not have permission to send automated emails.');
+
   const mailOptions = {
-    from: process.env.EMAIL,
+    from: 'dti.idol.github.bot@gmail.com',
     to,
     subject: `IDOL Notifs: ${subject}`,
     text

--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -5,10 +5,6 @@ import { isProd } from '../api';
 import AdminsDao from '../dao/AdminsDao';
 
 export const sendMail = async (to: string, subject: string, text: string): Promise<unknown> => {
-  // Don't send email notifications locally
-  if (!process.env.isProd) {
-    return {};
-  }
   const mailOptions = {
     from: process.env.EMAIL,
     to,

--- a/backend/src/API/memberAPI.ts
+++ b/backend/src/API/memberAPI.ts
@@ -4,7 +4,6 @@ import PermissionsManager from '../utils/permissionsManager';
 import { BadRequestError, PermissionError } from '../utils/errors';
 import { bucket } from '../firebase';
 import { getNetIDFromEmail, computeMembersDiff } from '../utils/memberUtil';
-import { sendMemberUpdateNotifications } from './mailAPI';
 
 const membersDao = new MembersDao();
 
@@ -55,10 +54,7 @@ export const updateMember = async (
     );
   }
 
-  return membersDao.updateMember(body.email, body).then(async (mem) => {
-    sendMemberUpdateNotifications(req);
-    return mem;
-  });
+  return membersDao.updateMember(body.email, body);
 };
 
 export const deleteMember = async (email: string, user: IdolMember): Promise<void> => {

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -377,7 +377,7 @@ loginCheckedPut('/candidate-decider/rating-and-comment', (req, user) =>
 );
 
 loginCheckedPost('/sendMail', async (req, user) => ({
-  info: await sendMail(req.body.to, req.body.subject, req.body.text)
+  info: await sendMail(req.body.to, req.body.subject, req.body.text, user)
 }));
 
 // Dev Portfolios


### PR DESCRIPTION
### Summary <!-- Required -->

- Add permissions check in `sendMail` API endpoint to restrict to admins only
- Remove extraneous/outdated `isProd` check. The corresponding environment variable is not called `isProd` anymore.
- Remove `sendMemberUpdateNotifications` call for every Member information update. This endpoint was previously "dead code" anyway, and it doesn't make sense to keep (i.e. notify every admin every time someone updates a profile)
-  Replace usage of `EMAIL` env variable. This environment variable is not used in the codebase anymore. We use exclusively "dti.idol.github.bot@gmail.com" in our codebase.

### Test Plan <!-- Required -->
Running this CURL command:
```
curl -X POST "localhost:9000/.netlify/functions/api/sendMail" -d '{"to": "<your email>", "subject": "test", "text": "Test test test"}' -H "auth-token:  <auth-token>" -H 'Content-Type: application/json'
```