### PR TITLE
Add ability to archive members

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 node_modules
 build
+dti-website
+dti-website-redesign

--- a/backend/src/API/memberAPI.ts
+++ b/backend/src/API/memberAPI.ts
@@ -3,6 +3,7 @@ import PermissionsManager from '../utils/permissionsManager';
 import { BadRequestError, PermissionError } from '../utils/errors';
 import { bucket } from '../firebase';
 import { getNetIDFromEmail, computeMembersDiff } from '../utils/memberUtil';
+import { generateArchive } from '../members-archive';
 
 const membersDao = new MembersDao();
 
@@ -159,4 +160,21 @@ export const reviewUserInformationChange = async (
     MembersDao.approveMemberInformationChanges(approved),
     MembersDao.revertMemberInformationChanges(rejected)
   ]);
+};
+
+/**
+ * Generates an archive of all IDOL members, separated into three categories: current, inactive, and alumni.
+ * @param user - the `IdolMember` submitting the request.
+ * @returns an object with the categories as the keys, each with value `NovaMember[]`.
+ */
+export const generateMemberArchive = async (
+  user: IdolMember
+): Promise<{ [key: string]: NovaMember[] }> => {
+  const canEditMembers = await PermissionsManager.canEditMembers(user);
+  if (!canEditMembers) {
+    throw new PermissionError(
+      `User with email: ${user.email} does not have permission to generate an archive!`
+    );
+  }
+  return generateArchive();
 };

