### PR TITLE
Break Word in Documentation Cell in Dev Portfolio Table

### DIFF
--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.module.css
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.module.css
@@ -1,3 +1,8 @@
 .container {
   padding: 1%;
 }
+
+.documentation {
+  max-width: 200px;
+  word-wrap: break-word;
+}

--- a/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/DevPortfolioDetails.tsx
@@ -257,7 +257,7 @@ const SubmissionDetails: React.FC<SubmissionDetailsProps> = ({
             prSubmission={submission.reviewedPRs.length > 0 ? submission.reviewedPRs[0] : undefined}
           />
         </Table.Cell>
-        <Table.Cell>{submission.documentationText}</Table.Cell>
+        <Table.Cell className={styles.documentation}>{submission.documentationText}</Table.Cell>
 
         {isAdminView ? (
           <Table.Cell rowSpan={`${numRows}`}>


### PR DESCRIPTION
### Summary <!-- Required -->

We have a UI bug in the Dev Portfolio Details table due to longer documentation responses that are not being properly text-wrapped, so much so that some columns are not even visible unless you zoom out on a standard browser viewport.

Set max width of documentation column to be 200px and wrap the text.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Before:
<img width="1512" alt="Screenshot 2023-12-03 at 2 29 39 PM" src="https://github.com/cornell-dti/idol/assets/59291082/f2117857-00c5-41fd-a4c2-3462da7c2252">


After:
<img width="1511" alt="Screenshot 2023-12-03 at 2 29 16 PM" src="https://github.com/cornell-dti/idol/assets/59291082/e4f1f9e0-81cc-40e3-997d-26de9bff95fb">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
