### PR TITLE
Candidate Decider: Wrap text without spaces to prevent overflow

### DIFF
--- a/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
@@ -12,6 +12,8 @@
   border-right: solid;
   border-color: lightgrey;
   padding: 1%;
+  overflow-wrap: break-word;
+  overflow: hidden;
 }
 
 .progressContainer {


### PR DESCRIPTION
### Summary <!-- Required -->

Noticing that there's text without spaces that overflows the text.

Discovered this from a person's application from SP24 which caused the entire left panel to overflow and take up the entire screen (you had to zoom out to see both left and right panels).

Before:
<img width="1503" alt="Screenshot 2024-08-28 at 3 41 07 PM" src="https://github.com/user-attachments/assets/d2eaee8d-c3a4-4215-8e3f-7197b83d4656">

After:
<img width="1505" alt="Screenshot 2024-08-28 at 3 41 24 PM" src="https://github.com/user-attachments/assets/ecf532f5-b0d1-4bc8-96b1-5344551c2504">

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Manual

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

