### PR TITLE
TEC Admin tool: disable "Approve" when reason for reject isn't empty.

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
@@ -99,6 +99,7 @@ const TeamEventCreditReview = (props: {
         onClick={() => {
           approveCreditRequest(teamEventAttendance);
         }}
+        disabled={reason !== ''}
       >
         Set to Approved
       </Button>
@@ -128,6 +129,7 @@ const TeamEventCreditReview = (props: {
         <Button
           basic
           color="green"
+          disabled={reason !== ''}
           onClick={() => {
             approveCreditRequest(teamEventAttendance);
             setOpen(false);

--- a/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
@@ -99,7 +99,6 @@ const TeamEventCreditReview = (props: {
         onClick={() => {
           approveCreditRequest(teamEventAttendance);
         }}
-        disabled={reason !== ''}
       >
         Set to Approved
       </Button>


### PR DESCRIPTION
Previously, a TEC Admin would be able to Approve a request even if the "reason for reject" text field was not empty, leading to accidentally approvals. However, this change disables the "Approve" button if there's text in the "reason for reject" field. (see attached video)

https://github.com/user-attachments/assets/07ac6966-e6e9-4392-a8e5-9649fcabb2f2

