### PR TITLE
add dev advisor role

### DIFF
--- a/common-types/constants.js
+++ b/common-types/constants.js
@@ -1,3 +1,3 @@
-const ALL_ROLES = ['lead', 'tpm', 'pm', 'developer', 'designer', 'business'];
+const ALL_ROLES = ['lead', 'tpm', 'pm', 'developer', 'designer', 'business', 'dev-advisor'];
 
 export default ALL_ROLES;

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -1,7 +1,7 @@
 /** The common types required by more than one workspace. */
 
 /** All possible roles for a DTI member */
-type Role = 'lead' | 'tpm' | 'pm' | 'developer' | 'designer' | 'business';
+type Role = 'lead' | 'tpm' | 'pm' | 'developer' | 'designer' | 'business' | 'dev-advisor';
 
 /** The corresponding more human readable role description of all roles. */
 type RoleDescription =
@@ -10,7 +10,8 @@ type RoleDescription =
   | 'Product Manager'
   | 'Developer'
   | 'Designer'
-  | 'Business Analyst';
+  | 'Business Analyst'
+  | 'Dev Advisor';
 
 /** The data type used by IDOL to represent a DTI member. */
 interface IdolMember {

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -13,6 +13,8 @@ const DevPortfolioForm: React.FC = () => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const userInfo = useSelf()!;
   const isTpm = userInfo.role === 'tpm';
+  const isDevAdvisor = userInfo.role === 'dev-advisor';
+  console.log(userInfo.role)
 
   const [devPortfolio, setDevPortfolio] = useState<DevPortfolio | undefined>(undefined);
   const [devPortfolios, setDevPortfolios] = useState<DevPortfolio[]>([]);
@@ -86,7 +88,7 @@ const DevPortfolioForm: React.FC = () => {
       ? devPortfolio.lateDeadline
       : devPortfolio?.deadline;
 
-    if (!isTpm && otherEmpty && (openedEmpty || reviewedEmpty)) {
+    if (!isDevAdvisor && otherEmpty && (openedEmpty || reviewedEmpty)) {
       Emitters.generalError.emit({
         headerMsg: 'No opened or reviewed PR url submitted',
         contentMsg: 'Please paste a link to a opened and reviewed PR!'
@@ -110,7 +112,7 @@ const DevPortfolioForm: React.FC = () => {
         headerMsg: 'Documentation Empty',
         contentMsg: 'Please write something for the documentation section of the assignment.'
       });
-    } else if (!isTpm && !otherEmpty && textEmpty) {
+    } else if (!isDevAdvisor && !otherEmpty && textEmpty) {
       Emitters.generalError.emit({
         headerMsg: 'Explanation Empty',
         contentMsg: 'Please write an explanation for your other PR submission.'
@@ -224,7 +226,7 @@ const DevPortfolioForm: React.FC = () => {
             placeholder="Opened PR"
             label="Opened Pull Request Github Link:"
             openOther={openOther}
-            isTpm={isTpm}
+            isRequired={!isDevAdvisor}
           />
           <PRInputs
             prs={reviewPRs}
@@ -232,7 +234,7 @@ const DevPortfolioForm: React.FC = () => {
             placeholder="Reviewed PR"
             label="Reviewed Pull Request Github Link:"
             openOther={openOther}
-            isTpm={isTpm}
+            isRequired={!isDevAdvisor}
           />
           {isTpm ? (
             <></>
@@ -302,14 +304,14 @@ const PRInputs = ({
   label,
   placeholder,
   openOther,
-  isTpm
+  isRequired
 }: {
   prs: string[];
   setPRs: React.Dispatch<React.SetStateAction<string[]>>;
   label: string;
   placeholder: string;
   openOther: boolean;
-  isTpm: boolean;
+  isRequired: boolean;
 }) => {
   const keyDownHandler = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.code === 'Enter') {
@@ -319,7 +321,7 @@ const PRInputs = ({
   return (
     <div className={styles.inline}>
       <label className={styles.bold}>
-        {label} {!isTpm && !openOther && <span className={styles.red_color}>*</span>}
+        {label} {isRequired && !openOther && <span className={styles.red_color}>*</span>}
       </label>
       {prs.map((pr, index) => (
         <div className={styles.prInputContainer} key={index}>

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -14,7 +14,6 @@ const DevPortfolioForm: React.FC = () => {
   const userInfo = useSelf()!;
   const isTpm = userInfo.role === 'tpm';
   const isDevAdvisor = userInfo.role === 'dev-advisor';
-  console.log(userInfo.role)
 
   const [devPortfolio, setDevPortfolio] = useState<DevPortfolio | undefined>(undefined);
   const [devPortfolios, setDevPortfolios] = useState<DevPortfolio[]>([]);

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -16,6 +16,8 @@ export const getRoleDescriptionFromRoleID = (role: Role): RoleDescription => {
       return 'Designer';
     case 'business':
       return 'Business Analyst';
+    case 'dev-advisor':
+      return 'Dev Advisor';
     default:
       throw new Error();
   }


### PR DESCRIPTION
### Summary <!-- Required -->

- Adds `dev-advisor` as another role for IDOL members
- Dev advisors only need to submit documentation for dev portfolio
- Also changed dev portfolio requirements to reflect the new TPM expectations (opened PR is now mandatory)
- Changed `PRInputs` prop from `isTpm` to `isRequired`

Dev Advisor
<img width="750" alt="image" src="https://github.com/cornell-dti/idol/assets/69322572/dfebf918-0f18-4f20-8b1c-17aa20871bc7">
<img width="750" alt="image" src="https://github.com/cornell-dti/idol/assets/69322572/32ed94d0-eeaf-4abc-b259-38a7c71f6502">

TPM
<img width="750" alt="image" src="https://github.com/cornell-dti/idol/assets/69322572/fa5ae82b-e1cf-482c-8057-6b5b7d69e5f1">


<!-- Optional: If adding/updating endpoints, update the backend api specification (openapi.yaml) -->

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

- Changed myself to dev advisor and made sure dev portfolio submission is blocked if no documentation is provided
- Changed myself to tpm and made sure dev portfolio submission is blocked if no opened PR was provided 

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
