### PR TITLE
Create filter for TEC status

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.module.css
@@ -1,3 +1,8 @@
+.attendanceCards {
+  display: flex;
+  justify-content: center;
+}
+
 .bold {
   font-weight: bold;
 }
@@ -19,7 +24,7 @@
 }
 
 .dropdown {
-  padding: 1em;
+  padding-top: 2.5em;
   width: 13em;
 }
 
@@ -41,21 +46,18 @@
 }
 
 .inline {
-  padding-top: 1.3em;
+  padding-top: 3.6em;
+  padding-left: 1em;
+  width: 8.5em;
 }
 
 .listsContainer {
   display: flex;
-  justify-content: space-between;
+  justify-content: left;
 }
 
 .listContainer {
   margin: 0 1em;
-}
-
-.listContainerAll {
-  width: 50%;
-  margin: 0 2em;
 }
 
 .memberGroup {
@@ -67,7 +69,7 @@
   text-align: center;
 }
 
-.row_direction {
+.rowDirection {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.module.css
@@ -46,7 +46,7 @@
 }
 
 .inline {
-  padding-top: 3.6em;
+  padding-top: 3.9em;
   padding-left: 1em;
   width: 8.5em;
 }

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.module.css
@@ -1,3 +1,7 @@
+.bold {
+  font-weight: bold;
+}
+
 .container {
   width: 90%;
   margin: 5em auto;
@@ -12,6 +16,11 @@
   font-size: 3em;
   text-decoration: none;
   cursor: pointer;
+}
+
+.dropdown {
+  padding: 1em;
+  width: 13em;
 }
 
 .eventName {
@@ -31,12 +40,20 @@
   margin: auto;
 }
 
+.inline {
+  padding-top: 1.3em;
+}
+
 .listsContainer {
   display: flex;
   justify-content: space-between;
 }
 
 .listContainer {
+  margin: 0 1em;
+}
+
+.listContainerAll {
   width: 50%;
   margin: 0 2em;
 }
@@ -48,4 +65,10 @@
 .memberTitle {
   margin: 1em;
   text-align: center;
+}
+
+.row_direction {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Message, Modal, Button, Loader } from 'semantic-ui-react';
+import { Card, Message, Modal, Button, Loader, Dropdown } from 'semantic-ui-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import EditTeamEvent from './EditTeamEvent';
@@ -63,6 +63,8 @@ const TeamEventDetails: React.FC = () => {
   const uuid = location.query.uuid as string;
   const [teamEvent, setTeamEvent] = useState<TeamEvent>(defaultTeamEvent);
   const [isLoading, setLoading] = useState(true);
+  const [status, setStatus] = useState<Status | string>();
+  const allStatus: Status[] = ['approved', 'pending', 'rejected'];
 
   const fullReset = () => {
     setLoading(true);
@@ -137,18 +139,62 @@ const TeamEventDetails: React.FC = () => {
         )}
       </div>
 
-      <div className={styles.listsContainer}>
-        <div className={styles.listContainer}>
-          <h2 className={styles.memberTitle}>Members Pending</h2>
-          <AttendanceDisplay status={'pending' as Status} teamEvent={teamEvent} />
+      <div className={styles.row_direction}>
+        <div className={styles.dropdown}>
+          <label className={styles.bold}>Select Status:</label>
+          <Dropdown
+            placeholder="Select Status"
+            fluid
+            selection
+            options={allStatus.map((status) => ({
+              text: status,
+              value: status
+            }))}
+            onChange={(_, data) => {
+              setStatus(data.value as Status);
+            }}
+          />
         </div>
 
-        <div className={styles.listContainer}>
-          <h2 className={styles.memberTitle}>Members Approved</h2>
-          <AttendanceDisplay status={'approved' as Status} teamEvent={teamEvent} />
-          <h2 className={styles.memberTitle}>Members Rejected</h2>
-          <AttendanceDisplay status={'rejected' as Status} teamEvent={teamEvent} />
-        </div>
+        {status && (
+          <div className={styles.inline}>
+            <Button
+              onClick={() => {
+                setStatus(undefined);
+                fullReset();
+              }}
+            >
+              View All
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.listContainer}>
+        {status ? (
+          <>
+            <h2 className={styles.memberTitle}>
+              Members {status.charAt(0).toUpperCase() + status.slice(1)}
+            </h2>
+            <AttendanceDisplay status={status as Status} teamEvent={teamEvent} />
+          </>
+        ) : (
+          <>
+            <div className={styles.listsContainer}>
+              <div className={styles.listContainer}>
+                <h2 className={styles.memberTitle}>Members Pending</h2>
+                <AttendanceDisplay status={'pending' as Status} teamEvent={teamEvent} />
+              </div>
+
+              <div className={styles.listContainer}>
+                <h2 className={styles.memberTitle}>Members Approved</h2>
+                <AttendanceDisplay status={'approved' as Status} teamEvent={teamEvent} />
+                <h2 className={styles.memberTitle}>Members Rejected</h2>
+                <AttendanceDisplay status={'rejected' as Status} teamEvent={teamEvent} />
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -7,8 +7,7 @@ import TeamEventCreditReview from './TeamEventCreditReview';
 import styles from './TeamEventDetails.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters } from '../../../utils';
-import { ALL_STATUS } from '../../../consts';
-import { INITIATIVE_EVENTS } from '../../../consts';
+import { ALL_STATUS, INITIATIVE_EVENTS } from '../../../consts';
 
 const defaultTeamEvent: TeamEvent = {
   name: '',

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -7,6 +7,7 @@ import TeamEventCreditReview from './TeamEventCreditReview';
 import styles from './TeamEventDetails.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters } from '../../../utils';
+import { ALL_STATUS } from '../../../consts';
 
 const defaultTeamEvent: TeamEvent = {
   name: '',
@@ -29,7 +30,7 @@ const AttendanceDisplay: React.FC<AttendanceDisplayProps> = ({ status, teamEvent
   return (
     <>
       {newAttendance && newAttendance.length !== 0 ? (
-        <Card.Group>
+        <Card.Group className={styles.attendanceCards}>
           {newAttendance.map((req, i) => (
             <Card className={styles.memberCard} key={i}>
               <Card.Content>
@@ -64,7 +65,6 @@ const TeamEventDetails: React.FC = () => {
   const [teamEvent, setTeamEvent] = useState<TeamEvent>(defaultTeamEvent);
   const [isLoading, setLoading] = useState(true);
   const [status, setStatus] = useState<Status | string>();
-  const allStatus: Status[] = ['approved', 'pending', 'rejected'];
 
   const fullReset = () => {
     setLoading(true);
@@ -139,59 +139,59 @@ const TeamEventDetails: React.FC = () => {
         )}
       </div>
 
-      <div className={styles.row_direction}>
-        <div className={styles.dropdown}>
-          <label className={styles.bold}>Select Status:</label>
-          <Dropdown
-            placeholder="Select Status"
-            fluid
-            selection
-            options={allStatus.map((status) => ({
-              text: status,
-              value: status
-            }))}
-            onChange={(_, data) => {
-              setStatus(data.value as Status);
-            }}
-          />
+      <div className={styles.listsContainer}>
+        <div className={styles.listContainer}>
+          <div className={styles.rowDirection}>
+            <div className={styles.dropdown}>
+              <label className={styles.bold}>Select Status:</label>
+              <Dropdown
+                placeholder="Select Status"
+                fluid
+                selection
+                value={status || ''}
+                options={ALL_STATUS.map((status) => ({
+                  text: status,
+                  value: status
+                }))}
+                onChange={(_, data) => {
+                  setStatus(data.value as Status);
+                }}
+              />
+            </div>
+
+            {status && (
+              <div className={styles.inline}>
+                <Button
+                  onClick={() => {
+                    setStatus(undefined);
+                  }}
+                >
+                  View All
+                </Button>
+              </div>
+            )}
+          </div>
         </div>
 
-        {status && (
-          <div className={styles.inline}>
-            <Button
-              onClick={() => {
-                setStatus(undefined);
-                fullReset();
-              }}
-            >
-              View All
-            </Button>
-          </div>
-        )}
-      </div>
-
-      <div className={styles.listContainer}>
         {status ? (
-          <>
+          <div className={styles.listContainer}>
             <h2 className={styles.memberTitle}>
               Members {status.charAt(0).toUpperCase() + status.slice(1)}
             </h2>
             <AttendanceDisplay status={status as Status} teamEvent={teamEvent} />
-          </>
+          </div>
         ) : (
           <>
-            <div className={styles.listsContainer}>
-              <div className={styles.listContainer}>
-                <h2 className={styles.memberTitle}>Members Pending</h2>
-                <AttendanceDisplay status={'pending' as Status} teamEvent={teamEvent} />
-              </div>
+            <div className={styles.listContainer}>
+              <h2 className={styles.memberTitle}>Members Pending</h2>
+              <AttendanceDisplay status={'pending' as Status} teamEvent={teamEvent} />
+            </div>
 
-              <div className={styles.listContainer}>
-                <h2 className={styles.memberTitle}>Members Approved</h2>
-                <AttendanceDisplay status={'approved' as Status} teamEvent={teamEvent} />
-                <h2 className={styles.memberTitle}>Members Rejected</h2>
-                <AttendanceDisplay status={'rejected' as Status} teamEvent={teamEvent} />
-              </div>
+            <div className={styles.listContainer}>
+              <h2 className={styles.memberTitle}>Members Approved</h2>
+              <AttendanceDisplay status={'approved' as Status} teamEvent={teamEvent} />
+              <h2 className={styles.memberTitle}>Members Rejected</h2>
+              <AttendanceDisplay status={'rejected' as Status} teamEvent={teamEvent} />
             </div>
           </>
         )}

--- a/frontend/src/consts.ts
+++ b/frontend/src/consts.ts
@@ -2,3 +2,4 @@
 export const REQUIRED_COMMUNITY_CREDITS = 1;
 export const REQUIRED_MEMBER_TEC_CREDITS = 3;
 export const REQUIRED_LEAD_TEC_CREDITS = 6;
+export const ALL_STATUS: Status[] = ['approved', 'pending', 'rejected'];


### PR DESCRIPTION
### Summary

The admin page where the C&I lead can approve/reject TECs previously showed all submission statuses on one page, which caused inconvenient scrolling when there were many submissions. There is now a dropdown menu that can filter through each status and also go back to showing all statuses, if needed.

### Notion/Figma Link

https://www.notion.so/Admin-TEC-Filter-by-status-04f238712c8245689253cfc53b8d065c?pvs=4

### Test Plan

I checked that only TEC submissions of the selected status are shown, the "View All" button only appears when there is a status selected, and approving/rejecting a request will stay on the same selected status when the process is complete.

![Screenshot 2024-02-27 at 12 30 44 PM](https://github.com/cornell-dti/idol/assets/125151386/0cea0088-72ec-4722-8451-882fec74d992)

![Screenshot 2024-02-27 at 12 39 36 PM](https://github.com/cornell-dti/idol/assets/125151386/99749a13-cc5d-4103-8e9f-80cff66b74c3)