### PR TITLE
[IDOL, TEC Admin] display TEC rejected reason

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDetails.tsx
@@ -39,6 +39,11 @@ const AttendanceDisplay: React.FC<AttendanceDisplayProps> = ({ status, teamEvent
                   {req.member.firstName} {req.member.lastName}
                 </Card.Header>
                 <Card.Meta>{req.member.email}</Card.Meta>
+                {status === 'rejected' && req.reason && (
+                  <Card.Description>
+                    <strong>Rejection Reason:</strong> {req.reason}
+                  </Card.Description>
+                )}
               </Card.Content>
               <Card.Content extra>
                 <TeamEventCreditReview


### PR DESCRIPTION
Previously, an Admin couldn't see the reason they previously wrote for rejecting someone's TEC request. However, this PR now displays it alongside the option for re-approval.

![image](https://github.com/user-attachments/assets/0edd0da4-6a1a-4ada-9448-fc035a214519)