### PR TITLE
Create export to CSV feature for TEC dashboard

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
@@ -1,3 +1,14 @@
+.headerContainer {
+  display: flex;
+  justify-content: right;
+}
+
+.csvButton {
+  padding-left: 30%;
+  padding-right: 5%;
+  padding-bottom: 0.5em;
+}
+
 .dashboardContainer {
   margin: 3%;
   overflow-x: scroll;

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Table, Header, Loader, Button, Icon, Checkbox } from 'semantic-ui-react';
+import { ExportToCsv, Options } from 'export-to-csv';
 import { useMembers } from '../../Common/FirestoreDataProvider';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import {
@@ -10,7 +11,6 @@ import {
 } from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
-import { ExportToCsv, Options } from 'export-to-csv';
 
 const calculateMemberCreditsForEvent = (
   member: IdolMember,
@@ -64,12 +64,10 @@ const TeamEventDashboard: React.FC = () => {
       );
 
       const data = teamEvents.reduce(
-        (prev, event) => {
-          return {
-            ...prev,
-            [event.name]: calculateTotalCreditsForEvent(member, event)
-          };
-        },
+        (prev, event) => ({
+          ...prev,
+          [event.name]: calculateTotalCreditsForEvent(member, event)
+        }),
         {
           Name: `${member.firstName} ${member.lastName}`,
           NetID: `${member.netid}`,

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -36,6 +36,17 @@ const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): nu
 const calculateInitiativeCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, true);
 
+const getTotalCredits = (member: IdolMember, teamEvents: TeamEvent[]): number => {
+  return teamEvents.reduce((val, event) => val + calculateTotalCreditsForEvent(member, event), 0);
+};
+
+const getInitiativeCredits = (member: IdolMember, teamEvents: TeamEvent[]): number => {
+  return teamEvents.reduce(
+    (val, event) => val + calculateInitiativeCreditsForEvent(member, event),
+    0
+  );
+};
+
 const TeamEventDashboard: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -54,14 +65,8 @@ const TeamEventDashboard: React.FC = () => {
 
   const handleExportToCsv = () => {
     const csvData = allMembers.map((member) => {
-      const totalCredits = teamEvents.reduce(
-        (val, event) => val + calculateTotalCreditsForEvent(member, event),
-        0
-      );
-      const initiativeCredits = teamEvents.reduce(
-        (val, event) => val + calculateInitiativeCreditsForEvent(member, event),
-        0
-      );
+      const totalCredits = getTotalCredits(member, teamEvents);
+      const initiativeCredits = getInitiativeCredits(member, teamEvents);
 
       const data = teamEvents.reduce(
         (prev, event) => ({
@@ -101,7 +106,7 @@ const TeamEventDashboard: React.FC = () => {
       <div className={styles.headerContainer}>
         <Header as="h1">Team Event Dashboard</Header>
         <div className={styles.csvButton}>
-          <Button onClick={() => handleExportToCsv()}>Export to CSV</Button>
+          <Button onClick={handleExportToCsv}>Export to CSV</Button>
         </div>
       </div>
       <div className={styles.tableContainer}>
@@ -147,14 +152,8 @@ const TeamEventDashboard: React.FC = () => {
           </Table.Header>
           <Table.Body>
             {allMembers.map((member) => {
-              const totalCredits = teamEvents.reduce(
-                (val, event) => val + calculateTotalCreditsForEvent(member, event),
-                0
-              );
-              const initiativeCredits = teamEvents.reduce(
-                (val, event) => val + calculateInitiativeCreditsForEvent(member, event),
-                0
-              );
+              const totalCredits = getTotalCredits(member, teamEvents);
+              const initiativeCredits = getInitiativeCredits(member, teamEvents);
               const totalCreditsMet =
                 totalCredits >=
                 (member.role === 'lead' ? REQUIRED_LEAD_TEC_CREDITS : REQUIRED_MEMBER_TEC_CREDITS);

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
+import { ExportToCsv, Options } from 'export-to-csv';
 
 const calculateMemberCreditsForEvent = (
   member: IdolMember,
@@ -51,11 +52,60 @@ const TeamEventDashboard: React.FC = () => {
 
   if (isLoading) return <Loader active>Fetching team event data...</Loader>;
 
+  const handleExportToCsv = () => {
+    const csvData = allMembers.map((member) => {
+      const totalCredits = teamEvents.reduce(
+        (val, event) => val + calculateTotalCreditsForEvent(member, event),
+        0
+      );
+      const initiativeCredits = teamEvents.reduce(
+        (val, event) => val + calculateInitiativeCreditsForEvent(member, event),
+        0
+      );
+
+      const data = teamEvents.reduce(
+        (prev, event) => {
+          return {
+            ...prev,
+            [event.name]: calculateTotalCreditsForEvent(member, event)
+          };
+        },
+        {
+          Name: `${member.firstName} ${member.lastName}`,
+          NetID: `${member.netid}`,
+          Total: totalCredits,
+          Initiative: initiativeCredits
+        }
+      );
+
+      return data;
+    });
+
+    const options: Options = {
+      filename: `TEC_Dashboard`,
+      fieldSeparator: ',',
+      quoteStrings: '"',
+      decimalSeparator: '.',
+      showLabels: true,
+      showTitle: true,
+      title: `TEC Dashboard`,
+      useTextFile: false,
+      useBom: true,
+      useKeysAsHeaders: true
+    };
+
+    const csvExporter = new ExportToCsv(options);
+    csvExporter.generateCsv(csvData);
+  };
+
   return (
     <div className={styles.dashboardContainer}>
-      <Header as="h1" textAlign="center">
-        Team Event Dashboard
-      </Header>
+      <div className={styles.headerContainer}>
+        <Header as="h1">Team Event Dashboard</Header>
+        <div className={styles.csvButton}>
+          <Button onClick={() => handleExportToCsv()}>Export to CSV</Button>
+        </div>
+      </div>
       <div className={styles.tableContainer}>
         <Table celled selectable striped className={styles.dashboardTable}>
           <Table.Header>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -36,16 +36,10 @@ const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): nu
 const calculateInitiativeCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, true);
 
-const getTotalCredits = (member: IdolMember, teamEvents: TeamEvent[]): number => {
-  return teamEvents.reduce((val, event) => val + calculateTotalCreditsForEvent(member, event), 0);
-};
-
-const getInitiativeCredits = (member: IdolMember, teamEvents: TeamEvent[]): number => {
-  return teamEvents.reduce(
-    (val, event) => val + calculateInitiativeCreditsForEvent(member, event),
-    0
-  );
-};
+const getTotalCredits = (member: IdolMember, teamEvents: TeamEvent[]): number =>
+  teamEvents.reduce((val, event) => val + calculateTotalCreditsForEvent(member, event), 0);
+const getInitiativeCredits = (member: IdolMember, teamEvents: TeamEvent[]): number =>
+  teamEvents.reduce((val, event) => val + calculateInitiativeCreditsForEvent(member, event), 0);
 
 const TeamEventDashboard: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);


### PR DESCRIPTION
### Summary

The leads needed a way to export the TEC information for each member to a CSV format. The TEC dashboard page now has the ability to export the entire table to a CSV format. The exported file will contain each member's name, netID, total TECs, initiative TECs, and the corresponding TECs they have from each team event.

For each member in `allMembers`, the `totalCredits` and `initiativeCredits` are calculated and added to the CSV data. Also, the number of credits they have for each team event in `teamEvents`  is added to the CSV data. After configuring the CSV format, the CSV exporter generates the file based on the data.

### Notion/Figma Link

https://www.notion.so/TEC-Export-to-csv-30f17a9b406243f0a24ec297626c1025?pvs=4

### Test Plan 

I checked to see that the data in the exported CSV file aligns with what is shown in the TEC dashboard page. 

<img width="1483" alt="Screenshot 2024-03-23 at 8 01 14 PM" src="https://github.com/cornell-dti/idol/assets/125151386/f586a29d-d069-4ec4-a3ba-e7da689f6fdc">

<img width="1483" alt="Screenshot 2024-03-23 at 8 01 27 PM" src="https://github.com/cornell-dti/idol/assets/125151386/f9373125-3500-40dd-8f76-3c5037807b4a">

### Notes

Depending on if the C&I lead wants this, there could be an additional column that shows if a member has met the credit requirement.