### PR TITLE
Candidate Decider: Check Authorized Members By Email

### DIFF
--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -75,13 +75,7 @@ export const getCandidateDeciderInstance = async (
   if (!instance) {
     throw new NotFoundError(`Instance with uuid ${uuid} does not exist`);
   }
-  if (
-    !(
-      (await PermissionsManager.isAdmin(user)) ||
-      instance.authorizedMembers.includes(user) ||
-      instance.authorizedRoles.includes(user.role)
-    )
-  ) {
+  if (!(await PermissionsManager.canAccessCandidateDeciderInstance(user, instance))) {
     throw new PermissionError(
       `User with email ${user.email} does not have permission to access this Candidate Decider instance`
     );
@@ -100,13 +94,7 @@ export const updateCandidateDeciderRatingAndComment = async (
   if (!instance) {
     throw new NotFoundError(`Instance with uuid ${uuid} does not exist`);
   }
-  if (
-    !(
-      (await PermissionsManager.isAdmin(user)) ||
-      instance.authorizedMembers.includes(user) ||
-      instance.authorizedRoles.includes(user.role)
-    )
-  )
+  if (!(await PermissionsManager.canAccessCandidateDeciderInstance(user, instance)))
     throw new PermissionError(
       `User with email ${user.email} does not have permission to access this Candidate Decider instance`
     );

--- a/backend/src/utils/permissionsManager.ts
+++ b/backend/src/utils/permissionsManager.ts
@@ -49,4 +49,15 @@ export default class PermissionsManager {
   public static async isLeadOrAdmin(mem: IdolMember): Promise<boolean> {
     return mem.role === 'lead' || this.isAdmin(mem);
   }
+
+  public static async canAccessCandidateDeciderInstance(
+    mem: IdolMember,
+    instance: CandidateDeciderInstance
+  ): Promise<boolean> {
+    return (
+      (await this.isAdmin(mem)) ||
+      instance.authorizedMembers.some((authorizedMember) => authorizedMember.email === mem.email) ||
+      instance.authorizedRoles.includes(mem.role)
+    );
+  }
 }


### PR DESCRIPTION
### Summary <!-- Required -->

Bug: Candidate decider was responding with a permissions error (403) for accessing and updating ratings/comments for an instance, even if the member was listed under authorized members.

`/.netlify/functions/api/candidate-decider/rating-and-comment`
Response:
```
{
    "error": "User with email axc2@cornell.edu does not have permission to access this Candidate Decider instance"
}
```

This is because `Array.includes(...)` checks for equality of two object references. Check equality by email field instead.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Manual:
1. Added myself to authorized members for an instance
2. Removed myself as an admin from IDOL
3. Verified that I am still able to update ratings and comments

### Notes <!-- Optional -->
- Also abstracted permissions logic for updating ratings/comments to a helper `PermissionsManager.canAccessCandidateDeciderInstance`

### Breaking Changes <!-- Optional -->

