### PR TITLE
Website: Remove width constraint on the image carousel

### DIFF
--- a/new-dti-website/components/products/imageCarousel.tsx
+++ b/new-dti-website/components/products/imageCarousel.tsx
@@ -29,7 +29,7 @@ const ImageCarousel = (props: { items: carouselItem[] }) => {
   return (
     <div className="bg-black overflow-x-hidden">
       <Carousel
-        className="lg:w-[1688px] h-40 md:h-52 lg:h-64 xl:h-80 2xl:h-96 lg:-ml-[105px]"
+        className="h-40 md:h-52 lg:h-64 xl:h-80 2xl:h-96 lg:-ml-[105px]"
         opts={{
           align: 'start',
           loop: true


### PR DESCRIPTION
### Summary <!-- Required -->

The image carousel wasn't stretching to the full viewport width after stretching the screen long enough.

Remove the width constraint to allow for the carousel to take up the entire viewport width.

Before:

![Screenshot 2024-08-27 at 6 27 00 PM](https://github.com/user-attachments/assets/3a2ab146-44fa-4bf0-a0c0-182395e92add)

After:

![Screenshot 2024-08-27 at 6 27 06 PM](https://github.com/user-attachments/assets/b5118b20-a11d-4d20-9672-6151844a5315)



### Notion/Figma Link <!-- Optional -->

https://www.notion.so/Carousel-Hero-Component-0-5-sprints-ab360524d0c541f4aedcba75b55f29de

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