--- a/backend/src/API/memberAPI.ts
+++ b/backend/src/API/memberAPI.ts
@@ -166,7 +166,7 @@ export const reviewUserInformationChange = async (
  * @param membershipChanges - an object with lists of NetIds corresponding to the status of IDOL members in the next semester.
  * @param user - the `IdolMember` submitting the request.
  * @param semesters - the number of previous semesters to look back, undefined if no limit.
- * @returns an object with the categories as the keys, each with value `NovaMember[]`.
+ * @returns an object with the categories as the keys, each with value `MemberProfile[]`.
  */
 export const generateMemberArchive = async (
   membershipChanges: { [key: string]: string[] },

--- a/backend/src/API/memberAPI.ts
+++ b/backend/src/API/memberAPI.ts
@@ -3,7 +3,6 @@ import PermissionsManager from '../utils/permissionsManager';
 import { BadRequestError, PermissionError } from '../utils/errors';
 import { bucket } from '../firebase';
 import { getNetIDFromEmail, computeMembersDiff } from '../utils/memberUtil';
-import { generateArchive } from '../members-archive';
 
 const membersDao = new MembersDao();
 
@@ -164,17 +163,21 @@ export const reviewUserInformationChange = async (
 
 /**
  * Generates an archive of all IDOL members, separated into three categories: current, inactive, and alumni.
+ * @param membershipChanges - an object with lists of NetIds corresponding to the status of IDOL members in the next semester.
  * @param user - the `IdolMember` submitting the request.
+ * @param semesters - the number of previous semesters to look back, undefined if no limit.
  * @returns an object with the categories as the keys, each with value `NovaMember[]`.
  */
 export const generateMemberArchive = async (
-  user: IdolMember
-): Promise<{ [key: string]: NovaMember[] }> => {
+  membershipChanges: { [key: string]: string[] },
+  user: IdolMember,
+  semesters: number | undefined
+): Promise<{ [key: string]: string[] }> => {
   const canEditMembers = await PermissionsManager.canEditMembers(user);
   if (!canEditMembers) {
     throw new PermissionError(
       `User with email: ${user.email} does not have permission to generate an archive!`
     );
   }
-  return generateArchive();
+  return MembersDao.generateArchive(membershipChanges, semesters);
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -229,8 +229,8 @@ loginCheckedPut('/memberDiffs', async (req, user) => ({
   member: await reviewUserInformationChange(req.body.approved, req.body.rejected, user)
 }));
 
-loginCheckedGet('/memberArchive', async (_, user) => ({
-  archive: await generateMemberArchive(user)
+loginCheckedPost('/member-archive', async (req, user) => ({
+  archive: await generateMemberArchive(req.body, user, req.query.semesters as number | undefined)
 }));
 
 // Teams

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -21,7 +21,8 @@ import {
   deleteMember,
   updateMember,
   getUserInformationDifference,
-  reviewUserInformationChange
+  reviewUserInformationChange,
+  generateMemberArchive
 } from './API/memberAPI';
 import { getMemberImage, setMemberImage, allMemberImages } from './API/imageAPI';
 import { allTeams, setTeam, deleteTeam } from './API/teamAPI';
@@ -226,6 +227,10 @@ loginCheckedGet('/memberDiffs', async (_, user) => ({
 }));
 loginCheckedPut('/memberDiffs', async (req, user) => ({
   member: await reviewUserInformationChange(req.body.approved, req.body.rejected, user)
+}));
+
+loginCheckedGet('/memberArchive', async (_, user) => ({
+  archive: await generateMemberArchive(user)
 }));
 
 // Teams

--- a/backend/src/members-archive/index.ts
+++ b/backend/src/members-archive/index.ts
@@ -2,6 +2,8 @@ import sp21 from './sp21.json';
 import fa21 from './fa21.json';
 import sp23 from './sp23.json';
 import fa23 from './fa23.json';
+import { allApprovedMembers } from '../API/memberAPI';
+import { allMemberImages } from '../API/imageAPI';
 
 export const archivedMembersBySemesters: Readonly<Record<string, readonly IdolMember[]>> = {
   'Spring 2021': sp21.members as unknown as readonly IdolMember[],
@@ -19,3 +21,38 @@ export const archivedMembersByEmail: Readonly<Record<string, IdolMember>> = (() 
   });
   return map;
 })();
+
+const generateArchive = async (): Promise<{ [key: string]: NovaMember[] }> => {
+  const allMembers: Set<string> = new Set();
+  const archive: { [key: string]: NovaMember[] } = { current: [], alumni: [], inactive: [] };
+
+  const currentMembers = await allApprovedMembers();
+  const images = await allMemberImages();
+
+  const addToArchive = (key: string, member: IdolMember) => {
+    const image = images.find((image) => image.fileName.split('.')[0] === member.netid);
+    archive[key].push({
+      ...member,
+      image: image ? image.url : null,
+      coffeeChatLink: `mailto:${member.email}`
+    });
+  };
+
+  currentMembers.forEach((member) => {
+    allMembers.add(member.netid);
+    addToArchive('current', member);
+  });
+
+  Object.values(archivedMembersBySemesters).forEach((semester) => {
+    semester.forEach((member) => {
+      if (!allMembers.has(member.netid)) {
+        allMembers.add(member.netid);
+        Date.parse(member.graduation) < Date.now()
+          ? addToArchive('alumni', member)
+          : addToArchive('inactive', member);
+      }
+    });
+  });
+
+  return archive;
+};

--- a/backend/src/members-archive/index.ts
+++ b/backend/src/members-archive/index.ts
@@ -22,7 +22,7 @@ export const archivedMembersByEmail: Readonly<Record<string, IdolMember>> = (() 
   return map;
 })();
 
-const generateArchive = async (): Promise<{ [key: string]: NovaMember[] }> => {
+export const generateArchive = async (): Promise<{ [key: string]: NovaMember[] }> => {
   const allMembers: Set<string> = new Set();
   const archive: { [key: string]: NovaMember[] } = { current: [], alumni: [], inactive: [] };
 

--- a/backend/src/members-archive/index.ts
+++ b/backend/src/members-archive/index.ts
@@ -2,8 +2,6 @@ import sp21 from './sp21.json';
 import fa21 from './fa21.json';
 import sp23 from './sp23.json';
 import fa23 from './fa23.json';
-import { allApprovedMembers } from '../API/memberAPI';
-import { allMemberImages } from '../API/imageAPI';
 
 export const archivedMembersBySemesters: Readonly<Record<string, readonly IdolMember[]>> = {
   'Spring 2021': sp21.members as unknown as readonly IdolMember[],
@@ -21,38 +19,3 @@ export const archivedMembersByEmail: Readonly<Record<string, IdolMember>> = (() 
   });
   return map;
 })();
-
-export const generateArchive = async (): Promise<{ [key: string]: NovaMember[] }> => {
-  const allMembers: Set<string> = new Set();
-  const archive: { [key: string]: NovaMember[] } = { current: [], alumni: [], inactive: [] };
-
-  const currentMembers = await allApprovedMembers();
-  const images = await allMemberImages();
-
-  const addToArchive = (key: string, member: IdolMember) => {
-    const image = images.find((image) => image.fileName.split('.')[0] === member.netid);
-    archive[key].push({
-      ...member,
-      image: image ? image.url : null,
-      coffeeChatLink: `mailto:${member.email}`
-    });
-  };
-
-  currentMembers.forEach((member) => {
-    allMembers.add(member.netid);
-    addToArchive('current', member);
-  });
-
-  Object.values(archivedMembersBySemesters).forEach((semester) => {
-    semester.forEach((member) => {
-      if (!allMembers.has(member.netid)) {
-        allMembers.add(member.netid);
-        Date.parse(member.graduation) < Date.now()
-          ? addToArchive('alumni', member)
-          : addToArchive('inactive', member);
-      }
-    });
-  });
-
-  return archive;
-};

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -42,25 +42,7 @@ interface IdolMemberDiff {
 }
 
 /** The data type used by Nova site to represent a DTI member. */
-interface NovaMember {
-  readonly netid: string;
-  readonly email: string;
-  readonly firstName: string;
-  readonly lastName: string;
-  readonly pronouns: string;
-  readonly graduation: string;
-  readonly major: string;
-  readonly doubleMajor?: string | null;
-  readonly minor?: string | null;
-  readonly website?: string | null;
-  readonly linkedin?: string | null;
-  readonly github?: string | null;
-  readonly hometown: string;
-  readonly about: string;
-  readonly subteams: readonly string[];
-  readonly formerSubteams?: readonly string[] | null;
-  readonly role: Role;
-  readonly roleDescription: RoleDescription;
+interface NovaMember extends IdolMember {
   readonly image?: string | null;
   readonly coffeeChatLink?: string | null;
 }

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -44,22 +44,25 @@ interface IdolMemberDiff {
 /** The data type used by Nova site to represent a DTI member. */
 interface NovaMember {
   readonly netid: string;
-  readonly name: string;
+  readonly email: string;
+  readonly firstName: string;
+  readonly lastName: string;
   readonly pronouns: string;
-  readonly isLead?: boolean;
   readonly graduation: string;
   readonly major: string;
-  readonly doubleMajor?: string;
-  readonly minor?: string;
-  readonly website?: string;
-  readonly linkedin?: string;
-  readonly github?: string;
+  readonly doubleMajor?: string | null;
+  readonly minor?: string | null;
+  readonly website?: string | null;
+  readonly linkedin?: string | null;
+  readonly github?: string | null;
   readonly hometown: string;
   readonly about: string;
-  readonly subteams?: string[];
-  readonly formerSubteams?: string[];
-  readonly roleId: string;
-  readonly roleDescription: string;
+  readonly subteams: readonly string[];
+  readonly formerSubteams?: readonly string[] | null;
+  readonly role: Role;
+  readonly roleDescription: RoleDescription;
+  readonly image?: string | null;
+  readonly coffeeChatLink?: string | null;
 }
 
 interface ProfileImage {

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -41,8 +41,31 @@ interface IdolMemberDiff {
   readonly diffString: string;
 }
 
-/** The data type used by Nova site to represent a DTI member. */
-interface NovaMember extends IdolMember {
+/** The data type used by Nova site to represent a DTI member. 
+ * @deprecated used in past DTI websites
+*/
+interface NovaMember {
+  readonly netid: string;
+  readonly name: string;
+  readonly pronouns: string;
+  readonly isLead?: boolean;
+  readonly graduation: string;
+  readonly major: string;
+  readonly doubleMajor?: string;
+  readonly minor?: string;
+  readonly website?: string;
+  readonly linkedin?: string;
+  readonly github?: string;
+  readonly hometown: string;
+  readonly about: string;
+  readonly subteams?: string[];
+  readonly formerSubteams?: string[];
+  readonly roleId: string;
+  readonly roleDescription: string;
+}
+
+/** The data type used by new DTI website to represent a DTI member. */
+interface MemberProfile extends IdolMember {
   readonly image?: string | null;
   readonly coffeeChatLink?: string | null;
 }

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -41,9 +41,9 @@ interface IdolMemberDiff {
   readonly diffString: string;
 }
 
-/** The data type used by Nova site to represent a DTI member. 
+/** The data type used by Nova site to represent a DTI member.
  * @deprecated used in past DTI websites
-*/
+ */
 interface NovaMember {
   readonly netid: string;
   readonly name: string;

--- a/frontend/public/sample_returning_members.csv
+++ b/frontend/public/sample_returning_members.csv
@@ -1,0 +1,1 @@
+NetID,Graduation Semester,Returning

--- a/frontend/public/sample_returning_members.csv
+++ b/frontend/public/sample_returning_members.csv
@@ -1,1 +1,1 @@
-NetID,Graduation Semester,Returning
+NetID,Returning

--- a/frontend/src/API/MembersAPI.ts
+++ b/frontend/src/API/MembersAPI.ts
@@ -31,6 +31,12 @@ export class MembersAPI {
     );
   }
 
+  public static getArchive(body: {
+    [key: string]: string[];
+  }): Promise<{ [key: string]: NovaMember[] }> {
+    return APIWrapper.post(`${backendURL}/member-archive`, body).then((res) => res.data);
+  }
+
   public static notifyMember(
     member: Member,
     endOfSemesterReminder: boolean

--- a/frontend/src/API/MembersAPI.ts
+++ b/frontend/src/API/MembersAPI.ts
@@ -33,7 +33,7 @@ export class MembersAPI {
 
   public static getArchive(body: {
     [key: string]: string[];
-  }): Promise<{ [key: string]: NovaMember[] }> {
+  }): Promise<{ [key: string]: MemberProfile[] }> {
     return APIWrapper.post(`${backendURL}/member-archive`, body).then((res) => res.data);
   }
 


### PR DESCRIPTION
### Summary <!-- Required -->
This pull request adds a section to the `admin/edit` page to download an archive, in json form, of all past and present DTI members given a returning members survey. This will be used by the ops leads at the end of each semester to generate the next semester's roster. The json will contain three keys: current, alumni, inactive, each storing a list of member details. 
* `NovaMember` now has a purpose again! It represents a member on the new DTI website, specifically with a coffee chat and image field.
* A sample returning members survey is attached.
* Endpoint `/member-archive?semesters=` allows you to define a limit to how many semesters back, if any, to include in the archive. 

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/Member-archive-script-0540cb5e7d0349c4921f344b1875387e?pvs=4
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
![image](https://github.com/cornell-dti/idol/assets/144409850/3b04698f-b35c-4c1f-9dfe-72aca18042b2)
Test CSV:
```
NetID,Graduation Semester,Returning
cc2785,May 2027,Yes
```
Output JSON:
[archive.json](https://github.com/user-attachments/files/16135513/archive.json)

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->

* `NovaMember` as mentioned above, now extends `IdolMember`.
