### PR TITLE
Coffee Chat: Remove lodash isEqual, Add Permissions Checks to createCoffeeChat, Make Smarter DB Queries

### DIFF
--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -1,4 +1,3 @@
-import isEqual from 'lodash.isequal';
 import CoffeeChatDao from '../dao/CoffeeChatDao';
 import PermissionsManager from '../utils/permissionsManager';
 import { PermissionError } from '../utils/errors';
@@ -20,16 +19,30 @@ export const getCoffeeChatsByUser = async (user: IdolMember): Promise<CoffeeChat
 /**
  * Creates a new coffee chat for member
  * @param coffeeChat - Newly created CoffeeChat object
+ * @param user - user who is submitting the coffee chat
  * A member can not coffee chat themselves.
  * A member can not coffee chat the same person from previous semesters.
  */
-export const createCoffeeChat = async (coffeeChat: CoffeeChat): Promise<CoffeeChat> => {
-  if (isEqual(coffeeChat.submitter, coffeeChat.otherMember)) {
+export const createCoffeeChat = async (
+  coffeeChat: CoffeeChat,
+  user: IdolMember
+): Promise<CoffeeChat> => {
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  if (!isLeadOrAdmin && coffeeChat.submitter.email !== user.email) {
+    throw new Error(
+      `User with email ${user.email} does not have permissions to create coffee chat.`
+    );
+  }
+
+  if (coffeeChat.submitter.email === coffeeChat.otherMember.email) {
     throw new Error('Cannot create coffee chat with yourself.');
   }
 
-  const prevChats = await coffeeChatDao.getCoffeeChatsByUser(coffeeChat.submitter);
-  const chatExists = prevChats.some((chat) => isEqual(coffeeChat.otherMember, chat.otherMember));
+  const prevChats = await coffeeChatDao.getCoffeeChatsByUser(
+    coffeeChat.submitter,
+    coffeeChat.otherMember
+  );
+  const chatExists = prevChats.length > 0;
 
   if (chatExists) {
     throw new Error(

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -289,8 +289,8 @@ loginCheckedGet('/coffee-chat', async () => ({
   coffeeChats: await getAllCoffeeChats()
 }));
 
-loginCheckedPost('/coffee-chat', async (req) => ({
-  coffeeChats: await createCoffeeChat(req.body)
+loginCheckedPost('/coffee-chat', async (req, user) => ({
+  coffeeChats: await createCoffeeChat(req.body, user)
 }));
 
 loginCheckedDelete('/coffee-chat', async (_, user) => {

--- a/backend/src/dao/BaseDao.ts
+++ b/backend/src/dao/BaseDao.ts
@@ -6,7 +6,7 @@ import { firestore } from 'firebase-admin';
  * comparisonOperator -- the comparison operator to use for comparison/filtering (https://cloud.google.com/firestore/docs/query-data/queries)
  * value -- the value to compare the field to
  */
-interface FirestoreFilter {
+export interface FirestoreFilter {
   field: string;
   comparisonOperator: FirebaseFirestore.WhereFilterOp;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -29,9 +29,8 @@ const fakeSubteams = (): string[] => {
 };
 
 const fakeRoleObject = () => {
-  const roles: Role[] = ['lead', 'tpm', 'pm', 'developer', 'designer', 'business'];
+  const roles: Role[] = ['tpm', 'pm', 'developer', 'designer', 'business'];
   const role_descriptions: RoleDescription[] = [
-    'Lead',
     'Technical PM',
     'Product Manager',
     'Developer',
@@ -59,6 +58,16 @@ export const fakeIdolMember = (): IdolMember => {
     about: faker.lorem.paragraph(),
     subteams: fakeSubteams(),
     ...fakeRoleObject()
+  };
+  return member;
+};
+
+/** Create fake non-admin */
+export const fakeIdolLead = (): IdolMember => {
+  const member = {
+    ...fakeIdolMember(),
+    role: 'Lead',
+    roleDescription: 'lead'
   };
   return member;
 };


### PR DESCRIPTION
### Summary <!-- Required -->

Following up on some post-merge PR comments from @henry-li-06: https://github.com/cornell-dti/idol/pull/649/files.
- Remove lodash `isEqual` usage since we can just compare emails (over deep equality check)
- Add permissions checks for `createCoffeeChat`
- Make `getCoffeeChatsByUser` have the ability to filter by submitter and otherMember (optional)

### Notion/Figma Link <!-- Optional -->

https://www.notion.so/Design-Doc-c6dfb74b11cc4c7993ea0939109c9db8?pvs=4

### Test Plan <!-- Required -->

Updated existing unit tests wrote new tests for the permissions checks.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

