### PR TITLE
Candidate Decider: Refactor Reviews to Separate Collection to Prevent Race Conditions

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -62,7 +62,8 @@ import {
   deleteCandidateDeciderInstance,
   getCandidateDeciderInstance,
   updateCandidateDeciderRatingAndComment,
-  updateCandidateDeciderInstance
+  updateCandidateDeciderInstance,
+  getCandidateDeciderReviews
 } from './API/candidateDeciderAPI';
 import {
   deleteEventProofImage,
@@ -365,6 +366,9 @@ loginCheckedGet('/candidate-decider', async (_, user) => ({
 }));
 loginCheckedGet('/candidate-decider/:uuid', async (req, user) => ({
   instance: await getCandidateDeciderInstance(req.params.uuid, user)
+}));
+loginCheckedGet('/candidate-decider/:uuid/review', async (req, user) => ({
+  reviews: await getCandidateDeciderReviews(req.params.uuid, user)
 }));
 loginCheckedPost('/candidate-decider', async (req, user) => ({
   instance: await createNewCandidateDeciderInstance(req.body, user)

--- a/backend/src/dao/CandidateDeciderDao.ts
+++ b/backend/src/dao/CandidateDeciderDao.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { candidateDeciderCollection, db, memberCollection } from '../firebase';
+import { candidateDeciderCollection, memberCollection } from '../firebase';
 import { DBCandidateDeciderInstance } from '../types/DataTypes';
 import { getMemberFromDocumentReference } from '../utils/memberUtil';
 import BaseDao from './BaseDao';
@@ -12,17 +12,7 @@ async function serializeCandidateDeciderInstance(
     authorizedMembers: instance.authorizedMembers.map((member) =>
       memberCollection.doc(member.email)
     ),
-    candidates: instance.candidates.map((candidate) => ({
-      ...candidate,
-      ratings: candidate.ratings.map((rating) => ({
-        ...rating,
-        reviewer: memberCollection.doc(rating.reviewer.email)
-      })),
-      comments: candidate.comments.map((comment) => ({
-        ...comment,
-        reviewer: memberCollection.doc(comment.reviewer.email)
-      }))
-    }))
+    candidates: instance.candidates
   };
 }
 
@@ -37,18 +27,8 @@ async function materializeCandidateDeciderInstance(
     candidates: await Promise.all(
       dbInstance.candidates.map(async (candidate) => ({
         ...candidate,
-        ratings: await Promise.all(
-          candidate.ratings.map(async (rating) => ({
-            ...rating,
-            reviewer: await getMemberFromDocumentReference(rating.reviewer)
-          }))
-        ),
-        comments: await Promise.all(
-          candidate.comments.map(async (comment) => ({
-            ...comment,
-            reviewer: await getMemberFromDocumentReference(comment.reviewer)
-          }))
-        )
+        ratings: [],
+        comments: []
       }))
     )
   };
@@ -116,65 +96,5 @@ export default class CandidateDeciderDao extends BaseDao<
    */
   async updateInstance(instance: CandidateDeciderInstance): Promise<CandidateDeciderInstance> {
     return this.updateDocument(instance.uuid, instance);
-  }
-
-  /**
-   * Updates a specific CandidateDecider instance in the database with a rating
-   * and comment. This implementation uses a transaction in order to prevent
-   * race conditions from multiple users making multiple rating/comment updates.
-   * @param instance - CandidateDeciderInstance object containing the updated data.
-   * @param user - user who created the review
-   * @param id - id associated with the candidate
-   * @param rating - rating submitted by the user
-   * @param comment - comment submitted by the user
-   * @returns The updated CandidateDeciderInstance object.
-   */
-  async updateInstanceWithTransaction(
-    instance: CandidateDeciderInstance,
-    user: IdolMember,
-    id: number,
-    rating: Rating,
-    comment: string
-  ): Promise<CandidateDeciderInstance> {
-    const candidateDeciderRef = this.collection.doc(instance.uuid);
-    const newInstance: CandidateDeciderInstance = await db.runTransaction(async (t) => {
-      const doc = await t.get(candidateDeciderRef);
-
-      const dbCandidateDeciderInstance = doc.data() as DBCandidateDeciderInstance;
-      const candidateDeciderInstance = await materializeCandidateDeciderInstance(
-        dbCandidateDeciderInstance
-      );
-      const candidates = candidateDeciderInstance.candidates.map((cd) =>
-        cd.id !== id
-          ? cd
-          : {
-              ...cd,
-              ratings: [
-                ...cd.ratings.filter((rt) => rt.reviewer.email !== user.email),
-                { reviewer: user, rating }
-              ],
-              comments: [
-                ...cd.comments.filter((cmt) => cmt.reviewer.email !== user.email),
-                { reviewer: user, comment }
-              ]
-            }
-      );
-      t.update(candidateDeciderRef, {
-        candidates: candidates.map((candidate) => ({
-          ...candidate,
-          ratings: candidate.ratings.map((rating) => ({
-            ...rating,
-            reviewer: memberCollection.doc(rating.reviewer.email)
-          })),
-          comments: candidate.comments.map((comment) => ({
-            ...comment,
-            reviewer: memberCollection.doc(comment.reviewer.email)
-          }))
-        }))
-      });
-
-      return { ...candidateDeciderInstance, candidates };
-    });
-    return newInstance;
   }
 }

--- a/backend/src/dao/CandidateDeciderReviewDao.ts
+++ b/backend/src/dao/CandidateDeciderReviewDao.ts
@@ -1,0 +1,142 @@
+import { v4 as uuidv4 } from 'uuid';
+import { firestore } from 'firebase-admin';
+import { candidateDeciderReviewCollection, db, memberCollection } from '../firebase';
+import { DBCandidateDeciderReview } from '../types/DataTypes';
+import { getMemberFromDocumentReference } from '../utils/memberUtil';
+import BaseDao from './BaseDao';
+
+async function serializeCandidateDeciderReview(
+  review: CandidateDeciderReview
+): Promise<DBCandidateDeciderReview> {
+  return {
+    ...review,
+    reviewer: memberCollection.doc(review.reviewer.email)
+  };
+}
+
+async function materializeCandidateDeciderReview(
+  dbReview: DBCandidateDeciderReview
+): Promise<CandidateDeciderReview> {
+  return {
+    ...dbReview,
+    reviewer: await getMemberFromDocumentReference(dbReview.reviewer)
+  };
+}
+
+export default class CandidateDeciderDao extends BaseDao<
+  CandidateDeciderReview,
+  DBCandidateDeciderReview
+> {
+  constructor() {
+    super(
+      candidateDeciderReviewCollection,
+      materializeCandidateDeciderReview,
+      serializeCandidateDeciderReview
+    );
+  }
+
+  /**
+   * Retrieves all CandidateDecider reviews from the database.
+   * @returns An array of CandidateDeciderReview objects.
+   */
+  async getAllReviews(): Promise<CandidateDeciderReview[]> {
+    return this.getDocuments();
+  }
+
+  /**
+   * Retrieves a specific CandidateDecider review from the database.
+   * @param uuid - The unique identifier of the desired CandidateDecider review.
+   * @returns A CandidateDeciderReview object if found, or null.
+   */
+  async getReview(uuid: string): Promise<CandidateDeciderReview | null> {
+    return this.getDocument(uuid);
+  }
+
+  /**
+   * Gets all CandidateDecider reviews by candidate decider instance uuid.
+   * @param uuid - DB uuid of the candidate decider instance
+   */
+  async getReviewsByCandidateDeciderInstance(uuid: string): Promise<CandidateDeciderReview[]> {
+    return this.getDocuments([
+      {
+        field: 'candidateDeciderInstanceUuid',
+        comparisonOperator: '==',
+        value: uuid
+      }
+    ]);
+  }
+
+  /**
+   * Creates a new CandidateDecider review in the database.
+   * @param user - User who made the review
+   * @param uuid - Candidate decider uuid
+   * @param id - Candidate's id within the candidate decider instance
+   * @param rating - Rating for candidate
+   * @param comment - Comment for candidate
+   * @returns A CandidateDeciderReview object.
+   */
+  async createNewReview(
+    instance: CandidateDeciderInstance,
+    user: IdolMember,
+    id: number,
+    rating: Rating,
+    comment: string
+  ): Promise<CandidateDeciderReview> {
+    const review = {
+      candidateDeciderInstanceUuid: instance.uuid,
+      candidateId: id,
+      reviewer: user,
+      rating,
+      comment
+    };
+
+    const newReview: CandidateDeciderReview = await db.runTransaction(async (t) => {
+      const query = (this.collection as firestore.Query<DBCandidateDeciderReview>)
+        .where('candidateDeciderInstanceUuid', '==', review.candidateDeciderInstanceUuid)
+        .where('candidateId', '==', review.candidateId)
+        .where('reviewer', '==', memberCollection.doc(review.reviewer.email));
+
+      const snapshot = await t.get(query);
+      const candidateDeciderReviews = snapshot.docs.map(
+        (doc) => doc.data() as DBCandidateDeciderReview
+      );
+
+      let reviewWithUUID;
+      if (candidateDeciderReviews.length === 0) {
+        reviewWithUUID = {
+          ...review,
+          uuid: uuidv4()
+        };
+        const dbReview = await serializeCandidateDeciderReview(reviewWithUUID);
+        t.create(this.collection.doc(reviewWithUUID.uuid), dbReview);
+      } else {
+        const candidateDeciderReview = candidateDeciderReviews[0];
+        reviewWithUUID = {
+          ...review,
+          uuid: candidateDeciderReview.uuid
+        };
+        const dbReview = await serializeCandidateDeciderReview(reviewWithUUID);
+        t.update(this.collection.doc(reviewWithUUID.uuid), dbReview);
+      }
+      return reviewWithUUID;
+    });
+    return newReview;
+  }
+
+  /**
+   * Deletes a specific CandidateDecider review from the database.
+   * @param uuid - The unique identifier of the CandidateDecider review to be deleted.
+   */
+  async deleteReview(uuid: string): Promise<void> {
+    await this.deleteDocument(uuid);
+  }
+
+  /**
+   * Updates a specific CandidateDecider review in the database.
+   * @param review - The CandidateDeciderReview object containing the updated data.
+   * @returns The updated CandidateDeciderReview object.
+   */
+  async updateReview(review: CandidateDeciderReview): Promise<CandidateDeciderReview> {
+    return this.updateDocument(review.uuid, review);
+  }
+}

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -6,6 +6,7 @@ import {
   DBDevPortfolio,
   DevPortfolioSubmissionRequestLog,
   DBTeamEventAttendance,
+  DBCandidateDeciderReview,
   DBCoffeeChat
 } from './types/DataTypes';
 import { configureAccount } from './utils/firebase-utils';
@@ -150,3 +151,13 @@ export const adminCollection: admin.firestore.CollectionReference = db.collectio
 
 export const teamEventAdminCollection: admin.firestore.CollectionReference =
   db.collection('team-event-admins');
+
+export const candidateDeciderReviewCollection: admin.firestore.CollectionReference<DBCandidateDeciderReview> =
+  db.collection('candidate-decider-review').withConverter({
+    fromFirestore(snapshot): DBCandidateDeciderReview {
+      return snapshot.data() as DBCandidateDeciderReview;
+    },
+    toFirestore(candidateDeciderReviewData: DBCandidateDeciderReview) {
+      return candidateDeciderReviewData;
+    }
+  });

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -55,8 +55,15 @@ export type DBCandidateDeciderComment = {
 export type DBCandidateDeciderCandidate = {
   readonly responses: string[];
   readonly id: number;
-  ratings: DBCandidateDeciderRating[];
-  comments: DBCandidateDeciderComment[];
+};
+
+export type DBCandidateDeciderReview = {
+  readonly candidateDeciderInstanceUuid: string;
+  readonly candidateId: number;
+  readonly reviewer: firestore.DocumentReference;
+  readonly rating: Rating;
+  readonly comment: string;
+  readonly uuid: string;
 };
 
 export type DBCandidateDeciderInstance = {

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -136,8 +136,15 @@ interface CandidateDeciderComment {
 interface CandidateDeciderCandidate {
   readonly responses: string[];
   readonly id: number;
-  ratings: CandidateDeciderRating[];
-  comments: CandidateDeciderComment[];
+}
+
+interface CandidateDeciderReview {
+  readonly candidateDeciderInstanceUuid: string;
+  readonly candidateId: number;
+  readonly reviewer: IdolMember;
+  readonly rating: Rating;
+  readonly comment: string;
+  readonly uuid: string;
 }
 
 interface CandidateDeciderInstance extends CandidateDeciderInfo {

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/frontend/src/API/CandidateDeciderAPI.ts
+++ b/frontend/src/API/CandidateDeciderAPI.ts
@@ -12,6 +12,11 @@ export default class CandidateDeciderAPI {
     return response.then((val) => val.data.instance);
   }
 
+  static async getReviews(uuid: string): Promise<CandidateDeciderReview[]> {
+    const response = APIWrapper.get(`${backendURL}/candidate-decider/${uuid}/review`);
+    return response.then((val) => val.data.reviews);
+  }
+
   static async createNewInstance(
     instance: CandidateDeciderInstance
   ): Promise<CandidateDeciderInfo> {

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -46,22 +46,14 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const [defaultCurrentComment, setDefaultCurrentComment] = useState<string>();
 
   useEffect(() => {
-    // Only set the currentRating and currentComment once when the instance first loads in
-    if (
-      instance.candidates[currentCandidate] &&
-      currentRating === undefined &&
-      currentComment === undefined
-    ) {
-      const rating = getRating(currentCandidate);
-      const comment = getComment(currentCandidate);
-
-      setCurrentRating(rating);
-      setCurrentComment(comment);
-      setDefaultCurrentRating(rating);
-      setDefaultCurrentComment(comment);
-    }
+    const rating = getRating(currentCandidate);
+    const comment = getComment(currentCandidate);
+    setCurrentRating(rating);
+    setCurrentComment(comment);
+    setDefaultCurrentRating(rating);
+    setDefaultCurrentComment(comment);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentCandidate, instance.candidates]);
+  }, [currentCandidate, instance.candidates, reviews]);
 
   const next = () => {
     if (currentCandidate === instance.candidates.length - 1) return;

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -29,7 +29,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
       (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
     );
     if (rating) return rating.rating;
-    return undefined;
+    return 0;
   };
 
   const getComment = (candidate: number) => {
@@ -37,7 +37,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
       (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
     );
     if (comment) return comment.comment;
-    return undefined;
+    return '';
   };
 
   const [currentRating, setCurrentRating] = useState<Rating>();
@@ -48,8 +48,8 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   useEffect(() => {
     if (
       instance.candidates[currentCandidate] &&
-      currentRating === undefined &&
-      currentComment === undefined
+      (currentRating === undefined || currentRating === 0) &&
+      (currentComment === undefined || currentComment === '')
     ) {
       const rating = getRating(currentCandidate);
       const comment = getComment(currentCandidate);

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -29,7 +29,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
       (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
     );
     if (rating) return rating.rating;
-    return 0;
+    return undefined;
   };
 
   const getComment = (candidate: number) => {
@@ -37,7 +37,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
       (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
     );
     if (comment) return comment.comment;
-    return '';
+    return undefined;
   };
 
   const [currentRating, setCurrentRating] = useState<Rating>();
@@ -46,12 +46,18 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const [defaultCurrentComment, setDefaultCurrentComment] = useState<string>();
 
   useEffect(() => {
-    const rating = getRating(currentCandidate);
-    const comment = getComment(currentCandidate);
-    setCurrentRating(rating);
-    setCurrentComment(comment);
-    setDefaultCurrentRating(rating);
-    setDefaultCurrentComment(comment);
+    if (
+      instance.candidates[currentCandidate] &&
+      currentRating === undefined &&
+      currentComment === undefined
+    ) {
+      const rating = getRating(currentCandidate);
+      const comment = getComment(currentCandidate);
+      setCurrentRating(rating);
+      setCurrentComment(comment);
+      setDefaultCurrentRating(rating);
+      setDefaultCurrentComment(comment);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentCandidate, instance.candidates, reviews]);
 

--- a/frontend/src/components/Candidate-Decider/GlobalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/GlobalProgressPanel.tsx
@@ -5,36 +5,30 @@ import styles from './ProgressPanel.module.css';
 type Props = {
   showOtherVotes: boolean;
   candidates: CandidateDeciderCandidate[];
+  reviews: CandidateDeciderReview[];
 };
 
-const GlobalProgressPanel: React.FC<Props> = ({ showOtherVotes, candidates }) => {
+const GlobalProgressPanel: React.FC<Props> = ({ showOtherVotes, candidates, reviews }) => {
   const reviewers = new Set();
-  let totalReviews = 0;
-  candidates.forEach((candidate) =>
-    candidate.ratings.forEach((rating) => {
-      reviewers.add(rating.reviewer.email);
-      totalReviews += 1;
-    })
-  );
+  reviews.forEach((review) => reviewers.add(review.reviewer.email));
   const allReviewers = Array.from(reviewers);
-  const allRatings = candidates.map((candidate) => candidate.ratings).flat();
 
   return (
     <div className={styles.progressContainer}>
       <h3>Global Progress</h3>
       <Progress
-        value={totalReviews}
+        value={reviews.length}
         total={allReviewers.length * candidates.length}
         size="tiny"
         color="blue"
-      >{`${allRatings.length}/${candidates.length * allReviewers.length}`}</Progress>
-      <RatingsDisplay ratings={allRatings} header="Global Rating Statistics" />
+      >{`${reviews.length}/${candidates.length * allReviewers.length}`}</Progress>
+      <RatingsDisplay ratings={reviews} header="Global Rating Statistics" />
       {showOtherVotes ? (
         <>
           <h3>Per-person Ratings</h3>
           {candidates.map((candidate) => (
             <RatingsDisplay
-              ratings={candidate.ratings}
+              ratings={reviews.filter((review) => review.candidateId === candidate.id)}
               header={`Candidate ${candidate.id}`}
               key={candidate.id}
             />

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -8,44 +8,41 @@ type ProgressPanelProps = {
   showOtherVotes: boolean;
   candidates: CandidateDeciderCandidate[];
   currentCandidate: number;
+  reviews: CandidateDeciderReview[];
 };
 
 const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
   showOtherVotes,
   candidates,
-  currentCandidate
+  currentCandidate,
+  reviews
 }) => {
   const userInfo = useSelf();
 
-  const myReviews = candidates.filter((candidate) =>
-    candidate.ratings.some((rating) => rating.reviewer.email === userInfo?.email)
-  );
-  const myRatings = myReviews.map(
-    (candidate) =>
-      candidate.ratings.find(
-        (rating) => rating.reviewer.email === userInfo?.email
-      ) as CandidateDeciderRating
+  const myRatings = reviews.filter((review) => review.reviewer.email === userInfo?.email);
+  const currentCandidateReviews = reviews.filter(
+    (review) => review.candidateId === currentCandidate
   );
   return (
     <div className={styles.progressContainer}>
       <h3>My Progress</h3>
       <Progress
-        value={myReviews.length}
+        value={myRatings.length}
         total={candidates.length}
         size="tiny"
         color="blue"
-      >{`${myReviews.length}/${candidates.length}`}</Progress>
+      >{`${myRatings.length}/${candidates.length}`}</Progress>
       <RatingsDisplay ratings={myRatings} header="My Rating Statistics" />
       {showOtherVotes && userInfo?.role === 'lead' ? (
         <>
           <RatingsDisplay
-            ratings={candidates[currentCandidate].ratings}
+            ratings={currentCandidateReviews}
             header={`Candidate ${currentCandidate} Global Ratings`}
           />
           <div>
             <h3>All Votes on Candidate {currentCandidate}</h3>
             <div className={styles.verticalContentContainer}>
-              {candidates[currentCandidate].ratings
+              {currentCandidateReviews
                 .filter((rating) => rating.rating !== 0)
                 .map((rating) => (
                   <span
@@ -58,11 +55,11 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
             </div>
             <h3>All Comments on Candidate {currentCandidate}</h3>
             <div className={styles.verticalContentContainer}>
-              {candidates[currentCandidate].comments.map((comment) => (
+              {currentCandidateReviews.map((review) => (
                 <span
                   className={`${styles.fullWidth} ${styles.smallVerticalMargin}`}
-                  key={comment.reviewer.email}
-                >{`${comment.reviewer.firstName} ${comment.reviewer.lastName}: ${comment.comment}
+                  key={review.reviewer.email}
+                >{`${review.reviewer.firstName} ${review.reviewer.lastName}: ${review.comment}
             `}</span>
               ))}
             </div>


### PR DESCRIPTION
### Summary <!-- Required -->
Candidate Decider was having race conditions due to multiple people making reviews at a time. 
- Create new collection `candidate-decider-review` to factor out the ratings and comments into a separate collection. This will make it easier to implement database transactions on them.
- Use database transactions for updating ratings and comments
- Add firebase listener for `candidate-decider-review`
- Remove `ratings` and `comments` field from `CandidateDeciderInstance`

Also added this Firebase rule:
```
    match /candidate-decider-review/{uuid} {
allow read: if 
   get(/databases/$(database)/documents/members/$(request.auth.token.email)).data.role in 
   get(/databases/$(database)/documents/candidate-decider/$(resource.data.candidateDeciderUuid)).data.authorizedRoles ||
   /databases/$(database)/documents/members/$(request.auth.token.email) in 
   get(/databases/$(database)/documents/candidate- 
  decider/$(resource.data.candidateDeciderUuid)).data.authorizedMembers || 
  isAdmin()
}
```

### Notion/Figma Link <!-- Optional -->

https://www.notion.so/Candidate-Decider-Fix-Race-Conditions-2c110afcbd554ab8adc34c0f8ab1a801?pvs=4

### Test Plan <!-- Required -->

Manual

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
Remove `ratings` and `comments` field from `CandidateDeciderInstance`. Now the data comes directly from the `candidate-decider-review` collection.
