### PR TITLE
update TEC email notifs to only send weekly on mondays

### DIFF
--- a/.github/workflows/idol-notifications.yml
+++ b/.github/workflows/idol-notifications.yml
@@ -2,7 +2,7 @@ name: IDOL Notifications
 on:
   schedule:
     # Runs script at 8AM UTC (6PM or 7PM ET) everyday. This hsould be an hour before pull-from-idol
-    - cron: '0 23 * * *'
+    - cron: '0 23 * * MON'
 
 jobs:
   profile-update-notifications:


### PR DESCRIPTION
### Summary <!-- Required -->

Kevin requested to receive TEC notifications less frequently. 

<!--- List any important or subtle points, future considerations, or other items of note. -->

- Maybe we could allow C&I lead to change the frequency of these emails themselves?
- Could potentially look into for Slack integrations as well.