### PR TITLE
New Website: Fix 3 Second Slideshow Delay Bug

### DIFF
--- a/new-dti-website/src/app/page.tsx
+++ b/new-dti-website/src/app/page.tsx
@@ -6,7 +6,7 @@ import Slideshow from '../../components/slideshow';
 import Bottom from '../../components/bottom';
 
 const Home: React.FC = () => {
-  const [selectedIcon, setSelectedIcon] = useState<number | null>(null);
+  const [selectedIcon, setSelectedIcon] = useState<number | null>(0);
   const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
 
   const icons = [


### PR DESCRIPTION
### Summary <!-- Required -->

There's been a mysterious 3-second delay on the slideshow whenever it's loaded. Originally, we thought it was due to image size, but it was actually a bug caused by how the initial state of the slideshow is set!

Set the initial value to be image 0, so that the slideshow is loaded upon page load.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Load up the page and observe that the slideshow loads immediately and doesn't take 3 seconds.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->


