### PR TITLE
Add confirmation for ops leads on edit users page

### DIFF
--- a/frontend/src/components/Admin/AddUser/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser/AddUser.tsx
@@ -108,10 +108,6 @@ export default function AddUser(): JSX.Element {
       },
       isCreatingUser: true
     });
-    Emitters.generalSuccess.emit({
-      headerMsg: 'Creating User',
-      contentMsg: 'You are creating a new user!'
-    });
   }
 
   async function deleteUser(memberEmail: string): Promise<void> {
@@ -125,7 +121,7 @@ export default function AddUser(): JSX.Element {
         setState({ currentSelectedMember: undefined, isCreatingUser: false });
         Emitters.generalSuccess.emit({
           headerMsg: 'Deleting User',
-          contentMsg: `You have successfully deleted user with email ${memberEmail} .`
+          contentMsg: `You have successfully deleted user with email ${memberEmail}`
         });
       }
     });

--- a/frontend/src/components/Admin/AddUser/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser/AddUser.tsx
@@ -113,6 +113,7 @@ export default function AddUser(): JSX.Element {
       contentMsg: 'You are creating a new user!'
     });
   }
+
   async function deleteUser(memberEmail: string): Promise<void> {
     MembersAPI.deleteMember(memberEmail).then((val) => {
       if (val.error) {

--- a/frontend/src/components/Admin/AddUser/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser/AddUser.tsx
@@ -125,7 +125,7 @@ export default function AddUser(): JSX.Element {
         setState({ currentSelectedMember: undefined, isCreatingUser: false });
         Emitters.generalSuccess.emit({
           headerMsg: 'Deleting User',
-          contentMsg: `You have successfully deleted user with email ` + memberEmail + ' .'
+          contentMsg: `You have successfully deleted user with email ${  memberEmail  } .`
         });
       }
     });
@@ -143,7 +143,7 @@ export default function AddUser(): JSX.Element {
         Emitters.generalSuccess.emit({
           headerMsg: 'Saving User',
           contentMsg:
-            `You have successfully saved ` + member.firstName + ' ' + member.lastName + '.'
+            `You have successfully saved ${  member.firstName  } ${  member.lastName  }.`
         });
       }
     });

--- a/frontend/src/components/Admin/AddUser/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser/AddUser.tsx
@@ -108,8 +108,11 @@ export default function AddUser(): JSX.Element {
       },
       isCreatingUser: true
     });
+    Emitters.generalSuccess.emit({
+      headerMsg: 'Creating User',
+      contentMsg: 'You are creating a new user!'
+    });
   }
-
   async function deleteUser(memberEmail: string): Promise<void> {
     MembersAPI.deleteMember(memberEmail).then((val) => {
       if (val.error) {
@@ -119,6 +122,10 @@ export default function AddUser(): JSX.Element {
         });
       } else {
         setState({ currentSelectedMember: undefined, isCreatingUser: false });
+        Emitters.generalSuccess.emit({
+          headerMsg: 'Deleting User',
+          contentMsg: `You have successfully deleted user with email ` + memberEmail + ' .'
+        });
       }
     });
   }
@@ -132,6 +139,11 @@ export default function AddUser(): JSX.Element {
         });
       } else {
         setState((s) => ({ ...s, isCreatingUser: false }));
+        Emitters.generalSuccess.emit({
+          headerMsg: 'Saving User',
+          contentMsg:
+            `You have successfully saved ` + member.firstName + ' ' + member.lastName + '.'
+        });
       }
     });
   }

--- a/frontend/src/components/Admin/AddUser/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser/AddUser.tsx
@@ -125,7 +125,7 @@ export default function AddUser(): JSX.Element {
         setState({ currentSelectedMember: undefined, isCreatingUser: false });
         Emitters.generalSuccess.emit({
           headerMsg: 'Deleting User',
-          contentMsg: `You have successfully deleted user with email ${  memberEmail  } .`
+          contentMsg: `You have successfully deleted user with email ${memberEmail} .`
         });
       }
     });
@@ -142,8 +142,7 @@ export default function AddUser(): JSX.Element {
         setState((s) => ({ ...s, isCreatingUser: false }));
         Emitters.generalSuccess.emit({
           headerMsg: 'Saving User',
-          contentMsg:
-            `You have successfully saved ${  member.firstName  } ${  member.lastName  }.`
+          contentMsg: `You have successfully saved ${member.firstName} ${member.lastName}.`
         });
       }
     });


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request provides confirmation for an ops lead on the edit users page that they have completed the action performed (edit user, create user, or save user).

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/Edit-Users-Confirmation-after-Save-Delete-Create-User-Operations-f1efb32f482f449f82336b997d5e94b9?pvs=4

<img width="842" alt="Screenshot 2023-11-26 at 10 35 51 PM" src="https://github.com/cornell-dti/idol/assets/69472409/8bdf14f0-076f-435b-8483-64b3f4f74db1">
<img width="697" alt="Screenshot 2023-11-26 at 10 36 12 PM" src="https://github.com/cornell-dti/idol/assets/69472409/88d90ab7-b840-4a55-ab9c-2e52a9497af2">
<img width="800" alt="Screenshot 2023-11-26 at 10 36 37 PM" src="https://github.com/cornell-dti/idol/assets/69472409/1dcfb049-8701-4fa6-a82b-8fe1079e56f2">

