### PR TITLE
Add Shoutout Leaderboard Script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "send-profile-update-notifications": "esr scripts/send-profile-update-notifications.ts",
     "send-tec-notifications": "esr scripts/send-tec-notifications.ts",
     "backup-prod-db": "esr scripts/backup-prod-db.ts",
-    "restore-from-backup": "esr scripts/restore-from-backup.ts"
+    "restore-from-backup": "esr scripts/restore-from-backup.ts",
+    "shoutout-leaderboard": "esr scripts/shoutout-leaderboard.ts"
   },
   "license": "AGPL-3.0",
   "dependencies": {

--- a/backend/scripts/shoutout-leaderboard.ts
+++ b/backend/scripts/shoutout-leaderboard.ts
@@ -1,0 +1,52 @@
+/* eslint-disable no-console */
+import admin from 'firebase-admin';
+import { configureAccount } from '../src/utils/firebase-utils';
+import { DBShoutout } from '../src/types/DataTypes';
+import { getMemberFromDocumentReference } from '../src/utils/memberUtil';
+
+const serviceAcc = require('../resources/idol-b6c68-firebase-adminsdk-h4e6t-40e4bd5536.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(configureAccount(serviceAcc, 'prod')),
+  databaseURL: 'https://idol-b6c68.firebaseio.com',
+  storageBucket: 'gs://cornelldti-idol.appspot.com'
+});
+
+const db = admin.firestore();
+const QUERY_DATE = '2023-08-01';
+
+const main = async () => {
+  console.log(`Collecting all shoutouts from ${QUERY_DATE} until now...`);
+  const queryDateUnix = Math.floor(new Date(QUERY_DATE).getTime());
+
+  const shoutoutDocs = (
+    await db.collection('shoutouts').where('timestamp', '>=', queryDateUnix).get()
+  ).docs;
+
+  const memberToNumberOfShoutouts: { [key: string]: number } = {};
+  await Promise.all(
+    shoutoutDocs.map(async (shoutoutDoc) => {
+      const shoutout = shoutoutDoc.data() as DBShoutout;
+      const member = await getMemberFromDocumentReference(shoutout.giver);
+      const memberStr = `${member.firstName} ${member.lastName} (${member.netid})`;
+
+      if (memberToNumberOfShoutouts[memberStr] === undefined) {
+        memberToNumberOfShoutouts[memberStr] = 1;
+      } else {
+        memberToNumberOfShoutouts[memberStr] += 1;
+      }
+    })
+  );
+
+  const rankedMembers: [string, number][] = [];
+
+  // eslint-disable-next-line guard-for-in
+  for (const memberStr in memberToNumberOfShoutouts) {
+    rankedMembers.push([memberStr, memberToNumberOfShoutouts[memberStr]]);
+  }
+  rankedMembers.sort((a, b) => b[1] - a[1]);
+
+  console.log(rankedMembers);
+};
+
+main();


### PR DESCRIPTION
### Summary <!-- Required -->

Add script that parses leaderboard for shoutout givers, given a `QUERY_DATE`, and outputs data to console (similar to Dev Wrapped script).

We can now run `yarn workspace backend shoutout-leaderboard` to get this info.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Ran script:

```
% yarn workspace backend shoutout-leaderboard
yarn workspace v1.22.19
yarn run v1.22.19
$ esr scripts/shoutout-leaderboard.ts
Collecting all shoutouts from 2023-08-01 until now...
[
  [ 'Benjamin Tang (bt283)', 35 ],
  [ 'Richard Gu (rg779)', 14 ],
  [ 'Mikayla Lin (ml953)', 13 ],
  [ 'Sophia Pham (tpp38)', 12 ],
  [ 'Andrew Chen (axc2)', 11 ],
...
```

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->