### PR TITLE
TEC Form: Enforce TEC Limit for Bulk Submissions

### DIFF
--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -239,7 +239,8 @@ const TeamEventCreditForm: React.FC = () => {
           </label>
           <p className={styles.margin_bottom_zero}>
             Please include a picture of yourself (and others) and/or an email chain only if the
-            former is not possible.
+            former is not possible. You may click the "+" button to add additional submissions to
+            the same event (if the event allows for multiple submissions).
           </p>
 
           {images.map((image, i) => (


### PR DESCRIPTION
### Summary <!-- Required -->
Currently we enforce TEC limit for single submissions that exceed the total credit limit of the TEC event. But we missed this check on bulk submissions, where a user can submit multiple events at a time that in total will exceed the max credit limit.

This PR enforces the TEC Limit for bulk submissions.

### Notion/Figma Link <!-- Optional -->

https://cornelldti.slack.com/archives/C07K7HFJLPJ/p1725836378114069

### Test Plan <!-- Required -->

Manual


https://github.com/user-attachments/assets/27ae2aa6-f05e-4def-9dd3-7e04280623a1



### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
