### PR TITLE
Member archive reminder cronjob

### DIFF
--- a/.github/workflows/idol-notifications.yml
+++ b/.github/workflows/idol-notifications.yml
@@ -61,18 +61,18 @@ jobs:
           OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
         run: yarn workspace backend send-tec-notifications
 
-member-archive-reminder:
-  if: contains(github.event.schedule, '0 14 20 1,8 *')
+  member-archive-reminder:
+    if: contains(github.event.schedule, '0 14 20 1,8 *')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_TOKEN }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
       - name: Use Yarn Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}

--- a/.github/workflows/idol-notifications.yml
+++ b/.github/workflows/idol-notifications.yml
@@ -1,11 +1,14 @@
 name: IDOL Notifications
 on:
   schedule:
-    # Runs script at 8AM UTC (6PM or 7PM ET) everyday. This hsould be an hour before pull-from-idol
+    # Runs at 8AM UTC (6PM or 7PM ET) everyday. This should be an hour before pull-from-idol
     - cron: '0 23 * * MON'
+    # Runs at 2PM UTC (9AM or 10AM ET) on 1/20 and 8/20 (before each semester starts)
+    - cron: '0 14 20 1,8 *'
 
 jobs:
   profile-update-notifications:
+    if: contains(github.event.schedule, '0 23 * * MON')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,6 +35,7 @@ jobs:
         run: yarn workspace backend send-profile-update-notifications
 
   tec-request-notification:
+    if: contains(github.event.schedule, '0 23 * * MON')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +52,7 @@ jobs:
           restore-keys: yarn-
       - name: Install
         run: yarn
-      - name: Profile update notifications
+      - name: TEC request notification
         env:
           FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
           FIREBASE_PRIVATE_KEY_ID: ${{ secrets.FIREBASE_PRIVATE_KEY_ID }}
@@ -56,3 +60,30 @@ jobs:
           OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
           OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
         run: yarn workspace backend send-tec-notifications
+
+member-archive-reminder:
+  if: contains(github.event.schedule, '0 14 20 1,8 *')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: .node-version
+      - name: Use Yarn Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+          restore-keys: yarn-
+      - name: Install
+        run: yarn
+      - name: Member archive reminder
+        env:
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          FIREBASE_PRIVATE_KEY_ID: ${{ secrets.FIREBASE_PRIVATE_KEY_ID }}
+          OAUTH_CLIENTID: ${{ secrets.OAUTH_CLIENTID}}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          OAUTH_REFRESH_TOKEN: ${{ secrets.OAUTH_REFRESH_TOKEN }}
+        run: yarn workspace backend send-member-archive-reminder

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "tsc": "tsc",
     "build": "tsc",
     "update-dev-db": "esr scripts/update-dev-db.ts",
+    "send-member-archive-reminder": "esr scripts/send-member-archive-reminder.ts",
     "send-profile-update-notifications": "esr scripts/send-profile-update-notifications.ts",
     "send-tec-notifications": "esr scripts/send-tec-notifications.ts",
     "backup-prod-db": "esr scripts/backup-prod-db.ts",

--- a/backend/scripts/send-member-archive-reminder.ts
+++ b/backend/scripts/send-member-archive-reminder.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-console */
+import admin from 'firebase-admin';
+import sendMail from './utils';
+import { configureAccount } from '../src/utils/firebase-utils';
+
+const serviceAcc = require('../resources/idol-b6c68-firebase-adminsdk-h4e6t-40e4bd5536.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(configureAccount(serviceAcc, 'prod')),
+  databaseURL: 'https://idol-b6c68.firebaseio.com',
+  storageBucket: 'gs://cornelldti-idol.appspot.com'
+});
+
+const db = admin.firestore();
+
+const EMAIL_SUBJECT = '[ACTION REQUIRED] Members Archive';
+const EMAIL_BODY =
+  'Hey there from the IDOL team!\n\nThis is a reminder to upload the CSV results from the returning members survey to archive members before this upcoming semester.\n\nThank you!';
+
+const main = async () => {
+  const opsLeadsEmails = (await db.collection('ops-leads').get()).docs.map((doc) => doc.id);
+  opsLeadsEmails.map((email) => console.log(email));
+  console.log('Sending email notification...');
+  try {
+    await Promise.all(opsLeadsEmails.map((email) => sendMail(email, EMAIL_SUBJECT, EMAIL_BODY)));
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+  console.log('Email notification successfully sent :)');
+};
+
+main();


### PR DESCRIPTION
### Summary

There will be a script made that archives members automatically each semester. This cronjob sends an email to the Ops Leads reminding them to upload the CSV from the returning members survey to archive members at the beginning of each semester.

### Notion/Figma Link

https://www.notion.so/Member-archive-script-0540cb5e7d0349c4921f344b1875387e?pvs=4

### Test Plan

Ran `yarn ts-node --transpile-only scripts/send-member-archive-reminder.ts` locally.

### Breaking Changes

Need to add an ops-leads collection with emails as the documents in the prod DB.
