### PR TITLE
Filter Admin Only Cards for Home Page

### DIFF
--- a/frontend/src/components/Common/NavigationCard/NavigationCard.module.css
+++ b/frontend/src/components/Common/NavigationCard/NavigationCard.module.css
@@ -1,9 +1,3 @@
-.content {
-  margin-left: 2rem;
-  margin-right: 2rem;
-  padding-top: 2rem;
-}
-
 @media (max-width: 900px) {
   .cardsContainer {
     display: flex;

--- a/frontend/src/components/Common/NavigationCard/NavigationCard.tsx
+++ b/frontend/src/components/Common/NavigationCard/NavigationCard.tsx
@@ -19,30 +19,28 @@ export default function NavigationCard({ testID, items }: Props): JSX.Element {
 
   return (
     <div data-testid={testID}>
-      <div className={styles.content}>
-        <Card.Group className={styles.cardsContainer}>
-          {items.map(
-            ({ header, description, link, adminOnly }) =>
-              (!isProduction || !adminOnly || hasAdminPermission) && (
-                <Card key={link}>
-                  <Card.Content>
-                    <Card.Header>{header}</Card.Header>
-                    <Card.Description>{description}</Card.Description>
-                  </Card.Content>
-                  <Card.Content extra>
-                    <div className="ui one buttons">
-                      <Link href={link}>
-                        <Button basic color="blue">
-                          Go To
-                        </Button>
-                      </Link>
-                    </div>
-                  </Card.Content>
-                </Card>
-              )
-          )}
-        </Card.Group>
-      </div>
+      <Card.Group className={styles.cardsContainer}>
+        {items.map(
+          ({ header, description, link, adminOnly }) =>
+            (!isProduction || !adminOnly || hasAdminPermission) && (
+              <Card key={link}>
+                <Card.Content>
+                  <Card.Header>{header}</Card.Header>
+                  <Card.Description>{description}</Card.Description>
+                </Card.Content>
+                <Card.Content extra>
+                  <div className="ui one buttons">
+                    <Link href={link}>
+                      <Button basic color="blue">
+                        Go To
+                      </Button>
+                    </Link>
+                  </div>
+                </Card.Content>
+              </Card>
+            )
+        )}
+      </Card.Group>
     </div>
   );
 }

--- a/frontend/src/components/Homepage/Homepage/Homepage.module.css
+++ b/frontend/src/components/Homepage/Homepage/Homepage.module.css
@@ -21,20 +21,8 @@
 }
 
 .sectionDescription {
-  min-height: 6rem;
+  min-height: 4rem;
   margin-bottom: 1rem;
-}
-
-.card {
-  display: flex;
-  width: 40%;
-  margin-left: 2rem;
-  margin-bottom: 2rem;
-}
-
-.devCard {
-  margin-left: 2rem;
-  margin-bottom: 2rem;
 }
 
 @media (max-width: 900px) {
@@ -43,21 +31,8 @@
     flex-direction: column;
   }
 
-  .card {
-    display: flex;
-    width: 100%;
-    margin-top: 2rem;
-    margin-bottom: 0;
-  }
-
   .sectionDescription {
     min-height: 0;
     margin-bottom: 1rem;
-  }
-
-  .quick {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
   }
 }

--- a/frontend/src/components/Homepage/Homepage/Homepage.tsx
+++ b/frontend/src/components/Homepage/Homepage/Homepage.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 import React from 'react';
-import { Button, Card, Divider } from 'semantic-ui-react';
+import { Divider } from 'semantic-ui-react';
 import styles from './Homepage.module.css';
 
