### PR TITLE
Add support for initiative TEC

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -14,9 +14,9 @@ import NotifyMemberModal from '../../Modals/NotifyMemberModal';
 const calculateMemberCreditsForEvent = (
   member: IdolMember,
   event: TeamEvent,
-  isCommunity: boolean
+  isInitiativeEvent: boolean
 ): number =>
-  isCommunity && !event.isCommunity
+  isInitiativeEvent && !event.isCommunity
     ? 0
     : event.requests
         .filter((req) => req.status === 'approved')
@@ -32,7 +32,7 @@ const calculateMemberCreditsForEvent = (
 const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, false);
 
-const calculateCommunityCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
+const calculateInitiativeCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, true);
 
 const TeamEventDashboard: React.FC = () => {
@@ -103,14 +103,14 @@ const TeamEventDashboard: React.FC = () => {
                 (val, event) => val + calculateTotalCreditsForEvent(member, event),
                 0
               );
-              const communityCredits = teamEvents.reduce(
-                (val, event) => calculateCommunityCreditsForEvent(member, event),
+              const initiativeCredits = teamEvents.reduce(
+                (val, event) => calculateInitiativeCreditsForEvent(member, event),
                 0
               );
               const totalCreditsMet =
                 totalCredits >=
                 (member.role === 'lead' ? REQUIRED_LEAD_TEC_CREDITS : REQUIRED_MEMBER_TEC_CREDITS);
-              const communityCreditsMet = communityCredits >= REQUIRED_INITIATIVE_CREDITS;
+              const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
 
               return (
                 <Table.Row>
@@ -127,7 +127,7 @@ const TeamEventDashboard: React.FC = () => {
                   </Table.Cell>
                   <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
                   {INITIATIVE_EVENTS && (
-                    <Table.Cell positive={communityCreditsMet}>{communityCredits}</Table.Cell>
+                    <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
                   )}
                   {teamEvents.map((event) => {
                     const numCredits = calculateTotalCreditsForEvent(member, event);

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -5,13 +5,11 @@ import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import {
   REQUIRED_LEAD_TEC_CREDITS,
   REQUIRED_MEMBER_TEC_CREDITS,
-  REQUIRED_COMMUNITY_CREDITS
+  REQUIRED_INITIATIVE_CREDITS,
+  INITIATIVE_EVENTS
 } from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
-
-// remove this and its usage if/when community events are released
-const COMMUNITY_EVENTS = false;
 
 const calculateMemberCreditsForEvent = (
   member: IdolMember,
@@ -94,7 +92,7 @@ const TeamEventDashboard: React.FC = () => {
               />
             </Table.HeaderCell>
             <Table.HeaderCell>Total</Table.HeaderCell>
-            {COMMUNITY_EVENTS && <Table.HeaderCell>Total Community Credits</Table.HeaderCell>}
+            {INITIATIVE_EVENTS && <Table.HeaderCell>Total Initiative Credits</Table.HeaderCell>}
             {teamEvents.map((event) => (
               <Table.HeaderCell>{event.name}</Table.HeaderCell>
             ))}
@@ -112,7 +110,7 @@ const TeamEventDashboard: React.FC = () => {
               const totalCreditsMet =
                 totalCredits >=
                 (member.role === 'lead' ? REQUIRED_LEAD_TEC_CREDITS : REQUIRED_MEMBER_TEC_CREDITS);
-              const communityCreditsMet = communityCredits >= REQUIRED_COMMUNITY_CREDITS;
+              const communityCreditsMet = communityCredits >= REQUIRED_INITIATIVE_CREDITS;
 
               return (
                 <Table.Row>
@@ -128,7 +126,7 @@ const TeamEventDashboard: React.FC = () => {
                     )}
                   </Table.Cell>
                   <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
-                  {COMMUNITY_EVENTS && (
+                  {INITIATIVE_EVENTS && (
                     <Table.Cell positive={communityCreditsMet}>{communityCredits}</Table.Cell>
                   )}
                   {teamEvents.map((event) => {

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -7,6 +7,7 @@ import TeamEventCreditReview from './TeamEventCreditReview';
 import styles from './TeamEventDetails.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters } from '../../../utils';
+import { INITIATIVE_EVENTS } from '../../../consts';
 
 const defaultTeamEvent: TeamEvent = {
   name: '',
@@ -54,9 +55,6 @@ const AttendanceDisplay: React.FC<AttendanceDisplayProps> = ({ status, teamEvent
     </>
   );
 };
-
-// remove this variable and usage when community events ready to be released
-const COMMUNITY_EVENTS = false;
 
 const TeamEventDetails: React.FC = () => {
   const location = useRouter();
@@ -130,9 +128,9 @@ const TeamEventDetails: React.FC = () => {
         <h3 className={styles.eventDetails}>Date: {teamEvent.date}</h3>
         <h3 className={styles.eventDetails}>Credits: {teamEvent.numCredits}</h3>
         <h3 className={styles.eventDetails}>Has Hours: {teamEvent.hasHours ? 'yes' : 'no'}</h3>
-        {COMMUNITY_EVENTS && (
+        {INITIATIVE_EVENTS && (
           <h3 className={styles.eventDetails}>
-            Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}
+            Initiative Event: {teamEvent.isCommunity ? 'Yes' : 'No'}
           </h3>
         )}
       </div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
@@ -3,6 +3,7 @@ import { Form, Radio, Button } from 'semantic-ui-react';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters } from '../../../utils';
 import styles from './TeamEventForm.module.css';
+import { INITIATIVE_EVENTS } from '../../../consts';
 
 type Props = {
   formType: string;
@@ -10,9 +11,6 @@ type Props = {
   teamEvent?: TeamEvent;
   editTeamEvent?: (teamEvent: TeamEvent) => void;
 };
-
-// remove this variable and usage when community events ready to be released
-const COMMUNITY_EVENTS = false;
 
 const TeamEventForm = (props: Props): JSX.Element => {
   const { formType, setOpen, teamEvent, editTeamEvent } = props;
@@ -156,8 +154,12 @@ const TeamEventForm = (props: Props): JSX.Element => {
           </Form.Field>
         </Form.Group>
 
-        {COMMUNITY_EVENTS && <label className={styles.label}>Is this a community event?</label>}
-        {COMMUNITY_EVENTS && (
+        {INITIATIVE_EVENTS && (
+          <label className={styles.label}>
+            Is this an initiative event? <span className={styles.required}>*</span>
+          </label>
+        )}
+        {INITIATIVE_EVENTS && (
           <Form.Group inline>
             <Form.Field>
               <Radio

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -6,14 +6,12 @@ import styles from './TeamEvents.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters } from '../../../utils';
 import ClearTeamEventsModal from '../../Modals/ClearTeamEventsModal';
+import { INITIATIVE_EVENTS } from '../../../consts';
 
 type TeamEventsDisplayProps = {
   isLoading: boolean;
   teamEvents: TeamEvent[];
 };
-
-// remove this variable and usage when community events ready to be released
-const COMMUNITY_EVENTS = false;
 
 const TeamEventsDisplay: React.FC<TeamEventsDisplayProps> = ({ isLoading, teamEvents }) => {
   if (isLoading) return <Loader active inline />;
@@ -40,8 +38,10 @@ const TeamEventsDisplay: React.FC<TeamEventsDisplayProps> = ({ isLoading, teamEv
                         `0 pending requests`
                       )}
                     </Card.Meta>
-                    {COMMUNITY_EVENTS && (
-                      <Card.Meta>Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
+                    {INITIATIVE_EVENTS && (
+                      <Card.Meta>
+                        Initiative Event: {teamEvent.isCommunity ? 'Yes' : 'No'}
+                      </Card.Meta>
                     )}
                   </Card.Content>
                 </Card>

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -126,9 +126,7 @@ const TeamEventCreditForm: React.FC = () => {
                       <div className={styles.flex_space_center}>
                         <div className={styles.flex_start}>{event.name}</div>
                         <div className={styles.flex_end}>
-                          {INITIATIVE_EVENTS && event.isCommunity && (
-                            <Label content="initiative"/>
-                          )}
+                          {INITIATIVE_EVENTS && event.isCommunity && <Label content="initiative" />}
                           <Label
                             content={`${new Date(event.date).toLocaleDateString('en-us', {
                               month: 'short',

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -6,6 +6,7 @@ import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import TeamEventCreditDashboard from './TeamEventsCreditDashboard';
 import styles from './TeamEventCreditsForm.module.css';
 import ImagesAPI from '../../../API/ImagesAPI';
+import { INITIATIVE_EVENTS } from '../../../consts';
 
 const TeamEventCreditForm: React.FC = () => {
   // When the user is logged in, `useSelf` always return non-null data.
@@ -125,6 +126,9 @@ const TeamEventCreditForm: React.FC = () => {
                       <div className={styles.flex_space_center}>
                         <div className={styles.flex_start}>{event.name}</div>
                         <div className={styles.flex_end}>
+                          {INITIATIVE_EVENTS && event.isCommunity && (
+                            <Label content="initiative"></Label>
+                          )}
                           <Label
                             content={`${new Date(event.date).toLocaleDateString('en-us', {
                               month: 'short',

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -127,7 +127,7 @@ const TeamEventCreditForm: React.FC = () => {
                         <div className={styles.flex_start}>{event.name}</div>
                         <div className={styles.flex_end}>
                           {INITIATIVE_EVENTS && event.isCommunity && (
-                            <Label content="initiative"></Label>
+                            <Label content="initiative"/>
                           )}
                           <Label
                             content={`${new Date(event.date).toLocaleDateString('en-us', {

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
@@ -7,9 +7,10 @@ import ImagesAPI from '../../../API/ImagesAPI';
 import { Emitters } from '../../../utils';
 
 import {
-  REQUIRED_COMMUNITY_CREDITS,
+  REQUIRED_INITIATIVE_CREDITS,
   REQUIRED_LEAD_TEC_CREDITS,
-  REQUIRED_MEMBER_TEC_CREDITS
+  REQUIRED_MEMBER_TEC_CREDITS,
+  INITIATIVE_EVENTS
 } from '../../../consts';
 
 const TeamEventCreditDashboard = (props: {
@@ -63,7 +64,7 @@ const TeamEventCreditDashboard = (props: {
   };
 
   let approvedCredits = 0;
-  let approvedCommunityCredits = 0;
+  let approvedInitiativeCredits = 0;
   approvedAttendance.forEach(async (attendance) => {
     const event = allTEC.find((tec) => tec.uuid === attendance.eventUuid);
     if (event !== undefined) {
@@ -71,31 +72,31 @@ const TeamEventCreditDashboard = (props: {
         ? Number(event.numCredits) * getHoursAttended(attendance)
         : Number(event.numCredits);
       approvedCredits += currCredits;
-      approvedCommunityCredits += event.isCommunity ? currCredits : 0;
+      approvedInitiativeCredits += event.isCommunity ? currCredits : 0;
     }
   });
-
-  // remove this variable and usage when community events ready to be released
-  const COMMUNITY_EVENTS = false;
 
   // Calculate the remaining credits
   let remainingCredits;
   if (requiredCredits - approvedCredits > 0) remainingCredits = requiredCredits - approvedCredits;
-  else if (COMMUNITY_EVENTS && approvedCommunityCredits < REQUIRED_COMMUNITY_CREDITS)
-    remainingCredits = REQUIRED_COMMUNITY_CREDITS - approvedCommunityCredits;
+  else if (INITIATIVE_EVENTS && approvedInitiativeCredits < REQUIRED_INITIATIVE_CREDITS)
+    remainingCredits = REQUIRED_INITIATIVE_CREDITS - approvedInitiativeCredits;
   else remainingCredits = 0;
 
   let headerString;
   if (userRole !== 'lead')
     headerString = `Check your team event credit status for this semester here!  
-    Every DTI member must complete ${REQUIRED_MEMBER_TEC_CREDITS} team event credits 
-    ${COMMUNITY_EVENTS ? `and ${REQUIRED_COMMUNITY_CREDITS} community team event credits` : ''} 
+    Every DTI member must complete ${REQUIRED_MEMBER_TEC_CREDITS} team event credits${
+      INITIATIVE_EVENTS
+        ? `, with ${REQUIRED_INITIATIVE_CREDITS} of them being initiative team event credits`
+        : ''
+    } 
     to fulfill this requirement.`;
   else
-    headerString = `Since you are a lead, you must complete ${REQUIRED_LEAD_TEC_CREDITS} total team event credits
-    ${
-      COMMUNITY_EVENTS
-        ? `, with ${REQUIRED_COMMUNITY_CREDITS} of them being community event credits`
+    headerString = `Since you are a lead, you must complete ${REQUIRED_LEAD_TEC_CREDITS} total team event 
+    credits${
+      INITIATIVE_EVENTS
+        ? `, with ${REQUIRED_INITIATIVE_CREDITS} of them being initiative team event credits`
         : ''
     }.`;
 
@@ -132,8 +133,8 @@ const TeamEventCreditDashboard = (props: {
                       </Button>
                     )}
                   </Card.Meta>
-                  {COMMUNITY_EVENTS && (
-                    <Card.Meta>Community Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
+                  {INITIATIVE_EVENTS && (
+                    <Card.Meta>Initiative Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
                   )}
                 </Card.Content>
               </Card>
@@ -167,11 +168,11 @@ const TeamEventCreditDashboard = (props: {
             </label>
           </div>
 
-          {COMMUNITY_EVENTS && (
+          {INITIATIVE_EVENTS && (
             <div className={styles.inline}>
               <label className={styles.bold}>
-                Your Approved Community Credits:{' '}
-                <span className={styles.dark_grey_color}>{approvedCommunityCredits}</span>
+                Your Approved Initiative Credits:{' '}
+                <span className={styles.dark_grey_color}>{approvedInitiativeCredits}</span>
               </label>
             </div>
           )}
@@ -182,6 +183,17 @@ const TeamEventCreditDashboard = (props: {
               <span className={styles.dark_grey_color}>{remainingCredits}</span>
             </label>
           </div>
+
+          {INITIATIVE_EVENTS && (
+            <div className={styles.inline}>
+              <label className={styles.bold}>
+                Remaining Initiative Credits Needed:{' '}
+                <span className={styles.dark_grey_color}>
+                  {Math.max(0, REQUIRED_INITIATIVE_CREDITS - approvedInitiativeCredits)}
+                </span>
+              </label>
+            </div>
+          )}
 
           <div className={styles.inline}>
             <label className={styles.bold}>Approved Events:</label>

--- a/frontend/src/consts.ts
+++ b/frontend/src/consts.ts
@@ -1,4 +1,6 @@
 // Team Event constants
-export const REQUIRED_COMMUNITY_CREDITS = 1;
+export const REQUIRED_INITIATIVE_CREDITS = 1;
 export const REQUIRED_MEMBER_TEC_CREDITS = 3;
 export const REQUIRED_LEAD_TEC_CREDITS = 6;
+
+export const INITIATIVE_EVENTS = true;


### PR DESCRIPTION
### Summary <!-- Required -->
- Factor out `INITIATIVE_EVENTS` from several files relating to TEC into `consts.ts`
- Add a line for displaying remaining initiative TEC needed
- Add label for initiative events when submitting TEC

### Test Plan <!-- Required -->
- Previewing each page 
![image](https://github.com/cornell-dti/idol/assets/144409850/d5fe9d80-a6a5-45ab-9ea0-cca293502447)
![image](https://github.com/cornell-dti/idol/assets/144409850/bc72afe5-2bf6-46aa-9d77-44cea1973f71)

### Notes <!-- Optional -->
- The codebase still uses community instead of the initiative (official terminology) in several files, mainly in the API and backend files, which can be really confusing.