### PR TITLE
Add Ability to Send End of Semester TEC Submission Reminder

### DIFF
--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -123,10 +123,15 @@ export const sendMemberUpdateNotifications = async (req: Request): Promise<Promi
 /**
  * Send an email reminder to members who do not have enough TEC credits
  * @param req - The request made when sending the email
+ * @param endOfSemesterReminder - If set to true, sends a generic reminder email to submit all TEC (typically sent at end of semester when there are no more TEC's).
  * @param member - The member being sent the email
  * @returns - The response body containing information of the member being sent the email
  */
-export const sendTECReminder = async (req: Request, member: IdolMember): Promise<AxiosResponse> => {
+export const sendTECReminder = async (
+  req: Request,
+  endOfSemesterReminder: boolean,
+  member: IdolMember
+): Promise<AxiosResponse> => {
   const subject = 'TEC Reminder';
   const allEvents = await Promise.all(
     (
@@ -157,28 +162,34 @@ export const sendTECReminder = async (req: Request, member: IdolMember): Promise
     }
   });
 
-  const text =
-    `Hey! You currently have ${approvedCount} team event ${
-      approvedCount !== 1 ? 'credits' : 'credit'
-    } approved and ${pendingCount} team event ${
-      pendingCount !== 1 ? 'credits' : 'credit'
-    } pending this semester. ` +
-    `This is a reminder to get at least ${
-      member.role === 'lead' ? '6' : '3'
-    } team event credits by the end of the semester.\n` +
-    `\n${
-      futureEvents.length === 0
-        ? 'There are currently no upcoming team events listed on IDOL, but check the #team-events channel for upcoming team events.'
-        : 'Here is a list of upcoming team events you can participate in:'
-    } \n` +
-    `${(await futureEvents)
-      .map(
-        (event) =>
-          `${event.name} on ${event.date} (${event.numCredits} ${
-            Number(event.numCredits) !== 1 ? 'credits' : 'credit'
-          })\n`
-      )
-      .join('')}` +
-    '\nTo submit your TEC, please visit https://idol.cornelldti.org/forms/teamEventCredits.';
+  let reminder;
+
+  if (endOfSemesterReminder) {
+    reminder = 'This is a reminder to submit all your TEC requests by the end of the semester!';
+  } else {
+    reminder =
+      `This is a reminder to get at least ${
+        member.role === 'lead' ? '6' : '3'
+      } team event credits by the end of the semester.\n` +
+      `\n${
+        futureEvents.length === 0
+          ? 'There are currently no upcoming team events listed on IDOL, but check the #team-events channel for upcoming team events.'
+          : 'Here is a list of upcoming team events you can participate in:'
+      } \n` +
+      `${(await futureEvents)
+        .map(
+          (event) =>
+            `${event.name} on ${event.date} (${event.numCredits} ${
+              Number(event.numCredits) !== 1 ? 'credits' : 'credit'
+            })\n`
+        )
+        .join('')}`;
+  }
+
+  const text = `Hey! You currently have ${approvedCount} team event ${
+    approvedCount !== 1 ? 'credits' : 'credit'
+  } approved and ${pendingCount} team event ${
+    pendingCount !== 1 ? 'credits' : 'credit'
+  } pending this semester.\n${reminder}\nTo submit your TEC, please visit https://idol.cornelldti.org/forms/teamEventCredits.`;
   return emailMember(req, member, subject, text);
 };

