### PR TITLE
Add test file for TeamEventAttendanceDao

### DIFF
--- a/backend/tests/TeamEventAttendanceDao.test.ts
+++ b/backend/tests/TeamEventAttendanceDao.test.ts
@@ -1,0 +1,42 @@
+import TeamEventAttendanceDao from '../src/dao/TeamEventAttendanceDao';
+import { teamEventAttendanceCollection, memberCollection } from '../src/firebase';
+import { fakeTeamEventAttendance, fakeIdolMember } from './data/createData';
+
+const teamEventAttendanceDao = new TeamEventAttendanceDao();
+
+const mockEmail = 'test@cornell.edu';
+const mockMember = { ...fakeIdolMember(), email: mockEmail };
+const mockTEA = { ...fakeTeamEventAttendance(), member: mockMember, uuid: 'testUuid' };
+
+beforeAll(async () => {
+  await teamEventAttendanceDao.createTeamEventAttendance(mockTEA);
+  await memberCollection.doc(mockEmail).set(mockMember);
+});
+
+afterAll(async () => {
+  await teamEventAttendanceCollection.doc(mockTEA.uuid).delete();
+  await memberCollection.doc(mockEmail).delete();
+});
+
+test('Get all instances', () =>
+  teamEventAttendanceDao.getAllTeamEventAttendance().then((allAttendances) => {
+    expect(allAttendances.some((attendance) => attendance === mockTEA));
+  }));
+
+test('Get instance by member', () =>
+  teamEventAttendanceDao.getTeamEventAttendanceByUser(mockMember).then((attendances) => {
+    expect(attendances.some((attendance) => attendance === mockTEA));
+    expect(attendances[0].status === 'pending');
+  }));
+
+test('Get instance by uuid', () =>
+  teamEventAttendanceDao.getTeamEventAttendance('testUUid').then((attendance) => {
+    expect(attendance === mockTEA);
+  }));
+
+test('Delete instance', () => {
+  teamEventAttendanceDao.deleteTeamEventAttendance(mockTEA.uuid);
+  teamEventAttendanceDao.getAllTeamEventAttendance().then((allAttendances) => {
+    expect(allAttendances.every((attendance) => attendance !== mockTEA));
+  });
+});

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -70,7 +70,8 @@ export const fakeTeamEventAttendance = (): TeamEventAttendance => {
     hoursAttended: getRandomInt(1, 5),
     image: '',
     eventUuid: faker.datatype.uuid(),
-    pending: true,
+    reason: faker.lorem.word(),
+    status: 'pending' as Status,
     uuid: faker.datatype.uuid()
   };
   return TEA;


### PR DESCRIPTION
### Summary <!-- Required -->

I added unit testing for `TeamEventAttendanceDao` based on the previous tests files in the same directory. I also edited the random TeamEventAttendance generation to agree with the removal of pending and other field changes.

### Notes <!-- Optional -->
* In another PR, this directory should be cleaned up. Several files have type errors, and jest is not able to run the backend tests as a whole.
<!--- List any important or subtle points, future considerations, or other items of note. -->
