### PR TITLE
Add documentation to Members DAO

### DIFF
--- a/backend/src/dao/MembersDao.ts
+++ b/backend/src/dao/MembersDao.ts
@@ -97,7 +97,7 @@ export default class MembersDao extends BaseDao<IdolMember, IdolMember> {
   }
 
   /**
-   * Gets all teams based on the subteam and formersubteam(s) each member is on, since teams do not have 
+   * Gets all teams based on the subteam and formersubteam(s) each member is on, since teams do not have
    * a collection in the database (teams are aggregated data from the members collection).
    * @returns A promise that resolves to an array of all Team objects.
    */
@@ -131,7 +131,7 @@ export default class MembersDao extends BaseDao<IdolMember, IdolMember> {
   }
 
   /**
-   * Gets a specific team by searching through each IDOL member and saving each member of the team. 
+   * Gets a specific team by searching through each IDOL member and saving each member of the team.
    * @param id The name of the team
    * @returns A promise that resolves to the Team object with the specified name.
    */

--- a/backend/src/dao/MembersDao.ts
+++ b/backend/src/dao/MembersDao.ts
@@ -99,7 +99,7 @@ export default class MembersDao extends BaseDao<IdolMember, IdolMember> {
   /**
    * Gets all teams based on the subteam and formersubteam(s) each member is on, since teams do not have
    * a collection in the database (teams are aggregated data from the members collection).
-   * @returns A promise that resolves to an array of all Team objects.
+   * @returns A promise that resolves to an array of Team objects.
    */
   static async getAllTeams(): Promise<Team[]> {
     const allMembers = await MembersDao.getAllMembers(false);
@@ -132,8 +132,8 @@ export default class MembersDao extends BaseDao<IdolMember, IdolMember> {
 
   /**
    * Gets a specific team by searching through each IDOL member and saving each member of the team.
-   * @param id The name of the team
-   * @returns A promise that resolves to the Team object with the specified name.
+   * @param id - The name of the team
+   * @returns A promise that resolves to the Team object with the specified name, or null if the team has no members.
    */
   static async getTeam(id: string): Promise<Team | null> {
     const allMembers = await MembersDao.getAllMembers(false);

--- a/backend/src/dao/MembersDao.ts
+++ b/backend/src/dao/MembersDao.ts
@@ -96,6 +96,11 @@ export default class MembersDao extends BaseDao<IdolMember, IdolMember> {
     await batch.commit();
   }
 
+  /**
+   * Gets all teams based on the subteam and formersubteam(s) each member is on, since teams do not have 
+   * a collection in the database (teams are aggregated data from the members collection).
+   * @returns A promise that resolves to an array of all Team objects.
+   */
   static async getAllTeams(): Promise<Team[]> {
     const allMembers = await MembersDao.getAllMembers(false);
     const teamsMap = new Map<string, Team>();
@@ -125,6 +130,11 @@ export default class MembersDao extends BaseDao<IdolMember, IdolMember> {
     return Array.from(teamsMap.values());
   }
 
+  /**
+   * Gets a specific team by searching through each IDOL member and saving each member of the team. 
+   * @param id The name of the team
+   * @returns A promise that resolves to the Team object with the specified name.
+   */
   static async getTeam(id: string): Promise<Team | null> {
     const allMembers = await MembersDao.getAllMembers(false);
     const team: Team = { uuid: id, name: id, leaders: [], members: [], formerMembers: [] };


### PR DESCRIPTION
Added documentation to `getAllTeams` and `getTeam` in `MembersDao.ts`. It wasn't immediately clear why these functions are in the Members DAO, so there is now a short clarification (based on the explanation of the `Team` data type in #581).