### PR TITLE
Adjust Shoutouts Ending Time to Local Time Zone

### DIFF
--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -58,11 +58,12 @@ const AdminShoutouts: React.FC = () => {
         .filter((shoutout) => {
           const shoutoutDate = new Date(shoutout.timestamp);
           // Set time to be 4:59:59AM UTC/11:59PM EST/12:59AM EDT
-          const lastDateAdjusted = new Date(new Date(lastDate).setUTCHours(4, 59, 59, 59) + 60 * 60 * 24 * 1000);
+          const lastDateAdjusted = new Date(
+            new Date(lastDate).setUTCHours(4, 59, 59, 59) + 60 * 60 * 24 * 1000
+          );
 
           // Set time to be 5AM UTC/12AM EST/1AM EDT
           const earlyDateAdjusted = new Date(new Date(earlyDate).setUTCHours(5, 0, 0, 0));
-          // return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
           return shoutoutDate >= earlyDateAdjusted && shoutoutDate <= lastDateAdjusted;
         })
         .sort((a, b) => a.timestamp - b.timestamp);

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -58,10 +58,11 @@ const AdminShoutouts: React.FC = () => {
         .filter((shoutout) => {
           const shoutoutDate = new Date(shoutout.timestamp);
           // Set time to be 4:59:59AM UTC/11:59PM EST/12:59AM EDT
-          const lastDateAdjusted = new Date(lastDate.setUTCHours(4, 59, 59, 59));
+          const lastDateAdjusted = new Date(new Date(lastDate).setUTCHours(4, 59, 59, 59) + 60 * 60 * 24 * 1000);
 
           // Set time to be 5AM UTC/12AM EST/1AM EDT
-          const earlyDateAdjusted = new Date(earlyDate.setUTCHours(5, 0, 0, 0));
+          const earlyDateAdjusted = new Date(new Date(earlyDate).setUTCHours(5, 0, 0, 0));
+          // return shoutoutDate >= earlyDate && shoutoutDate <= lastDate;
           return shoutoutDate >= earlyDateAdjusted && shoutoutDate <= lastDateAdjusted;
         })
         .sort((a, b) => a.timestamp - b.timestamp);

--- a/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
+++ b/frontend/src/components/Admin/AdminShoutouts/AdminShoutouts.tsx
@@ -59,7 +59,13 @@ const AdminShoutouts: React.FC = () => {
           const shoutoutDate = new Date(shoutout.timestamp);
           // Set time to be 4:59:59AM UTC/11:59PM EST/12:59AM EDT
           const lastDateAdjusted = new Date(
-            new Date(lastDate).setUTCHours(4, 59, 59, 59) + 60 * 60 * 24 * 1000
+            new Date(lastDate.getTime() - lastDate.getTimezoneOffset() * 60 * 1000).setUTCHours(
+              4,
+              59,
+              59,
+              59
+            ) +
+              60 * 60 * 1000 * 24
           );
 
           // Set time to be 5AM UTC/12AM EST/1AM EDT


### PR DESCRIPTION
For the latest shoutout date, adjust the time to be 11:59pm on the same day, now adjusted to the current local time zone.