### PR TITLE
TEC Form: remove tec info card and fix dropdown selection bug

### DIFF
--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Form, Segment, Label, Button, Dropdown } from 'semantic-ui-react';
+import { Form, Label, Dropdown } from 'semantic-ui-react';
 import { Emitters, getNetIDFromEmail } from '../../../utils';
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
@@ -145,7 +145,7 @@ const TeamEventCreditForm: React.FC = () => {
             Select a Team Event: <span className={styles.red_color}>*</span>
           </label>
           <div className={styles.center_and_flex}>
-            {teamEventInfoList && !teamEvent ? (
+            {teamEventInfoList ? (
               <Dropdown
                 placeholder="Select a Team Event"
                 fluid
@@ -153,6 +153,12 @@ const TeamEventCreditForm: React.FC = () => {
                   options.filter((option) => option.key.toLowerCase().includes(query.toLowerCase()))
                 }
                 selection
+                value={teamEvent?.uuid ?? ''}
+                text={
+                  teamEvent
+                    ? `${teamEvent.name} - ${teamEvent.numCredits} credit(s) ${teamEvent.hasHours ? 'per hour' : ''}`
+                    : ''
+                }
                 options={teamEventInfoList
                   .sort((e1, e2) => new Date(e2.date).getTime() - new Date(e1.date).getTime())
                   .map((event) => ({
@@ -187,30 +193,6 @@ const TeamEventCreditForm: React.FC = () => {
                   setTeamEvent(teamEventInfoList.find((event) => event.uuid === data.value));
                 }}
               />
-            ) : undefined}
-
-            {teamEvent ? (
-              <div className={styles.row_direction}>
-                <div>
-                  <Segment>
-                    <h4>{teamEvent.name}</h4>
-                    <Label>
-                      {`${teamEvent.numCredits} credit(s)`} {teamEvent.hasHours ? 'per hour' : ''}
-                    </Label>
-                  </Segment>
-                </div>
-
-                <Button
-                  negative
-                  onClick={() => {
-                    setTeamEvent(undefined);
-                    setHours('0');
-                  }}
-                  className={styles.inline}
-                >
-                  Clear
-                </Button>
-              </div>
             ) : undefined}
           </div>
         </div>


### PR DESCRIPTION
### Summary <!-- Required -->
There was a bug where clicking on any option in the dropdown would always default to the first option in the list, and the dropdown would close, preventing users from clicking on any other options.

Remove TEC info card so that it's possible to select other options. Frankly, I don't see why we need the card in the first place and it adds an unnecessary layer of complexity.

Before:

https://github.com/user-attachments/assets/72d10e30-89f7-4216-8a9e-8771d7841ce1




After:


https://github.com/user-attachments/assets/f3899ba2-a014-4027-a07e-781b95c71195




### Notion/Figma Link <!-- Optional -->

https://cornelldti.slack.com/archives/C044T59JD34/p1713279418092159

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
