### PR TITLE
Add other category to dev portfolio form

### DIFF
--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -81,8 +81,9 @@ export type DBDevPortfolio = {
 
 export type DBDevPortfolioSubmission = {
   member: firestore.DocumentReference;
-  openedPRs: PullRequestSubmission[];
-  reviewedPRs: PullRequestSubmission[];
+  openedPRs?: PullRequestSubmission[];
+  reviewedPRs?: PullRequestSubmission[];
+  otherPRs?: PullRequestSubmission[];
   isLate?: boolean;
   text?: string;
   documentationText?: string;

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -81,9 +81,9 @@ export type DBDevPortfolio = {
 
 export type DBDevPortfolioSubmission = {
   member: firestore.DocumentReference;
-  openedPRs?: PullRequestSubmission[];
-  reviewedPRs?: PullRequestSubmission[];
-  otherPRs?: PullRequestSubmission[];
+  openedPRs: PullRequestSubmission[];
+  reviewedPRs: PullRequestSubmission[];
+  otherPRs: PullRequestSubmission[];
   isLate?: boolean;
   text?: string;
   documentationText?: string;

--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -283,8 +283,8 @@ export const getSubmissionStatus = (submission: DevPortfolioSubmission): Submiss
 
   // otherwise, valid if at least one valid in each category
   const atLeastOneValid =
-    submission.openedPRs.some((pr) => pr.status === 'valid') &&
-    submission.reviewedPRs.some((pr) => pr.status === 'valid');
+    submission.openedPRs && submission.openedPRs.some((pr) => pr.status === 'valid') &&
+    submission.reviewedPRs && submission.reviewedPRs.some((pr) => pr.status === 'valid');
 
   return atLeastOneValid ? 'valid' : 'invalid';
 };
@@ -294,19 +294,19 @@ export const validateSubmission = async (
   portfolio: DevPortfolio,
   submission: DevPortfolioSubmission
 ): Promise<DevPortfolioSubmission> => {
-  const reviewedResults = await Promise.all(
+  const reviewedResults = submission.reviewedPRs ? await Promise.all(
     submission.reviewedPRs.map(async (pr) => ({
       ...pr,
       ...(await validateReview(portfolio, submission, pr.url))
-    }))
-  );
+      }))
+    ) : [];
 
-  const openedResults = await Promise.all(
+  const openedResults = submission.openedPRs ? await Promise.all(
     submission.openedPRs.map(async (pr) => ({
       ...pr,
       ...(await validateOpen(portfolio, submission, pr.url))
     }))
-  );
+  ) : [];
 
   const updatedSubmission = {
     ...submission,

--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -283,8 +283,10 @@ export const getSubmissionStatus = (submission: DevPortfolioSubmission): Submiss
 
   // otherwise, valid if at least one valid in each category
   const atLeastOneValid =
-    submission.openedPRs && submission.openedPRs.some((pr) => pr.status === 'valid') &&
-    submission.reviewedPRs && submission.reviewedPRs.some((pr) => pr.status === 'valid');
+    submission.openedPRs &&
+    submission.openedPRs.some((pr) => pr.status === 'valid') &&
+    submission.reviewedPRs &&
+    submission.reviewedPRs.some((pr) => pr.status === 'valid');
 
   return atLeastOneValid ? 'valid' : 'invalid';
 };
@@ -294,19 +296,23 @@ export const validateSubmission = async (
   portfolio: DevPortfolio,
   submission: DevPortfolioSubmission
 ): Promise<DevPortfolioSubmission> => {
-  const reviewedResults = submission.reviewedPRs ? await Promise.all(
-    submission.reviewedPRs.map(async (pr) => ({
-      ...pr,
-      ...(await validateReview(portfolio, submission, pr.url))
-      }))
-    ) : [];
+  const reviewedResults = submission.reviewedPRs
+    ? await Promise.all(
+        submission.reviewedPRs.map(async (pr) => ({
+          ...pr,
+          ...(await validateReview(portfolio, submission, pr.url))
+        }))
+      )
+    : [];
 
-  const openedResults = submission.openedPRs ? await Promise.all(
-    submission.openedPRs.map(async (pr) => ({
-      ...pr,
-      ...(await validateOpen(portfolio, submission, pr.url))
-    }))
-  ) : [];
+  const openedResults = submission.openedPRs
+    ? await Promise.all(
+        submission.openedPRs.map(async (pr) => ({
+          ...pr,
+          ...(await validateOpen(portfolio, submission, pr.url))
+        }))
+      )
+    : [];
 
   const updatedSubmission = {
     ...submission,

--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -294,23 +294,19 @@ export const validateSubmission = async (
   portfolio: DevPortfolio,
   submission: DevPortfolioSubmission
 ): Promise<DevPortfolioSubmission> => {
-  const reviewedResults = submission.reviewedPRs
-    ? await Promise.all(
-        submission.reviewedPRs.map(async (pr) => ({
-          ...pr,
-          ...(await validateReview(portfolio, submission, pr.url))
-        }))
-      )
-    : [];
+  const reviewedResults = await Promise.all(
+    submission.reviewedPRs.map(async (pr) => ({
+      ...pr,
+      ...(await validateReview(portfolio, submission, pr.url))
+    }))
+  );
 
-  const openedResults = submission.openedPRs
-    ? await Promise.all(
-        submission.openedPRs.map(async (pr) => ({
-          ...pr,
-          ...(await validateOpen(portfolio, submission, pr.url))
-        }))
-      )
-    : [];
+  const openedResults = await Promise.all(
+    submission.openedPRs.map(async (pr) => ({
+      ...pr,
+      ...(await validateOpen(portfolio, submission, pr.url))
+    }))
+  );
 
   const updatedSubmission = {
     ...submission,

--- a/backend/src/utils/githubUtil.ts
+++ b/backend/src/utils/githubUtil.ts
@@ -283,9 +283,7 @@ export const getSubmissionStatus = (submission: DevPortfolioSubmission): Submiss
 
   // otherwise, valid if at least one valid in each category
   const atLeastOneValid =
-    submission.openedPRs &&
     submission.openedPRs.some((pr) => pr.status === 'valid') &&
-    submission.reviewedPRs &&
     submission.reviewedPRs.some((pr) => pr.status === 'valid');
 
   return atLeastOneValid ? 'valid' : 'invalid';

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -161,8 +161,9 @@ interface PullRequestSubmission {
 
 interface DevPortfolioSubmission {
   member: IdolMember;
-  openedPRs: PullRequestSubmission[];
-  reviewedPRs: PullRequestSubmission[];
+  openedPRs?: PullRequestSubmission[];
+  reviewedPRs?: PullRequestSubmission[];
+  otherPRs?: PullRequestSubmission[];
   isLate?: boolean;
   text?: string;
   documentationText?: string;

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -161,9 +161,9 @@ interface PullRequestSubmission {
 
 interface DevPortfolioSubmission {
   member: IdolMember;
-  openedPRs?: PullRequestSubmission[];
-  reviewedPRs?: PullRequestSubmission[];
-  otherPRs?: PullRequestSubmission[];
+  openedPRs: PullRequestSubmission[];
+  reviewedPRs: PullRequestSubmission[];
+  otherPRs: PullRequestSubmission[];
   isLate?: boolean;
   text?: string;
   documentationText?: string;

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -56,8 +56,12 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
     });
 
     const csvData = uniqueSubmissions.map((submission) => {
-      const open = Number(submission.openedPRs.some((pr) => pr.status === 'valid'));
-      const review = Number(submission.reviewedPRs.some((pr) => pr.status === 'valid'));
+      const open = Number(
+        submission.openedPRs && submission.openedPRs.some((pr) => pr.status === 'valid')
+      );
+      const review = Number(
+        submission.reviewedPRs && submission.reviewedPRs.some((pr) => pr.status === 'valid')
+      );
       return {
         name: `${submission.member.firstName} ${submission.member.lastName}`,
         netid: submission.member.netid,
@@ -221,7 +225,10 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
   updateStatus,
   isAdminView
 }) => {
-  const numRows = Math.max(submission.openedPRs.length, submission.reviewedPRs.length);
+  const numRows = Math.max(
+    submission.openedPRs ? submission.openedPRs.length : 0,
+    submission.reviewedPRs ? submission.reviewedPRs.length : 0
+  );
   const [submissionStatus, setSubmissionStatus] = useState(submission.status);
 
   // in case of regrade, need to reinitialize to correct status
@@ -249,12 +256,20 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
         </Table.Cell>
         <Table.Cell>
           <PullRequestDisplay
-            prSubmission={submission.openedPRs.length > 0 ? submission.openedPRs[0] : undefined}
+            prSubmission={
+              submission.openedPRs && submission.openedPRs.length > 0
+                ? submission.openedPRs[0]
+                : undefined
+            }
           />
         </Table.Cell>
         <Table.Cell>
           <PullRequestDisplay
-            prSubmission={submission.reviewedPRs.length > 0 ? submission.reviewedPRs[0] : undefined}
+            prSubmission={
+              submission.reviewedPRs && submission.reviewedPRs.length > 0
+                ? submission.reviewedPRs[0]
+                : undefined
+            }
           />
         </Table.Cell>
         <Table.Cell>{submission.documentationText}</Table.Cell>
@@ -287,6 +302,8 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
             <DevPortfolioTextModal
               title={`${submission.member.firstName} ${submission.member.lastName}`}
               text={submission.text}
+              member={submission.member}
+              otherPRs={submission.otherPRs}
             ></DevPortfolioTextModal>
           </Table.Cell>
         ) : (
@@ -298,9 +315,12 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
 
   if (numRows <= 1) return <FirstRow />;
 
-  const remainingOpenedPRs = submission.openedPRs.length > 1 ? submission.openedPRs.slice(1) : [];
+  const remainingOpenedPRs =
+    submission.openedPRs && submission.openedPRs.length > 1 ? submission.openedPRs.slice(1) : [];
   const remainingReviewedPRs =
-    submission.reviewedPRs.length > 1 ? submission.reviewedPRs.slice(1) : [];
+    submission.reviewedPRs && submission.reviewedPRs.length > 1
+      ? submission.reviewedPRs.slice(1)
+      : [];
   const remainingRows = (
     remainingOpenedPRs.length > remainingReviewedPRs.length
       ? remainingOpenedPRs

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -56,12 +56,8 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
     });
 
     const csvData = uniqueSubmissions.map((submission) => {
-      const open = Number(
-        submission.openedPRs.some((pr) => pr.status === 'valid')
-      );
-      const review = Number(
-        submission.reviewedPRs.some((pr) => pr.status === 'valid')
-      );
+      const open = Number(submission.openedPRs.some((pr) => pr.status === 'valid'));
+      const review = Number(submission.reviewedPRs.some((pr) => pr.status === 'valid'));
       return {
         name: `${submission.member.firstName} ${submission.member.lastName}`,
         netid: submission.member.netid,
@@ -256,20 +252,12 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
         </Table.Cell>
         <Table.Cell>
           <PullRequestDisplay
-            prSubmission={
-              submission.openedPRs.length > 0
-                ? submission.openedPRs[0]
-                : undefined
-            }
+            prSubmission={submission.openedPRs.length > 0 ? submission.openedPRs[0] : undefined}
           />
         </Table.Cell>
         <Table.Cell>
           <PullRequestDisplay
-            prSubmission={
-              submission.reviewedPRs.length > 0
-                ? submission.reviewedPRs[0]
-                : undefined
-            }
+            prSubmission={submission.reviewedPRs.length > 0 ? submission.reviewedPRs[0] : undefined}
           />
         </Table.Cell>
         <Table.Cell>{submission.documentationText}</Table.Cell>
@@ -315,12 +303,9 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
 
   if (numRows <= 1) return <FirstRow />;
 
-  const remainingOpenedPRs =
-    submission.openedPRs.length > 1 ? submission.openedPRs.slice(1) : [];
+  const remainingOpenedPRs = submission.openedPRs.length > 1 ? submission.openedPRs.slice(1) : [];
   const remainingReviewedPRs =
-    submission.reviewedPRs.length > 1
-      ? submission.reviewedPRs.slice(1)
-      : [];
+    submission.reviewedPRs.length > 1 ? submission.reviewedPRs.slice(1) : [];
   const remainingRows = (
     remainingOpenedPRs.length > remainingReviewedPRs.length
       ? remainingOpenedPRs

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -57,10 +57,10 @@ const DevPortfolioDetails: React.FC<Props> = ({ uuid, isAdminView }) => {
 
     const csvData = uniqueSubmissions.map((submission) => {
       const open = Number(
-        submission.openedPRs && submission.openedPRs.some((pr) => pr.status === 'valid')
+        submission.openedPRs.some((pr) => pr.status === 'valid')
       );
       const review = Number(
-        submission.reviewedPRs && submission.reviewedPRs.some((pr) => pr.status === 'valid')
+        submission.reviewedPRs.some((pr) => pr.status === 'valid')
       );
       return {
         name: `${submission.member.firstName} ${submission.member.lastName}`,
@@ -257,7 +257,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
         <Table.Cell>
           <PullRequestDisplay
             prSubmission={
-              submission.openedPRs && submission.openedPRs.length > 0
+              submission.openedPRs.length > 0
                 ? submission.openedPRs[0]
                 : undefined
             }
@@ -266,7 +266,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
         <Table.Cell>
           <PullRequestDisplay
             prSubmission={
-              submission.reviewedPRs && submission.reviewedPRs.length > 0
+              submission.reviewedPRs.length > 0
                 ? submission.reviewedPRs[0]
                 : undefined
             }
@@ -316,9 +316,9 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
   if (numRows <= 1) return <FirstRow />;
 
   const remainingOpenedPRs =
-    submission.openedPRs && submission.openedPRs.length > 1 ? submission.openedPRs.slice(1) : [];
+    submission.openedPRs.length > 1 ? submission.openedPRs.slice(1) : [];
   const remainingReviewedPRs =
-    submission.reviewedPRs && submission.reviewedPRs.length > 1
+    submission.reviewedPRs.length > 1
       ? submission.reviewedPRs.slice(1)
       : [];
   const remainingRows = (

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -221,10 +221,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
   updateStatus,
   isAdminView
 }) => {
-  const numRows = Math.max(
-    submission.openedPRs ? submission.openedPRs.length : 0,
-    submission.reviewedPRs ? submission.reviewedPRs.length : 0
-  );
+  const numRows = Math.max(submission.openedPRs.length, submission.reviewedPRs.length);
   const [submissionStatus, setSubmissionStatus] = useState(submission.status);
 
   // in case of regrade, need to reinitialize to correct status

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -218,7 +218,6 @@ const DevPortfolioForm: React.FC = () => {
             setPRs={setOpenPRs}
             placeholder="Opened PR"
             label="Opened Pull Request Github Link:"
-            isTpm={isTpm}
             openOther={openOther}
           />
           <PRInputs
@@ -226,7 +225,6 @@ const DevPortfolioForm: React.FC = () => {
             setPRs={setReviewedPRs}
             placeholder="Reviewed PR"
             label="Reviewed Pull Request Github Link:"
-            isTpm={isTpm}
             openOther={openOther}
           />
           <OtherPRInputs
@@ -236,7 +234,6 @@ const DevPortfolioForm: React.FC = () => {
             setOpenOther={setOpenOther}
             explanationText={text}
             setExplanationText={setText}
-            isTpm={isTpm}
           />
           <DocumentationInput
             setDocumentationText={setDocumentationText}
@@ -293,14 +290,12 @@ const PRInputs = ({
   setPRs,
   label,
   placeholder,
-  isTpm,
   openOther
 }: {
   prs: string[];
   setPRs: React.Dispatch<React.SetStateAction<string[]>>;
   label: string;
   placeholder: string;
-  isTpm: boolean;
   openOther: boolean;
 }) => {
   const keyDownHandler = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -311,7 +306,7 @@ const PRInputs = ({
   return (
     <div className={styles.inline}>
       <label className={styles.bold}>
-        {label} {!isTpm && !openOther && <span className={styles.red_color}>*</span>}
+        {label} {!openOther && <span className={styles.red_color}>*</span>}
       </label>
       {prs.map((pr, index) => (
         <div className={styles.prInputContainer} key={index}>
@@ -341,7 +336,7 @@ const PRInputs = ({
                 <Icon name="trash alternate" />
               </Button>
             ) : (
-              ''
+              <></>
             )}
           </div>
         </div>
@@ -361,8 +356,7 @@ const OtherPRInputs = ({
   openOther,
   setOpenOther,
   explanationText,
-  setExplanationText,
-  isTpm
+  setExplanationText
 }: {
   otherPRs: string[];
   setOtherPRs: React.Dispatch<React.SetStateAction<string[]>>;
@@ -370,7 +364,6 @@ const OtherPRInputs = ({
   setOpenOther: React.Dispatch<React.SetStateAction<boolean>>;
   explanationText: string | undefined;
   setExplanationText: React.Dispatch<React.SetStateAction<string | undefined>>;
-  isTpm?: boolean;
 }) => {
   const keyDownHandler = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.code === 'Enter') {
@@ -386,25 +379,18 @@ const OtherPRInputs = ({
       />
       <span className={styles.bold}>Other PRs</span>
       {openOther ? (
-        <div className={styles.center_and_flex}>
-          {' '}
-          This section is only for submitting PR links when you believe you have an exception for
-          one of the above requirements. Please submit the PR links, as well as an explanation for
-          what the links are for and why you have this exception.{' '}
-        </div>
-      ) : (
-        ''
-      )}
-      <br />
-      {openOther ? (
-        <label className={styles.bold}>
-          Other Pull Request Github Link: {!isTpm && <span className={styles.red_color}>*</span>}
-        </label>
-      ) : (
-        ''
-      )}
-      {openOther
-        ? otherPRs.map((pr, index) => (
+        <>
+          <div className={styles.center_and_flex}>
+            {' '}
+            This section is only for submitting PR links when you believe you have an exception for
+            one of the above requirements. Please submit the PR links, as well as an explanation for
+            what the links are for and why you have this exception.{' '}
+          </div>
+          <br />
+          <label className={styles.bold}>
+            Other Pull Request Github Link: {<span className={styles.red_color}>*</span>}
+          </label>
+          {otherPRs.map((pr, index) => (
             <div className={styles.prInputContainer} key={index}>
               <input
                 onKeyDown={keyDownHandler}
@@ -432,31 +418,29 @@ const OtherPRInputs = ({
                     <Icon name="trash alternate" />
                   </Button>
                 ) : (
-                  ''
+                  <></>
                 )}
               </div>
             </div>
-          ))
-        : ''}
-      {openOther ? (
-        <div className="row">
-          <div className="col-sm-12">
-            <button onClick={() => setOtherPRs([...otherPRs, ''])}>Add New</button>
+          ))}
+          <div className="row">
+            <div className="col-sm-12">
+              <button onClick={() => setOtherPRs([...otherPRs, ''])}>Add New</button>
+            </div>
           </div>
-        </div>
+          <div>
+            <br />
+            <label className={styles.bold}>
+              Explanation: {<span className={styles.red_color}>*</span>}
+            </label>
+            <TextArea
+              value={explanationText}
+              onChange={(e) => setExplanationText(e.target.value)}
+            />
+          </div>
+        </>
       ) : (
-        ''
-      )}
-      {openOther ? (
-        <div>
-          <br />
-          <label className={styles.bold}>
-            Explanation: {!isTpm && <span className={styles.red_color}>*</span>}
-          </label>
-          <TextArea value={explanationText} onChange={(e) => setExplanationText(e.target.value)} />
-        </div>
-      ) : (
-        ''
+        <></>
       )}
     </div>
   );

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -219,6 +219,7 @@ const DevPortfolioForm: React.FC = () => {
             placeholder="Opened PR"
             label="Opened Pull Request Github Link:"
             openOther={openOther}
+            isTpm={isTpm}
           />
           <PRInputs
             prs={reviewPRs}
@@ -226,15 +227,20 @@ const DevPortfolioForm: React.FC = () => {
             placeholder="Reviewed PR"
             label="Reviewed Pull Request Github Link:"
             openOther={openOther}
+            isTpm={isTpm}
           />
-          <OtherPRInputs
-            otherPRs={otherPRs}
-            setOtherPRs={setOtherPRs}
-            openOther={openOther}
-            setOpenOther={setOpenOther}
-            explanationText={text}
-            setExplanationText={setText}
-          />
+          {isTpm ? (
+            <></>
+          ) : (
+            <OtherPRInputs
+              otherPRs={otherPRs}
+              setOtherPRs={setOtherPRs}
+              openOther={openOther}
+              setOpenOther={setOpenOther}
+              explanationText={text}
+              setExplanationText={setText}
+            />
+          )}
           <DocumentationInput
             setDocumentationText={setDocumentationText}
             documentationText={documentationText}
@@ -290,13 +296,15 @@ const PRInputs = ({
   setPRs,
   label,
   placeholder,
-  openOther
+  openOther,
+  isTpm
 }: {
   prs: string[];
   setPRs: React.Dispatch<React.SetStateAction<string[]>>;
   label: string;
   placeholder: string;
   openOther: boolean;
+  isTpm: boolean;
 }) => {
   const keyDownHandler = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.code === 'Enter') {
@@ -306,7 +314,7 @@ const PRInputs = ({
   return (
     <div className={styles.inline}>
       <label className={styles.bold}>
-        {label} {!openOther && <span className={styles.red_color}>*</span>}
+        {label} {!isTpm && !openOther && <span className={styles.red_color}>*</span>}
       </label>
       {prs.map((pr, index) => (
         <div className={styles.prInputContainer} key={index}>

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -79,13 +79,11 @@ const DevPortfolioForm: React.FC = () => {
       ? devPortfolio.lateDeadline
       : devPortfolio?.deadline;
 
-    if (!isTpm && otherEmpty) {
-      if (openedEmpty || reviewedEmpty) {
-        Emitters.generalError.emit({
-          headerMsg: 'No opened or reviewed PR url submitted',
-          contentMsg: 'Please paste a link to a opened and reviewed PR!'
-        });
-      }
+    if (!isTpm && otherEmpty && (openedEmpty || reviewedEmpty)) {
+      Emitters.generalError.emit({
+        headerMsg: 'No opened or reviewed PR url submitted',
+        contentMsg: 'Please paste a link to a opened and reviewed PR!'
+      });
     } else if (
       (!openedEmpty && openPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null)) ||
       (!reviewedEmpty && reviewPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null)) ||

--- a/frontend/src/components/Modals/DevPortfolioTextModal.tsx
+++ b/frontend/src/components/Modals/DevPortfolioTextModal.tsx
@@ -8,7 +8,7 @@ type Props = {
   otherPRs: PullRequestSubmission[] | undefined;
 };
 
-type TextProps = {
+type DevPortfolioTextProps = {
   text: string;
   member: IdolMember;
   otherPRs: PullRequestSubmission[] | undefined;
@@ -27,7 +27,7 @@ const DevPortfolioTextModal: React.FC<Props> = ({ title, text, member, otherPRs 
       <Modal.Header>{title}</Modal.Header>
       <Modal.Content image>
         <Modal.Description>
-          <Text text={text} member={member} otherPRs={otherPRs} />
+          <DevPortfolioText text={text} member={member} otherPRs={otherPRs} />
         </Modal.Description>
       </Modal.Content>
       <Modal.Actions>
@@ -39,7 +39,7 @@ const DevPortfolioTextModal: React.FC<Props> = ({ title, text, member, otherPRs 
   );
 };
 
-const Text: React.FC<TextProps> = ({ text, member, otherPRs }) => {
+const DevPortfolioText: React.FC<DevPortfolioTextProps> = ({ text, member, otherPRs }) => {
   if (member.role === 'tpm') {
     return <p>{text}</p>;
   }

--- a/frontend/src/components/Modals/DevPortfolioTextModal.tsx
+++ b/frontend/src/components/Modals/DevPortfolioTextModal.tsx
@@ -53,9 +53,9 @@ const Text: React.FC<TextProps> = ({ text, member, otherPRs }) => {
       <br />
       {otherPRs ? (
         otherPRs.map((pr) => (
-          <div>
+          <a>
             {pr.url} <br />
-          </div>
+          </a>
         ))
       ) : (
         <div>No PRs submitted.</div>

--- a/frontend/src/components/Modals/DevPortfolioTextModal.tsx
+++ b/frontend/src/components/Modals/DevPortfolioTextModal.tsx
@@ -5,13 +5,13 @@ type Props = {
   title: string;
   text: string;
   member: IdolMember;
-  otherPRs: PullRequestSubmission[] | undefined;
+  otherPRs: PullRequestSubmission[];
 };
 
 type DevPortfolioTextProps = {
   text: string;
   member: IdolMember;
-  otherPRs: PullRequestSubmission[] | undefined;
+  otherPRs: PullRequestSubmission[];
 };
 
 const DevPortfolioTextModal: React.FC<Props> = ({ title, text, member, otherPRs }) => {

--- a/frontend/src/components/Modals/DevPortfolioTextModal.tsx
+++ b/frontend/src/components/Modals/DevPortfolioTextModal.tsx
@@ -4,10 +4,19 @@ import { Modal, Button } from 'semantic-ui-react';
 type Props = {
   title: string;
   text: string;
+  member: IdolMember;
+  otherPRs: PullRequestSubmission[] | undefined;
 };
 
-const DevPortfolioTextModal: React.FC<Props> = ({ title, text }) => {
+type TextProps = {
+  text: string;
+  member: IdolMember;
+  otherPRs: PullRequestSubmission[] | undefined;
+};
+
+const DevPortfolioTextModal: React.FC<Props> = ({ title, text, member, otherPRs }) => {
   const [viewText, setViewText] = useState(false);
+
   return (
     <Modal
       onClose={() => setViewText(false)}
@@ -17,7 +26,9 @@ const DevPortfolioTextModal: React.FC<Props> = ({ title, text }) => {
     >
       <Modal.Header>{title}</Modal.Header>
       <Modal.Content image>
-        <p>{text}</p>
+        <Modal.Description>
+          <Text text={text} member={member} otherPRs={otherPRs} />
+        </Modal.Description>
       </Modal.Content>
       <Modal.Actions>
         <Button color="red" onClick={() => setViewText(false)}>
@@ -25,6 +36,33 @@ const DevPortfolioTextModal: React.FC<Props> = ({ title, text }) => {
         </Button>
       </Modal.Actions>
     </Modal>
+  );
+};
+
+const Text: React.FC<TextProps> = ({ text, member, otherPRs }) => {
+  if (member.role === 'tpm') {
+    return <p>{text}</p>;
+  }
+  return (
+    <p>
+      <div>
+        {member.firstName} {member.lastName} has requested an exception to the normal dev portfolio
+        PR requirements. <br />
+        These are the PRs submitted for their exception:
+      </div>{' '}
+      <br />
+      {otherPRs ? (
+        otherPRs.map((pr) => (
+          <div>
+            {pr.url} <br />
+          </div>
+        ))
+      ) : (
+        <div>No PRs submitted.</div>
+      )}
+      <br />
+      <div>Explanation: {text}</div>
+    </p>
   );
 };
 

--- a/frontend/src/components/Modals/DevPortfolioTextModal.tsx
+++ b/frontend/src/components/Modals/DevPortfolioTextModal.tsx
@@ -53,7 +53,7 @@ const DevPortfolioText: React.FC<DevPortfolioTextProps> = ({ text, member, other
       <br />
       {otherPRs ? (
         otherPRs.map((pr) => (
-          <a>
+          <a href={pr.url} target="_blank" rel="noreferrer noopener">
             {pr.url} <br />
           </a>
         ))


### PR DESCRIPTION
### Summary

The dev portfolio submissions form now has a third category besides “Opened PRs” and “Reviewed PRs” to handle exceptions that don’t fall into either category, but should be counted as valid. This category is automatically hidden unless the user explicitly clicks the arrow to open this section. 

### Notion Link

https://www.notion.so/DP-Add-Other-Category-to-Allow-Exceptions-7ed09a2923ea4a51975ed773de0bcfd8?pvs=4

### Test Plan

I checked that opening the third category will set the previous two categories to optional.

<img width="907" alt="Screen Shot 2023-11-25 at 3 40 20 AM" src="https://github.com/cornell-dti/idol/assets/125151386/b15c28f2-32f9-41d7-a4e4-2996cf6d7b26">

I created a test dev portfolio that used the other category, and checked the submissions dashboard to see that the submission is automatically set to pending.
<img width="1149" alt="Screen Shot 2023-11-25 at 3 39 54 AM" src="https://github.com/cornell-dti/idol/assets/125151386/4167a88c-4c4b-4fd6-ba1d-5726269c17ab">

The PRs and explanation are shown when the admin opens the "Show Text" button.
<img width="964" alt="Screen Shot 2023-11-25 at 3 40 01 AM" src="https://github.com/cornell-dti/idol/assets/125151386/36296544-80df-42c5-a269-5ca88d2cf350">