### PR TITLE
Send staging emails to stdout

### DIFF
--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -5,6 +5,7 @@ import { isProd } from '../api';
 import AdminsDao from '../dao/AdminsDao';
 import PermissionsManager from '../utils/permissionsManager';
 import { PermissionError } from '../utils/errors';
+import { env } from '../firebase';
 
 export const sendMail = async (
   to: string,
@@ -22,7 +23,8 @@ export const sendMail = async (
     text
   };
 
-  if (!isProd) {
+  // Only sent emails in prod, otherwise, send to stdout.
+  if (env !== 'prod') {
     // eslint-disable-next-line no-console
     console.log(
       `Emails are not sent in non-production envs. Here's what would have been sent:\n`,


### PR DESCRIPTION
Small change: set it so that only "prod" environments will allow for the sending of emails. This will prevent us from accidentally sending out emails in staging and dev environments to lots of members.