### PR TITLE
Dev Portfolio: Make opened PR's Optional for TPMs

### DIFF
--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -14,6 +14,7 @@ const DevPortfolioForm: React.FC = () => {
   const userInfo = useSelf()!;
   const isTpm = userInfo.role === 'tpm';
   const isDevAdvisor = userInfo.role === 'dev-advisor';
+  const isOpenedPROptional = isTpm || isDevAdvisor;
 
   const [devPortfolio, setDevPortfolio] = useState<DevPortfolio | undefined>(undefined);
   const [devPortfolios, setDevPortfolios] = useState<DevPortfolio[]>([]);
@@ -87,7 +88,7 @@ const DevPortfolioForm: React.FC = () => {
       ? devPortfolio.lateDeadline
       : devPortfolio?.deadline;
 
-    if (!isDevAdvisor && otherEmpty && (openedEmpty || reviewedEmpty)) {
+    if (!isOpenedPROptional && otherEmpty && (openedEmpty || reviewedEmpty)) {
       Emitters.generalError.emit({
         headerMsg: 'No opened or reviewed PR url submitted',
         contentMsg: 'Please paste a link to a opened and reviewed PR!'
@@ -225,7 +226,7 @@ const DevPortfolioForm: React.FC = () => {
             placeholder="Opened PR"
             label="Opened Pull Request Github Link:"
             openOther={openOther}
-            isRequired={!isDevAdvisor}
+            isRequired={!isOpenedPROptional}
           />
           <PRInputs
             prs={reviewPRs}


### PR DESCRIPTION
### Summary <!-- Required -->
Make opened PR's Optional for TPMs (policy change now only requires 2/5 PR's, so TPM's will decide when they want to submit PR's)


### Notion/Figma Link <!-- Optional -->
https://www.notion.so/Dev-Portfolio-Make-opened-PR-s-Optional-for-TPMs-1080ad723ce1801c88b3de2b69cfbef1?pvs=4
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Manually submitted a TPM portfolio without open PRs.
Tried manually submitting a Dev portfolio without open PR's and it was not allowed.

TPM view:
<img width="798" alt="Screenshot 2024-09-22 at 1 02 46 AM" src="https://github.com/user-attachments/assets/bf19dc21-9d37-45b8-9e9f-a22fec514f9e">

Dev view:
<img width="799" alt="Screenshot 2024-09-22 at 12 55 17 AM" src="https://github.com/user-attachments/assets/4969d58d-bf65-4f2a-8cff-306ddd01e8e4">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

