### PR TITLE
Clear TEC and Dev Portfolio Forms Upon Submission

### DIFF
--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -47,8 +47,10 @@ const DevPortfolioForm: React.FC = () => {
           setDevPortfolio(undefined);
           setOpenPRs(['']);
           setReviewedPRs(['']);
-          setText(undefined);
+          setOtherPRs(['']);
+          setText('');
           setDocumentationText('');
+          setOpenOther(false);
           refreshDevPortfolios();
         }
       }

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -42,6 +42,11 @@ const DevPortfolioForm: React.FC = () => {
             headerMsg: 'Dev Portfolio Assignment submitted!',
             contentMsg: `The leads were notified of your submission and your submission will be graded soon!`
           });
+          setDevPortfolio(undefined);
+          setOpenPRs(['']);
+          setReviewedPRs(['']);
+          setText(undefined);
+          setDocumentationText('');
           refreshDevPortfolios();
         }
       }
@@ -151,7 +156,7 @@ const DevPortfolioForm: React.FC = () => {
                 fluid
                 search
                 selection
-                value={devPortfolio?.uuid}
+                value={devPortfolio?.uuid ?? ''}
                 options={devPortfolios
                   .sort((a, b) => a.deadline - b.deadline)
                   .map((assignment) => ({

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -33,6 +33,7 @@ const TeamEventCreditForm: React.FC = () => {
   const handleNewImage = (e: React.ChangeEvent<HTMLInputElement>): void => {
     if (!e.target.files) return;
     const newImage = URL.createObjectURL(e.target.files[0]);
+    console.log(newImage);
     setImage(newImage);
   };
 
@@ -89,6 +90,9 @@ const TeamEventCreditForm: React.FC = () => {
             headerMsg: 'Team Event Credit submitted!',
             contentMsg: `The leads were notified of your submission, and your credit will be approved soon!`
           });
+          setTeamEvent(undefined);
+          setHours('0');
+          setImage('');
         }
       });
     }
@@ -200,6 +204,8 @@ const TeamEventCreditForm: React.FC = () => {
             id="newImage"
             type="file"
             accept="image/png, image/jpeg"
+            defaultValue=""
+            value={image ? undefined : ''}
             onChange={handleNewImage}
           />
         </div>

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -33,7 +33,6 @@ const TeamEventCreditForm: React.FC = () => {
   const handleNewImage = (e: React.ChangeEvent<HTMLInputElement>): void => {
     if (!e.target.files) return;
     const newImage = URL.createObjectURL(e.target.files[0]);
-    console.log(newImage);
     setImage(newImage);
   };
 


### PR DESCRIPTION
### Summary <!-- Required -->

Context:

Just from taking a few passes on submissions this semester, I’ve noticed a lot of duplicate submissions for the TEC form and Dev Portfolios. This is most likely because for both the [TEC form](https://idol.cornelldti.org/forms/teamEventCredits) and [Dev Portfolio form](https://idol.cornelldti.org/forms/devPortfolio), when you submit, the form fields do not clear. So users might be confused as to whether or not their submissions went through, so they double/triple click and then we get a bunch of duplicate submissions.

This is by design, in case you wanted to make multiple submissions, or for Dev Portfolio, it was in case you wanted to replace your existing submission with a minor adjustment (so you don’t have to fill everything in the form again).
But I haven’t personally used this feature. It feels more like a bug, and I think we’re getting a lot of unintentional duplicate TEC/Dev Portfolio submissions from it.

Taking a poll in #idol-devs, survey says Dev's don't use it either.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

https://github.com/cornell-dti/idol/assets/59291082/3a3edb3f-afa9-4436-b598-33c25a117ffe




### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->