### PR TITLE
Coffee Chat: Change Members Field to submitter and otherMember, Change image to slackLink, Remove Description

### DIFF
--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -24,22 +24,12 @@ export const getCoffeeChatsByUser = async (user: IdolMember): Promise<CoffeeChat
  * A member can not coffee chat the same person from previous semesters.
  */
 export const createCoffeeChat = async (coffeeChat: CoffeeChat): Promise<CoffeeChat> => {
-  const [member1, member2] = coffeeChat.members;
-
-  if (isEqual(member1, member2)) {
+  if (isEqual(coffeeChat.submitter, coffeeChat.otherMember)) {
     throw new Error('Cannot create coffee chat with yourself.');
   }
 
-  const prevChats1 = await coffeeChatDao.getCoffeeChatsByUser(member1);
-  const prevChats2 = await coffeeChatDao.getCoffeeChatsByUser(member2);
-
-  const prevChats = [...prevChats1, ...prevChats2];
-
-  const chatExists = prevChats.some((chat) => {
-    const chatMembers = chat.members.map((m) => m.email).sort();
-    const currentMembers = [member1.email, member2.email].sort();
-    return isEqual(chatMembers, currentMembers);
-  });
+  const prevChats = await coffeeChatDao.getCoffeeChatsByUser(coffeeChat.submitter);
+  const chatExists = prevChats.some((chat) => isEqual(coffeeChat.otherMember, chat.otherMember));
 
   if (chatExists) {
     throw new Error(

--- a/backend/src/dao/CoffeeChatDao.ts
+++ b/backend/src/dao/CoffeeChatDao.ts
@@ -6,22 +6,24 @@ import BaseDao from './BaseDao';
 import { deleteCollection } from '../utils/firebase-utils';
 
 async function materializeCoffeeChat(dbCoffeeChat: DBCoffeeChat): Promise<CoffeeChat> {
-  const member1 = await getMemberFromDocumentReference(dbCoffeeChat.members[0]);
-  const member2 = await getMemberFromDocumentReference(dbCoffeeChat.members[1]);
+  const submitter = await getMemberFromDocumentReference(dbCoffeeChat.submitter);
+  const otherMember = await getMemberFromDocumentReference(dbCoffeeChat.otherMember);
 
   return {
     ...dbCoffeeChat,
-    members: [member1, member2]
+    submitter,
+    otherMember
   };
 }
 
 async function serializeCoffeeChat(coffeeChat: CoffeeChat): Promise<DBCoffeeChat> {
-  const member1Data = memberCollection.doc(coffeeChat.members[0].email);
-  const member2Data = memberCollection.doc(coffeeChat.members[1].email);
+  const submitter = memberCollection.doc(coffeeChat.submitter.email);
+  const otherMember = memberCollection.doc(coffeeChat.otherMember.email);
 
   return {
     ...coffeeChat,
-    members: [member1Data, member2Data]
+    submitter,
+    otherMember
   };
 }
 
@@ -69,14 +71,14 @@ export default class CoffeeChatDao extends BaseDao<CoffeeChat, DBCoffeeChat> {
   }
 
   /**
-   * Gets all coffee chat for a user
+   * Gets all coffee chat that a user has submitted
    * @param user - user whose coffee chats should be fetched
    */
   async getCoffeeChatsByUser(user: IdolMember): Promise<CoffeeChat[]> {
     return this.getDocuments([
       {
-        field: 'members',
-        comparisonOperator: 'array-contains',
+        field: 'submitter',
+        comparisonOperator: '==',
         value: memberCollection.doc(user.email)
       }
     ]);

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -107,10 +107,10 @@ export type DevPortfolioSubmissionRequestLog = {
 
 export type DBCoffeeChat = {
   uuid: string;
-  members: firestore.DocumentReference[];
-  image: string;
+  submitter: firestore.DocumentReference;
+  otherMember: firestore.DocumentReference;
+  slackLink: string;
   category: string;
-  description: string;
   status: Status;
   date: number;
 };

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -27,11 +27,11 @@ describe('User is not lead or admin', () => {
 
   const user = fakeIdolMember();
   const user2 = fakeIdolMember();
-  const coffeeChat = { ...fakeCoffeeChat(), members: [user, user2] };
+  const coffeeChat = { ...fakeCoffeeChat(), submitter: user, otherMember: user2 };
   createCoffeeChat(coffeeChat);
 
   test('createCoffeeChat should throw error if creating a coffee chat with self', async () => {
-    const selfChat = { ...coffeeChat, members: [user, user] };
+    const selfChat = { ...coffeeChat, submitter: user, otherMember: user };
     await expect(createCoffeeChat(selfChat)).rejects.toThrow(
       new Error('Cannot create coffee chat with yourself.')
     );
@@ -110,11 +110,12 @@ describe('User is lead or admin', () => {
 
   test('createCoffeeChat should successfully create a coffee chat', async () => {
     const coffeeChat = fakeCoffeeChat();
-    const newChat = { ...coffeeChat, members: [user, fakeIdolMember()] };
+    const newChat = { ...coffeeChat, submitter: user, otherMember: fakeIdolMember() };
     const result = await createCoffeeChat(newChat);
 
     expect(CoffeeChatDao.prototype.createCoffeeChat).toBeCalled();
-    expect(result.members).toEqual(newChat.members);
+    expect(result.submitter).toEqual(newChat.submitter);
+    expect(result.otherMember).toEqual(newChat.otherMember);
   });
 
   test('updateCoffeeChat should successfully update a coffee chat', async () => {
@@ -125,7 +126,7 @@ describe('User is lead or admin', () => {
 
   test('deleteCoffeeChat should successfully delete a coffee chat', async () => {
     const coffeeChat = fakeCoffeeChat();
-    const newChat = { ...coffeeChat, members: [user, fakeIdolMember()] };
+    const newChat = { ...coffeeChat, submitter: user, otherMember: fakeIdolMember() };
     await createCoffeeChat(newChat);
 
     await deleteCoffeeChat(newChat.uuid, user);

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -201,14 +201,14 @@ export const fakeCandidateDeciderInstance = (): CandidateDeciderInstance => {
 
 /** Create fake Coffee Chat */
 export const fakeCoffeeChat = (): CoffeeChat => {
-  const DP = {
+  const CC = {
     uuid: faker.datatype.uuid(),
-    members: [fakeIdolMember()],
-    image: '',
+    submitter: fakeIdolMember(),
+    otherMember: fakeIdolMember(),
+    slackLink: '',
     category: 'test',
-    description: 'test coffee chat',
     status: 'pending',
     date: Date.now()
   };
-  return DP;
+  return CC;
 };

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -211,10 +211,10 @@ interface Shoutout {
 
 interface CoffeeChat {
   readonly uuid: string;
-  readonly members: IdolMember[];
-  readonly image: string;
+  readonly submitter: IdolMember;
+  readonly otherMember: IdolMember;
+  readonly slackLink: string;
   readonly category: string;
-  readonly description: string;
   readonly status: Status;
   readonly date: number;
 }


### PR DESCRIPTION
### Summary <!-- Required -->
Make some updates to CoffeeChat and `DBCoffeeChat`, based on some requirement clarifications. This will make it more clear that a coffee chat needs to be submitted by both members, that the image is actually a Slack link.

We also don't need the description field.

### Notion/Figma Link <!-- Optional -->

https://www.notion.so/Design-Doc-c6dfb74b11cc4c7993ea0939109c9db8?pvs=4

Updated design doc to match the changes in the type.

### Test Plan <!-- Required -->
- Updated unit tests

### Notes <!-- Optional -->


### Breaking Changes <!-- Optional -->

