### PR TITLE
TEC: Don't Delete Image when Rejecting TEC Requests

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventCreditReview.tsx
@@ -58,7 +58,6 @@ const TeamEventCreditReview = (props: {
           headerMsg: 'Team Event Attendance Rejected!',
           contentMsg: 'The team event attendance was successfully rejected!'
         });
-        ImagesAPI.deleteImage(`${teamEventAttendance.image}`);
         Emitters.teamEventsUpdated.emit();
       })
       .catch((error) => {


### PR DESCRIPTION
### Summary <!-- Required -->
Kevin found that images for rejected TEC requests weren't being saved. Looks like we used to remove the image upon rejecting a TEC attendance request since we used to delete the TEC attendance altogether when it was rejected, instead of saving a record.

Looks like there aren't any rejected requests yet so this hasn't been a problem, but we'll want these images when we start making them available on the admin view.

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/TEC-Don-t-Delete-Image-When-Rejecting-TEC-Requests-1180ad723ce18075ad73c5e6c2478ccc?pvs=4

### Test Plan <!-- Required -->


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->


