### PR TITLE
Dev portfolio Admin Page: Fix Created Dev Portfolio State Bug

### DIFF
--- a/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolioForm.tsx
+++ b/frontend/src/components/Admin/DevPortfolio/AdminDevPortfolioForm.tsx
@@ -43,6 +43,7 @@ const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({
   const [deadline, setDeadline] = useState<Date>(deadlineDate);
   const [earliestDate, setEarliestDate] = useState<Date>(earliestValidDate);
   const [lateDeadline, setLateDeadline] = useState(lateDeadlineDate);
+  const [lastCreatedPortfolio, setLastCreatedPortfolio] = useState<DevPortfolio>();
 
   const handleSubmit = () => {
     if (name === '') {
@@ -90,6 +91,7 @@ const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({
       };
       DevPortfolioAPI.createDevPortfolio(newPortfolio).then((portfolio) => {
         setDevPortfolios((portfolios) => [...portfolios, portfolio]);
+        setLastCreatedPortfolio(portfolio);
         setSuccess(true);
       });
     }
@@ -131,11 +133,13 @@ const AdminDevPortfolioForm: React.FC<AdminDevPortfolioFormProps> = ({
           <Form.Button id={styles.submitButton} onClick={() => handleSubmit()}>
             Create Assignment
           </Form.Button>
-          <Message
-            success
-            header="Dev Portfolio Created"
-            content={`${name} was successfully created and will be due on ${deadline.toDateString()}`}
-          />
+          {lastCreatedPortfolio && (
+            <Message
+              success
+              header="Dev Portfolio Created"
+              content={`${lastCreatedPortfolio.name} was successfully created and will be due on ${new Date(lastCreatedPortfolio.deadline).toDateString()}`}
+            />
+          )}
         </>
       )}
 


### PR DESCRIPTION
### Summary <!-- Required -->

There was a bug with the newly created dev portfolio success message. The name and deadline were controlled by the state variables, so the UI would update as the corresponding fields were edited.

Store and read from a `lastCreatedPortfolio` instead.

Before:

https://github.com/user-attachments/assets/e0de1036-911d-4ccd-8b38-57323cb1c0d0



After:

https://github.com/user-attachments/assets/b4b2b224-a95b-47f7-9835-03868b9b1686




### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

