### PR TITLE
Improve mailAPI Response Body Data

### DIFF
--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -38,7 +38,7 @@ export const sendMail = async (
   const info = await transporter
     .sendMail(mailOptions)
     .then((info) => info)
-    .catch((error) => ({ error }));
+    .catch((error) => (console.log(error)));
   return info;
 };
 

--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -24,22 +24,23 @@ export const sendMail = async (
     text
   };
 
-  // Only sent emails in prod, otherwise, send to stdout.
-  if (env !== 'prod') {
-    // eslint-disable-next-line no-console
-    console.log(
-      `Emails are not sent in non-production envs. Here's what would have been sent:\n`,
-      mailOptions
-    );
-    return {};
-  }
+  // // Only sent emails in prod, otherwise, send to stdout.
+  // if (env !== 'prod') {
+  //   // eslint-disable-next-line no-console
+  //   console.log(
+  //     `Emails are not sent in non-production envs. Here's what would have been sent:\n`,
+  //     mailOptions
+  //   );
+  //   return {};
+  // }
 
   const transporter = await getEmailTransporter();
+  let transportError;
   const info = await transporter
     .sendMail(mailOptions)
     .then((info) => info)
-    .catch((error) => (console.log(error)));
-  return info;
+    .catch((error) => {transportError = error});
+  return { info, error: transportError ?? "None" };
 };
 
 const getSendMailURL = (req: Request): string => {

--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -35,12 +35,11 @@ export const sendMail = async (
   }
 
   const transporter = await getEmailTransporter();
-  let transportError;
   const info = await transporter
     .sendMail(mailOptions)
     .then((info) => info)
-    .catch((error) => {transportError = error});
-  return { info, error: transportError ?? "None", env };
+    .catch((error) => ({ error }));
+  return { info, env };
 };
 
 const getSendMailURL = (req: Request): string => {

--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -26,12 +26,10 @@ export const sendMail = async (
 
   // Only send emails in prod, otherwise, send to stdout.
   if (env !== 'prod') {
+    const nonProdEnvMessage = `Emails are not sent in non-production env: ${env}.\n`;
     // eslint-disable-next-line no-console
-    console.log(
-      `Emails are not sent in non-production envs. Here's what would have been sent:\n`,
-      mailOptions
-    );
-    return { env };
+    console.log(nonProdEnvMessage, `Here's what would have been sent:\n`, mailOptions);
+    return nonProdEnvMessage;
   }
 
   const transporter = await getEmailTransporter();
@@ -39,7 +37,7 @@ export const sendMail = async (
     .sendMail(mailOptions)
     .then((info) => info)
     .catch((error) => ({ error }));
-  return { info, env };
+  return info;
 };
 
 const getSendMailURL = (req: Request): string => {

--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -24,15 +24,15 @@ export const sendMail = async (
     text
   };
 
-  // // Only sent emails in prod, otherwise, send to stdout.
-  // if (env !== 'prod') {
-  //   // eslint-disable-next-line no-console
-  //   console.log(
-  //     `Emails are not sent in non-production envs. Here's what would have been sent:\n`,
-  //     mailOptions
-  //   );
-  //   return {};
-  // }
+  // Only send emails in prod, otherwise, send to stdout.
+  if (env !== 'prod') {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Emails are not sent in non-production envs. Here's what would have been sent:\n`,
+      mailOptions
+    );
+    return { env };
+  }
 
   const transporter = await getEmailTransporter();
   let transportError;
@@ -40,7 +40,7 @@ export const sendMail = async (
     .sendMail(mailOptions)
     .then((info) => info)
     .catch((error) => {transportError = error});
-  return { info, error: transportError ?? "None" };
+  return { info, error: transportError ?? "None", env };
 };
 
 const getSendMailURL = (req: Request): string => {

--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -230,7 +230,7 @@ export const notifyMember = async (
   if (!member.email || member.email === '') {
     throw new BadRequestError("Couldn't notify member with undefined email!");
   }
-
-  sendTECReminder(req, member);
-  return member;
+  const responseData = (await sendTECReminder(req, member)).data;
+  console.log(responseData);
+  return responseData;
 };

--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -230,7 +230,6 @@ export const notifyMember = async (
   if (!member.email || member.email === '') {
     throw new BadRequestError("Couldn't notify member with undefined email!");
   }
-  const responseData = (await sendTECReminder(req, member)).data;
-  console.log(responseData);
-  return responseData;
+  const responseBody = await sendTECReminder(req, member);
+  return responseBody.data;
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -337,7 +337,7 @@ loginCheckedDelete('/team-event-attendance/:uuid', async (req, user) => {
   return {};
 });
 loginCheckedPost('/team-event-reminder', async (req, user) => ({
-  member: await notifyMember(req, req.body, user)
+  info: await notifyMember(req, req.body, user)
 }));
 
 // Team Events Proof Image


### PR DESCRIPTION
### Summary ###

Before, the `/sendMail` endpoint just returned an IdolMember object for the recipient of the email, which wasn't very useful in figuring out whether or not the mail sent successfully.

I've changed this so that the response body contains the response received from the NodeMailer transporter, or if in non-prod environment, a message (which is also logged) that emails are not sent in non-production environments. 

This should make it easier to debug what's going wrong in prod right now with the mailAPI.


### Testing ###
```
curl -X POST "localhost:9000/.netlify/functions/api/sendMail" -d '{"to": "axc2@cornell.edu", "subject": "test", "text": "Test test test"}' -H "auth-token:  <auth-token>" -H 'Content-Type: application/json'
```

Before (not useful at all):
```
{
    "member": {
        "firstName": "Andrew",
        "graduation": "December 2024",
        "formerSubteams": [],
        "subteams": [
            "idol"
        ],
        "major": "Computer Science",
        "github": "https://github.com/andrew032011",
        "minor": "Business",
        "github ": "https://github.com/andrew032011",
        "website": null,
        "hometown": "Boston, MA",
        "pronouns": "he/him/his",
        "doubleMajor": null,
        "roleDescription": "Technical PM",
        "role": "tpm",
        "about": "Hello! I'm Andrew, a junior studying CS. My interests are mainly in software development and computer science education. I enjoy teaching, speedsolving the Rubik's Cube, and playing percussion. I'm always looking to learn more and take on new challenges.",
        "lastName": "Chen",
        "email": "axc2@cornell.edu",
        "linkedin": "https://www.linkedin.com/in/andrew-chen-210a72146/",
        "netid": "axc2"
    }
}
```

After:

```
{
    "member": {
        "info": {
            "accepted": [
                "axc2@cornell.edu"
            ],
            "rejected": [],
            "envelopeTime": 57,
            "messageTime": 237,
            "messageSize": 723,
            "response": "250 2.0.0 OK  1699904156 i2-20020ac87642000000b004194c21ee85sm2153743qtr.79 - gsmtp",
            "envelope": {
                "from": "dti.idol.github.bot@gmail.com",
                "to": [
                    "axc2@cornell.edu"
                ]
            },
            "messageId": "<9401b739-5b12-d9e5-8be3-c67e7b0c349b@gmail.com>"
        }
    }
}
```