--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -165,7 +165,9 @@ export const sendTECReminder = async (
   let reminder;
 
   if (endOfSemesterReminder) {
-    reminder = 'This is a reminder to submit all your TEC requests by the end of the semester!';
+    reminder = `This is a reminder to submit all your TEC requests to fulfill your ${
+      member.role === 'lead' ? '6' : '3'
+    } team event credits requirement by the end of the semester!`;
   } else {
     reminder =
       `This is a reminder to get at least ${

--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -218,6 +218,7 @@ export const deleteTeamEventAttendance = async (uuid: string, user: IdolMember):
  */
 export const notifyMember = async (
   req: Request,
+  endOfSemesterReminder: boolean,
   member: IdolMember,
   user: IdolMember
 ): Promise<unknown> => {
@@ -230,6 +231,6 @@ export const notifyMember = async (
   if (!member.email || member.email === '') {
     throw new BadRequestError("Couldn't notify member with undefined email!");
   }
-  const responseBody = await sendTECReminder(req, member);
+  const responseBody = await sendTECReminder(req, endOfSemesterReminder, member);
   return responseBody.data;
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -337,7 +337,7 @@ loginCheckedDelete('/team-event-attendance/:uuid', async (req, user) => {
   return {};
 });
 loginCheckedPost('/team-event-reminder', async (req, user) => ({
-  info: await notifyMember(req, req.body, user)
+  info: await notifyMember(req, req.query.end_of_semester_reminder !== undefined, req.body, user)
 }));
 
 // Team Events Proof Image

--- a/frontend/src/API/MembersAPI.ts
+++ b/frontend/src/API/MembersAPI.ts
@@ -31,7 +31,15 @@ export class MembersAPI {
     );
   }
 
-  public static notifyMember(member: Member): Promise<MemberResponseObj> {
-    return APIWrapper.post(`${backendURL}/team-event-reminder`, member).then((res) => res.data);
+  public static notifyMember(
+    member: Member,
+    endOfSemesterReminder: boolean
+  ): Promise<MemberResponseObj> {
+    return APIWrapper.post(
+      `${backendURL}/team-event-reminder${
+        endOfSemesterReminder ? '?end_of_semester_reminder=true' : ''
+      }`,
+      member
+    ).then((res) => res.data);
   }
 }

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
@@ -38,5 +38,4 @@
 
 .endOfSemesterCheckbox {
   margin-top: 5%;
-  margin-left: 36%;
 }

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
@@ -35,3 +35,8 @@
   position: absolute;
   right: 1%;
 }
+
+.endOfSemesterCheckbox {
+  margin-top: 5%;
+  margin-left: 36%;
+}

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Table, Header, Loader, Button, Icon } from 'semantic-ui-react';
+import { Table, Header, Loader, Button, Icon, Checkbox } from 'semantic-ui-react';
 import { useMembers } from '../../Common/FirestoreDataProvider';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import {
@@ -40,6 +40,7 @@ const calculateCommunityCreditsForEvent = (member: IdolMember, event: TeamEvent)
 const TeamEventDashboard: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [endOfSemesterReminder, setEndOfSemesterReminder] = useState(false);
 
   const allMembers = useMembers();
 
@@ -81,6 +82,16 @@ const TeamEventDashboard: React.FC = () => {
                       : REQUIRED_MEMBER_TEC_CREDITS)
                   );
                 })}
+                endOfSemesterReminder={endOfSemesterReminder}
+              />
+              <Checkbox
+                className={styles.endOfSemesterCheckbox}
+                label={{ children: 'End of Semester?' }}
+                checked={endOfSemesterReminder}
+                onChange={() => {
+                  console.log('helo');
+                  setEndOfSemesterReminder((endOfSemesterReminder) => !endOfSemesterReminder);
+                }}
               />
             </Table.HeaderCell>
             <Table.HeaderCell>Total</Table.HeaderCell>
@@ -113,6 +124,7 @@ const TeamEventDashboard: React.FC = () => {
                         all={false}
                         trigger={<Icon className={styles.notify} name="exclamation" color="red" />}
                         member={member}
+                        endOfSemesterReminder={endOfSemesterReminder}
                       />
                     )}
                   </Table.Cell>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -86,7 +86,7 @@ const TeamEventDashboard: React.FC = () => {
               />
               <Checkbox
                 className={styles.endOfSemesterCheckbox}
-                label={{ children: 'End of Semester?' }}
+                label={{ children: 'End of Semester Reminder?' }}
                 checked={endOfSemesterReminder}
                 onChange={() =>
                   setEndOfSemesterReminder((endOfSemesterReminder) => !endOfSemesterReminder)

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -88,10 +88,9 @@ const TeamEventDashboard: React.FC = () => {
                 className={styles.endOfSemesterCheckbox}
                 label={{ children: 'End of Semester?' }}
                 checked={endOfSemesterReminder}
-                onChange={() => {
-                  console.log('helo');
-                  setEndOfSemesterReminder((endOfSemesterReminder) => !endOfSemesterReminder);
-                }}
+                onChange={() =>
+                  setEndOfSemesterReminder((endOfSemesterReminder) => !endOfSemesterReminder)
+                }
               />
             </Table.HeaderCell>
             <Table.HeaderCell>Total</Table.HeaderCell>

--- a/frontend/src/components/Modals/NotifyMemberModal.tsx
+++ b/frontend/src/components/Modals/NotifyMemberModal.tsx
@@ -9,14 +9,15 @@ const NotifyMemberModal = (props: {
   member?: Member;
   members?: Member[];
   trigger: JSX.Element;
+  endOfSemesterReminder: boolean;
 }): JSX.Element => {
-  const { member, members, all, trigger } = props;
+  const { member, members, all, trigger, endOfSemesterReminder } = props;
   const [open, setOpen] = useState(false);
   const subject = !all && member ? `${member.firstName} ${member.lastName}` : 'everyone';
 
   const handleSubmit = () => {
     if (!all && member) {
-      MembersAPI.notifyMember(member).then((val) => {
+      MembersAPI.notifyMember(member, endOfSemesterReminder).then((val) => {
         Emitters.generalSuccess.emit({
           headerMsg: 'Reminder sent!',
           contentMsg: `An email reminder was successfully sent to ${member.firstName} ${member.lastName}!`
@@ -26,7 +27,7 @@ const NotifyMemberModal = (props: {
 
     if (all && members) {
       members.forEach(async (member) => {
-        await MembersAPI.notifyMember(member);
+        await MembersAPI.notifyMember(member, endOfSemesterReminder);
       });
       Emitters.generalSuccess.emit({
         headerMsg: 'Reminder sent!',


### PR DESCRIPTION
### Summary <!-- Required -->

Add ability to send an "end of semester" TEC submission reminder, which reminds members to submit all TEC credits after there are no more TEC credit events.

Feature request from Justin (C&I lead), most likely everyone has completed their TEC already, but they are procrastinating on submitting them.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<img width="304" alt="Screenshot 2023-11-30 at 6 45 13 PM" src="https://github.com/cornell-dti/idol/assets/59291082/e62b136e-bb43-4bd5-8827-6a890403e263">

![Screenshot 2023-11-30 at 6 36 06 PM](https://github.com/cornell-dti/idol/assets/59291082/589f2878-2e39-468b-ab6e-b9bdb370fa0a)


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
