### PR TITLE
Coffee Chat Admin Tool: Wrap entire cell with link

### DIFF
--- a/frontend/src/components/Admin/CoffeeChats/CoffeeChats.tsx
+++ b/frontend/src/components/Admin/CoffeeChats/CoffeeChats.tsx
@@ -38,22 +38,22 @@ const CoffeeChats: React.FC = () => {
         <div className={styles.bingo_board}>
           {bingoBoard.flat().map((category, index) => (
             <div key={index}>
-              <div className={styles.bingo_cell}>
-                <Link
-                  key={category}
-                  href={{
-                    pathname: `/admin/coffee-chat-details/${hashString(category)}`,
-                    query: { category }
-                  }}
-                >
+              <Link
+                key={category}
+                href={{
+                  pathname: `/admin/coffee-chat-details/${hashString(category)}`,
+                  query: { category }
+                }}
+              >
+                <div className={styles.bingo_cell}>
                   <div style={{ display: 'flex', flexDirection: 'column' }}>
                     <div className={styles.bingo_text}>{category}</div>
                     <div className={styles.pending_text}>
                       {chatCount.get(category) ? `${chatCount.get(category)} pending` : ''}{' '}
                     </div>
                   </div>
-                </Link>
-              </div>
+                </div>
+              </Link>
             </div>
           ))}
         </div>


### PR DESCRIPTION
### Summary <!-- Required -->

Noticed the hit box for the admin cell was a little small. I could only click into the cell once I hit the text, but we should be able to do it by clicking on the cell directly.

Wrap the entire cell in `Link`.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Manual:

https://github.com/user-attachments/assets/73f91314-840b-4174-ba07-a29523799610




### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