-import { NavigationCardItem } from '../../Common/NavigationCard/NavigationCard';
+import NavigationCard, { NavigationCardItem } from '../../Common/NavigationCard/NavigationCard';
 
 const everyoneItems: readonly NavigationCardItem[] = [
   {
@@ -37,31 +37,6 @@ const devItems: readonly NavigationCardItem[] = [
   }
 ];
 
-const NavCard = ({
-  className,
-  header,
-  description,
-  link
-}: NavigationCardItem & { className?: string }): JSX.Element => (
-  <div className={className ? `styles[${className}]` : styles.card}>
-    <Card key={link}>
-      <Card.Content>
-        <Card.Header>{header}</Card.Header>
-        <Card.Description>{description}</Card.Description>
-      </Card.Content>
-      <Card.Content extra>
-        <div className="ui one buttons">
-          <Link href={link}>
-            <Button basic color="blue">
-              Go To
-            </Button>
-          </Link>
-        </div>
-      </Card.Content>
-    </Card>
-  </div>
-);
-
 const Homepage: React.FC = () => (
   <div className={styles.Homepage} data-testid="Homepage">
     <div className={styles.content}>
@@ -88,11 +63,7 @@ const Homepage: React.FC = () => (
           <p className={styles.sectionDescription}>
             Check out your profile or log your attendance at a DTI event!
           </p>
-          <Card.Group className={styles.quick}>
-            {everyoneItems.map((item) => (
-              <NavCard key={item.link} {...item} />
-            ))}
-          </Card.Group>
+          <NavigationCard items={everyoneItems} />
         </div>
 
         <div>
@@ -105,11 +76,7 @@ const Homepage: React.FC = () => (
               profile you use for your subteam.
             </b>
           </p>
-          <Card.Group className={styles.quick}>
-            {devItems.map((item) => (
-              <NavCard className={styles.devCard} key={item.link} {...item} />
-            ))}
-          </Card.Group>
+          <NavigationCard items={devItems} />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/admin/index.module.css
+++ b/frontend/src/pages/admin/index.module.css
@@ -1,0 +1,5 @@
+.content {
+  margin-left: 2rem;
+  margin-right: 2rem;
+  padding-top: 2rem;
+}

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -2,6 +2,8 @@ import NavigationCard, {
   NavigationCardItem
 } from '../../components/Common/NavigationCard/NavigationCard';
 
+import styles from './index.module.css';
+
 const navCardItems: readonly NavigationCardItem[] = [
   {
     header: 'Member Information Review',
@@ -65,5 +67,9 @@ const navCardItems: readonly NavigationCardItem[] = [
   }
 ];
 
-const AdminIndex = (): JSX.Element => <NavigationCard items={navCardItems} />;
+const AdminIndex = (): JSX.Element => (
+  <div className={styles.content}>
+    <NavigationCard items={navCardItems} />
+  </div>
+);
 export default AdminIndex;

--- a/frontend/src/pages/forms/index.module.css
+++ b/frontend/src/pages/forms/index.module.css
@@ -1,0 +1,5 @@
+.content {
+  margin-left: 2rem;
+  margin-right: 2rem;
+  padding-top: 2rem;
+}

--- a/frontend/src/pages/forms/index.tsx
+++ b/frontend/src/pages/forms/index.tsx
@@ -2,6 +2,8 @@ import NavigationCard, {
   NavigationCardItem
 } from '../../components/Common/NavigationCard/NavigationCard';
 
+import styles from './index.module.css';
+
 const navCardItems: readonly NavigationCardItem[] = [
   { header: 'Sign-In Form', description: 'Sign in to an event!', link: '/forms/signin' },
   {
@@ -32,5 +34,9 @@ const navCardItems: readonly NavigationCardItem[] = [
   }
 ];
 
-const FormsIndex = (): JSX.Element => <NavigationCard items={navCardItems} />;
+const FormsIndex = (): JSX.Element => (
+  <div className={styles.content}>
+    <NavigationCard items={navCardItems} />
+  </div>
+);
 export default FormsIndex;


### PR DESCRIPTION
### Summary <!-- Required -->
We previously were only filtering navigation cards on the "Forms" tab, but not the home page. This is because we had two navigation card components, `NavCard` and `NavigationCard`, the first of which did not contain logic to filter against the "adminOnly" flag. We should allow `adminOnly` to be used on the homepage if we want to gate something through a feature flag.

Also, update the Homepage to use `NavigationCard` and delete `NavCard`. This consequently also fixes an alignment issue on the homepage too.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Verification steps:
1. Check that the "Admin" and "Forms" tab still look the same
2. Check that the homepage styling still looks acceptable (in terms of spacing and alignment of the cards)

Before:
![Screenshot 2024-10-06 at 12 46 27 AM](https://github.com/user-attachments/assets/c3bd8034-c1af-4b46-aef0-82d489de569b)

After:
![Screenshot 2024-10-06 at 12 46 21 AM](https://github.com/user-attachments/assets/a3c29055-f61c-4552-9b08-1aeb34792821)

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

