### PR TITLE
Bump prettier to v3.2.5

### DIFF
--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -134,9 +134,7 @@ export const sendTECReminder = async (
 ): Promise<AxiosResponse> => {
   const subject = 'TEC Reminder';
   const allEvents = await Promise.all(
-    (
-      await TeamEventsDao.getAllTeamEvents()
-    ).map(async (event) => ({
+    (await TeamEventsDao.getAllTeamEvents()).map(async (event) => ({
       ...event,
       requests: await teamEventAttendanceDao.getTeamEventAttendanceByEventId(event.uuid)
     }))

--- a/backend/src/API/teamEventsAPI.ts
+++ b/backend/src/API/teamEventsAPI.ts
@@ -114,9 +114,8 @@ export const requestTeamEventCredit = async (
     );
   }
   const updatedteamEvent = { ...request, status: 'pending' as Status };
-  const teamEventAttendance = await teamEventAttendanceDao.createTeamEventAttendance(
-    updatedteamEvent
-  );
+  const teamEventAttendance =
+    await teamEventAttendanceDao.createTeamEventAttendance(updatedteamEvent);
   return teamEventAttendance;
 };
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -97,8 +97,8 @@ export const enforceSession = true;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd
-  ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
-  : [/http:\/\/localhost:3000/];
+    ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
+    : [/http:\/\/localhost:3000/];
 
 // Middleware
 app.use(

--- a/backend/src/utils/errors.ts
+++ b/backend/src/utils/errors.ts
@@ -1,7 +1,10 @@
 /* eslint-disable max-classes-per-file */
 
 export class HandlerError extends Error {
-  constructor(public readonly errorCode: number, public readonly reason: string) {
+  constructor(
+    public readonly errorCode: number,
+    public readonly reason: string
+  ) {
     super();
   }
 }

--- a/dti-website-redesign/src/pages/App.css
+++ b/dti-website-redesign/src/pages/App.css
@@ -2,8 +2,18 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
-    Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    Fira Sans,
+    Droid Sans,
+    Helvetica Neue,
+    sans-serif;
   line-height: 1.6;
   font-size: 18px;
 }

--- a/dti-website/src/components/ProjectGoTo.tsx
+++ b/dti-website/src/components/ProjectGoTo.tsx
@@ -42,18 +42,21 @@ export default function ProjectGoTo({ project, className }: Props): JSX.Element 
               </Button>
             </Col>
           )}
-          {project.android_github && !project.appstore && !project.playstore && !project.website && (
-            <Col className="connect-icon-container col-auto">
-              <Button
-                variant="secondary"
-                className="align-content-center"
-                href={project.android_github}
-              >
-                <GitHub className="connect-icon connect-icon-blank" />
-                <span className="connect-text">Android</span>
-              </Button>
-            </Col>
-          )}
+          {project.android_github &&
+            !project.appstore &&
+            !project.playstore &&
+            !project.website && (
+              <Col className="connect-icon-container col-auto">
+                <Button
+                  variant="secondary"
+                  className="align-content-center"
+                  href={project.android_github}
+                >
+                  <GitHub className="connect-icon connect-icon-blank" />
+                  <span className="connect-text">Android</span>
+                </Button>
+              </Col>
+            )}
           {project.github && !project.appstore && !project.playstore && !project.website && (
             <Col className="connect-icon-container col-auto">
               <Button variant="secondary" className="align-content-center" href={project.github}>

--- a/frontend/src/components/Games/DTI48/dti48-upgrade-chain.test.ts
+++ b/frontend/src/components/Games/DTI48/dti48-upgrade-chain.test.ts
@@ -33,7 +33,7 @@ const designLeads = DESIGN_LEAD_NETIDS.map(
       netid,
       role: 'lead',
       subteams: ['leads', 'design-leads']
-    } as const)
+    }) as const
 );
 
 const devLeads = DEV_LEAD_NETIDS.map(
@@ -42,7 +42,7 @@ const devLeads = DEV_LEAD_NETIDS.map(
       netid,
       role: 'lead',
       subteams: ['leads', 'dev-leads']
-    } as const)
+    }) as const
 );
 
 const tpms = [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.2.4",
     "lint-staged": "^11.2.0",
-    "prettier": "^2.4.1",
+    "prettier": "^3.2.5",
     "typescript": "^5.2.2"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14750,15 +14750,15 @@ prettier-plugin-tailwindcss@^0.5.4:
   resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.6.tgz#8e511857a49bf127f078985f52b04a70e8e92285"
   integrity sha512-2Xgb+GQlkPAUCFi3sV+NOYcSI5XgduvDBL2Zt/hwJudeKXkyvRS65c38SB0yb9UB40+1rL83I6m0RtlOQ8eHdg==
 
-prettier@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
-
 prettier@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
   integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+
+prettier@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
+  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
 
 pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.2.4:
   version "27.2.4"


### PR DESCRIPTION
### Summary <!-- Required -->

This pr upgrades Prettier from version 2.4.1 to 3.2.5

<!-- Optional: If adding/updating endpoints, update the backend api specification (openapi.yaml) -->

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->