### PR TITLE
Replace TeamEventsAPI references in MailAPI with Calls to Dao Instead

### DIFF
--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -89,7 +89,9 @@ export const sendMemberUpdateNotifications = async (req: Request): Promise<Promi
 export const sendTECReminder = async (req: Request, member: IdolMember): Promise<AxiosResponse> => {
   const subject = 'TEC Reminder';
   const allEvents = await Promise.all(
-    (await TeamEventsDao.getAllTeamEvents()).map(async (event) => ({
+    (
+      await TeamEventsDao.getAllTeamEvents()
+    ).map(async (event) => ({
       ...event,
       requests: await teamEventAttendanceDao.getTeamEventAttendanceByEventId(event.uuid)
     }))


### PR DESCRIPTION
### Summary <!-- Required -->

Previously, we had TeamEventAPI references in `mailAPI`, which may reduce some code duplication, however, there are some permissions/authorization checks we do at the API level that we don't want to check "twice." 

In this case, using `TeamEventsAPI` introduced a bug that led to us not able to send reminder TEC emails to non-IDOL Admins/non-leads. 

Instead, reference `TeamEventAttendanceDao` and `TeamEventsDao` directly.

![Screenshot 2023-11-14 at 4 12 52 PM](https://github.com/cornell-dti/idol/assets/59291082/3136b1ce-4fb0-423d-8433-f3beff0a269c)


### Test Plan <!-- Required -->

Sent the rest of the emails to all non-admins successfully!

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
