### PR TITLE
Refactor isCommunity field

### DIFF
--- a/backend/src/dao/TeamEventsDao.ts
+++ b/backend/src/dao/TeamEventsDao.ts
@@ -79,7 +79,7 @@ export default class TeamEventsDao {
   /* Returns all team event information details through 'TeamEventInfo' objects */
   static async getAllTeamEventInfo(): Promise<TeamEventInfo[]> {
     const docRefs = await teamEventsCollection
-      .select('name', 'date', 'numCredits', 'hasHours', 'uuid')
+      .select('name', 'date', 'numCredits', 'hasHours', 'uuid', 'isInitiativeEvent')
       .get();
     return docRefs.docs.map((doc) => doc.data() as TeamEventInfo);
   }

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -86,7 +86,7 @@ export const fakeTeamEvent = (): TeamEvent => {
     requests: [fakeTeamEventAttendance()],
     attendees: [],
     uuid: faker.datatype.uuid(),
-    isCommunity: getRandomBoolean()
+    isInitiativeEvent: getRandomBoolean()
   };
   return TE;
 };

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -98,7 +98,8 @@ interface TeamEventInfo {
   readonly numCredits: string;
   readonly hasHours: boolean;
   readonly uuid: string;
-  readonly isCommunity: boolean;
+  readonly isCommunity?: boolean;
+  readonly isInitiativeEvent: boolean;
 }
 
 interface TeamEvent extends TeamEventInfo {

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -16,7 +16,7 @@ const calculateMemberCreditsForEvent = (
   event: TeamEvent,
   isInitiativeEvent: boolean
 ): number =>
-  isInitiativeEvent && !event.isCommunity
+  isInitiativeEvent && !event.isInitiativeEvent
     ? 0
     : event.requests
         .filter((req) => req.status === 'approved')
@@ -104,7 +104,7 @@ const TeamEventDashboard: React.FC = () => {
                 0
               );
               const initiativeCredits = teamEvents.reduce(
-                (val, event) => calculateInitiativeCreditsForEvent(member, event),
+                (val, event) => val + calculateInitiativeCreditsForEvent(member, event),
                 0
               );
               const totalCreditsMet =

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -16,7 +16,7 @@ const defaultTeamEvent: TeamEvent = {
   hasHours: false,
   requests: [],
   uuid: '',
-  isCommunity: false
+  isInitiativeEvent: false
 };
 
 type AttendanceDisplayProps = {
@@ -130,7 +130,7 @@ const TeamEventDetails: React.FC = () => {
         <h3 className={styles.eventDetails}>Has Hours: {teamEvent.hasHours ? 'yes' : 'no'}</h3>
         {INITIATIVE_EVENTS && (
           <h3 className={styles.eventDetails}>
-            Initiative Event: {teamEvent.isCommunity ? 'Yes' : 'No'}
+            Initiative Event: {teamEvent.isInitiativeEvent ? 'Yes' : 'No'}
           </h3>
         )}
       </div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventForm.tsx
@@ -19,7 +19,9 @@ const TeamEventForm = (props: Props): JSX.Element => {
   const [teamEventDate, setTeamEventDate] = useState(teamEvent?.date || '');
   const [teamEventCreditNum, setTeamEventCreditNum] = useState(teamEvent?.numCredits || '');
   const [teamEventHasHours, setTeamEventHasHours] = useState(teamEvent?.hasHours || false);
-  const [isCommunity, setIsCommunity] = useState<boolean>(teamEvent?.isCommunity || false);
+  const [isInitiativeEvent, setisInitiativeEvent] = useState<boolean>(
+    teamEvent?.isInitiativeEvent || false
+  );
 
   const submitTeamEvent = () => {
     if (!teamEventName) {
@@ -53,7 +55,8 @@ const TeamEventForm = (props: Props): JSX.Element => {
         date: teamEventDate,
         numCredits: teamEventCreditNum,
         hasHours: teamEventHasHours,
-        isCommunity
+        isCommunity: isInitiativeEvent,
+        isInitiativeEvent
       };
       editTeamEvent(editedTeamEvent);
       Emitters.generalSuccess.emit({
@@ -67,7 +70,7 @@ const TeamEventForm = (props: Props): JSX.Element => {
         date: teamEventDate,
         numCredits: teamEventCreditNum,
         hasHours: teamEventHasHours,
-        isCommunity
+        isInitiativeEvent
       };
       TeamEventsAPI.createTeamEventForm(newTeamEventInfo).then((val) => {
         if (val.error) {
@@ -165,16 +168,16 @@ const TeamEventForm = (props: Props): JSX.Element => {
               <Radio
                 label="Yes"
                 value="Yes"
-                checked={isCommunity}
-                onChange={() => setIsCommunity(true)}
+                checked={isInitiativeEvent}
+                onChange={() => setisInitiativeEvent(true)}
               />
             </Form.Field>
             <Form.Field>
               <Radio
                 label="No"
                 value="No"
-                checked={!isCommunity}
-                onChange={() => setIsCommunity(false)}
+                checked={!isInitiativeEvent}
+                onChange={() => setisInitiativeEvent(false)}
               />
             </Form.Field>
           </Form.Group>

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -40,7 +40,7 @@ const TeamEventsDisplay: React.FC<TeamEventsDisplayProps> = ({ isLoading, teamEv
                     </Card.Meta>
                     {INITIATIVE_EVENTS && (
                       <Card.Meta>
-                        Initiative Event: {teamEvent.isCommunity ? 'Yes' : 'No'}
+                        Initiative Event: {teamEvent.isInitiativeEvent ? 'Yes' : 'No'}
                       </Card.Meta>
                     )}
                   </Card.Content>

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -126,7 +126,9 @@ const TeamEventCreditForm: React.FC = () => {
                       <div className={styles.flex_space_center}>
                         <div className={styles.flex_start}>{event.name}</div>
                         <div className={styles.flex_end}>
-                          {INITIATIVE_EVENTS && event.isCommunity && <Label content="initiative" />}
+                          {INITIATIVE_EVENTS && event.isInitiativeEvent && (
+                            <Label content="initiative" />
+                          )}
                           <Label
                             content={`${new Date(event.date).toLocaleDateString('en-us', {
                               month: 'short',

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
@@ -72,7 +72,7 @@ const TeamEventCreditDashboard = (props: {
         ? Number(event.numCredits) * getHoursAttended(attendance)
         : Number(event.numCredits);
       approvedCredits += currCredits;
-      approvedInitiativeCredits += event.isCommunity ? currCredits : 0;
+      approvedInitiativeCredits += event.isInitiativeEvent ? currCredits : 0;
     }
   });
 
@@ -134,7 +134,9 @@ const TeamEventCreditDashboard = (props: {
                     )}
                   </Card.Meta>
                   {INITIATIVE_EVENTS && (
-                    <Card.Meta>Initiative Event: {teamEvent.isCommunity ? 'Yes' : 'No'}</Card.Meta>
+                    <Card.Meta>
+                      Initiative Event: {teamEvent.isInitiativeEvent ? 'Yes' : 'No'}
+                    </Card.Meta>
                   )}
                 </Card.Content>
               </Card>


### PR DESCRIPTION
### Summary <!-- Required -->

- Change most (see notes below) references of `isCommunity` field to `isInitiativeEvent` in FE
- Fix bug with displaying total initiative event credits in Dashboard
- Fix bug with not retrieving `isInitiativeEvent` when requesting all team event info

This pull request is the second step towards implementing support for initiative TEC

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/TEC-Add-support-for-Initiative-tec-279c8cac37124630b2b7d7f383c70e55

### Test Plan <!-- Required -->
![image](https://github.com/cornell-dti/idol/assets/144409850/2ce230e6-b1cc-4c6d-af25-89e44a16a66b)
![image](https://github.com/cornell-dti/idol/assets/144409850/39267c72-7bdd-4815-a030-5b3f56c0d15b)

### Notes <!-- Optional -->

- `isCommunity` is still referenced in some files to be safe, namely in `index.d.ts` and `TeamEventForm.tsx` when editing an event. In the latter case, `isCommunity` is updated to the value of `isInitiativeEvent`.

### Breaking Changes <!-- Optional -->
- Database schema change (anything that changes Firestore collection structure)
