### PR TITLE
New DTI Website: Remove Fading Transition for Photos in Slideshow

### DIFF
--- a/new-dti-website/components/slideshow.tsx
+++ b/new-dti-website/components/slideshow.tsx
@@ -36,13 +36,13 @@ const Slideshow: React.FC<SlideshowProps> = ({ selectedImage }) => (
     {imageNames.map((imageName, index) => (
       <div key={imageName} className="absolute top-0 left-0 w-full h-full">
         <ImageHeader imageName={imageName} isVisible={selectedImage === index} />
-        <div className="relative top-12 w-full h-[400px]">
+        <div className="relative top-10 w-full h-[400px]">
           <Image
             width={600}
             height={400}
             src={`/images/${imageName}`}
             alt={imageName.split('.')[0]}
-            className={`absolute top-0 left-1/2 transform -translate-x-1/2 max-w-full max-h-full transition-opacity duration-300 border-8 border-white rounded-lg ${
+            className={`absolute top-0 left-1/2 transform -translate-x-1/2 max-w-full max-h-full border-8 border-white rounded-lg ${
               selectedImage === index ? 'opacity-100' : 'opacity-0'
             }`}
           />


### PR DESCRIPTION
### Summary <!-- Required -->
I forget whether we added the fading transition for flair or if it was actually part of the design. Frankly I think it looks borderline buggy, and I don’t like how the header and the slide aren’t perfectly fading in alignment (even if we fixed that, I don’t know if I’d like it).

Let's try switching the slideshow component to switch between photos without the fading transition

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Before:

https://github.com/user-attachments/assets/7e43744c-c6c3-4859-b632-fd422ca858d8




After:

https://github.com/user-attachments/assets/3d58d0f3-e071-4e52-8a86-95756ec0d73e





### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
