### PR TITLE
Check for otherPRs instead of Member Role for Admin Dev Portfolio Display

### DIFF
--- a/frontend/src/components/Modals/DevPortfolioTextModal.tsx
+++ b/frontend/src/components/Modals/DevPortfolioTextModal.tsx
@@ -40,7 +40,9 @@ const DevPortfolioTextModal: React.FC<Props> = ({ title, text, member, otherPRs 
 };
 
 const DevPortfolioText: React.FC<DevPortfolioTextProps> = ({ text, member, otherPRs }) => {
-  if (member.role === 'tpm') {
+  // The other PR's field defines this as a Dev Portfolio, not a TPM portfolio.
+  // This check, compared to a member.role check, is more resilient towards mid-semester role changes.
+  if (!otherPRs) {
     return <p>{text}</p>;
   }
   return (

--- a/frontend/src/components/Modals/DevPortfolioTextModal.tsx
+++ b/frontend/src/components/Modals/DevPortfolioTextModal.tsx
@@ -42,7 +42,7 @@ const DevPortfolioTextModal: React.FC<Props> = ({ title, text, member, otherPRs 
 const DevPortfolioText: React.FC<DevPortfolioTextProps> = ({ text, member, otherPRs }) => {
   // The other PR's field defines this as a Dev Portfolio, not a TPM portfolio.
   // This check, compared to a member.role check, is more resilient towards mid-semester role changes.
-  if (!otherPRs) {
+  if (otherPRs.length === 0) {
     return <p>{text}</p>;
   }
   return (


### PR DESCRIPTION
### Summary <!-- Required -->

We avoid checking the role since otherPRs applies to Dev's only. If there are other PR's submitted, then the submission is a Dev Portfolio submission, not a TPM portfolio. 

Consider the case where a member is promoted to TPM mid-semester. That should not change the way this Dev Portfolio is displayed. 

Consider also the case where a member switches from TPM to Dev mid-semester. (Yes, both of these cases have happened at some point!). We want to preserve the state of the portfolio.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
