### PR TITLE
Coffee Chat Tool: Fix Delete All Coffee Chat Bug, Better Error Handling

### DIFF
--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -57,8 +57,8 @@ export const createCoffeeChat = async (
     );
   }
 
-  await coffeeChatDao.createCoffeeChat(coffeeChat);
-  return coffeeChat;
+  const newCoffeeChat = await coffeeChatDao.createCoffeeChat(coffeeChat);
+  return newCoffeeChat;
 };
 
 /**

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -291,7 +291,7 @@ loginCheckedGet('/coffee-chat', async () => ({
 }));
 
 loginCheckedPost('/coffee-chat', async (req, user) => ({
-  coffeeChats: await createCoffeeChat(req.body, user)
+  coffeeChat: await createCoffeeChat(req.body, user)
 }));
 
 loginCheckedDelete('/coffee-chat', async (_, user) => {
@@ -310,7 +310,7 @@ loginCheckedGet('/coffee-chat/:email', async (_, user) => {
 });
 
 loginCheckedPut('/coffee-chat', async (req, user) => ({
-  coffeeChats: await updateCoffeeChat(req.body, user)
+  coffeeChat: await updateCoffeeChat(req.body, user)
 }));
 
 loginCheckedGet('/coffee-chat-bingo-board', async () => {

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -85,6 +85,7 @@ describe('User is lead or admin', () => {
   const adminUser = fakeIdolLead();
   const submitter = fakeIdolMember();
   const otherMember = fakeIdolMember();
+  const mockCoffeeChat = fakeCoffeeChat();
 
   beforeAll(() => {
     const mockIsLeadOrAdmin = jest.fn().mockResolvedValue(true);
@@ -92,7 +93,7 @@ describe('User is lead or admin', () => {
     const mockGetCoffeeChatsByUser = jest
       .fn()
       .mockImplementation((submitter, otherMember) => (!otherMember ? [fakeCoffeeChat()] : []));
-    const mockCreateCoffeeChat = jest.fn().mockResolvedValue(fakeCoffeeChat());
+    const mockCreateCoffeeChat = jest.fn().mockResolvedValue(mockCoffeeChat);
     const mockUpdateCoffeeChat = jest.fn().mockResolvedValue(fakeCoffeeChat());
     const mockDeleteCoffeeChat = jest.fn().mockResolvedValue(undefined);
 
@@ -109,11 +110,13 @@ describe('User is lead or admin', () => {
   });
 
   test('createCoffeeChat should allow an admin user to create coffee chat for other user', async () => {
-    const newChat = { ...fakeCoffeeChat(), submitter, otherMember };
-    const result = await createCoffeeChat(newChat, adminUser);
+    const result = await createCoffeeChat(
+      { ...fakeCoffeeChat(), submitter, otherMember },
+      adminUser
+    );
     expect(CoffeeChatDao.prototype.createCoffeeChat).toBeCalled();
-    expect(result.submitter).toEqual(newChat.submitter);
-    expect(result.otherMember).toEqual(newChat.otherMember);
+    expect(result.submitter).toEqual(mockCoffeeChat.submitter);
+    expect(result.otherMember).toEqual(mockCoffeeChat.otherMember);
   });
 
   test('getAllCoffeeChats should return all coffee chats', async () => {
@@ -130,12 +133,14 @@ describe('User is lead or admin', () => {
 
   test('createCoffeeChat should successfully create a coffee chat', async () => {
     const coffeeChat = fakeCoffeeChat();
-    const newChat = { ...coffeeChat, submitter: adminUser, otherMember: fakeIdolMember() };
-    const result = await createCoffeeChat(newChat, adminUser);
+    const result = await createCoffeeChat(
+      { ...coffeeChat, submitter: adminUser, otherMember: fakeIdolMember() },
+      adminUser
+    );
 
     expect(CoffeeChatDao.prototype.createCoffeeChat).toBeCalled();
-    expect(result.submitter).toEqual(newChat.submitter);
-    expect(result.otherMember).toEqual(newChat.otherMember);
+    expect(result.submitter).toEqual(mockCoffeeChat.submitter);
+    expect(result.otherMember).toEqual(mockCoffeeChat.otherMember);
   });
 
   test('updateCoffeeChat should successfully update a coffee chat', async () => {

--- a/frontend/src/API/CoffeeChatAPI.ts
+++ b/frontend/src/API/CoffeeChatAPI.ts
@@ -26,10 +26,15 @@ export default class CoffeeChatAPI {
   }
 
   public static async updateCoffeeChat(coffeeChat: CoffeeChat): Promise<CoffeeChat> {
-    return APIWrapper.put(`${backendURL}/coffee-chat`, coffeeChat).then((res) => res.data);
+    return APIWrapper.put(`${backendURL}/coffee-chat`, coffeeChat).then(
+      (res) => res.data.coffeeChat
+    );
   }
 
   public static async deleteCoffeeChat(uuid: string): Promise<void> {
+    if (!uuid) {
+      return;
+    }
     await APIWrapper.delete(`${backendURL}/coffee-chat/${uuid}`);
   }
 

--- a/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsDashboard.tsx
+++ b/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsDashboard.tsx
@@ -46,6 +46,15 @@ const CoffeeChatsDashboard = ({
   );
 
   const deleteCoffeeChatRequest = (chat: CoffeeChat) => {
+    // Prevent accidentally clearing all coffee chats
+    if (!chat.uuid) {
+      Emitters.generalError.emit({
+        headerMsg: 'Failed to Delete Coffee Chat.',
+        contentMsg:
+          'Something went wrong, and the coffee chat was not deleted successfully. Please try again.'
+      });
+      return;
+    }
     CoffeeChatAPI.deleteCoffeeChat(chat.uuid)
       .then(() => {
         setOpen(false);

--- a/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
+++ b/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
@@ -49,9 +49,7 @@ const CoffeeChatsForm: React.FC = () => {
 
   const coffeeChatExists = (): boolean =>
     approvedChats.some((chat) => chat.otherMember.netid === member?.netid) ||
-    pendingChats.some(
-      (chat) => chat.otherMember.netid === member?.netid || chat.category === category
-    );
+    pendingChats.some((chat) => chat.otherMember.netid === member?.netid);
 
   const coffeeChatCategoryExists = (): boolean =>
     approvedChats.some((chat) => chat.category === category) ||

--- a/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
+++ b/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
@@ -53,6 +53,10 @@ const CoffeeChatsForm: React.FC = () => {
       (chat) => chat.otherMember.netid === member?.netid || chat.category === category
     );
 
+  const coffeeChatCategoryExists = (): boolean =>
+    approvedChats.some((chat) => chat.category === category) ||
+    pendingChats.some((chat) => chat.category === category);
+
   const submitCoffeeChat = async () => {
     if (!member) {
       Emitters.generalError.emit({
@@ -77,7 +81,12 @@ const CoffeeChatsForm: React.FC = () => {
     } else if (coffeeChatExists()) {
       Emitters.generalError.emit({
         headerMsg: 'Coffee Chat Exists',
-        contentMsg: 'Submission exists for this member or category!'
+        contentMsg: 'Pending or approved submission exists for this member!'
+      });
+    } else if (coffeeChatCategoryExists()) {
+      Emitters.generalError.emit({
+        headerMsg: 'Coffee Chat Category Filled',
+        contentMsg: 'There is already a pending or approved coffee chat in this category!'
       });
     } else {
       const newCoffeeChat: CoffeeChat = {
@@ -91,8 +100,8 @@ const CoffeeChatsForm: React.FC = () => {
         date: new Date().getTime()
       };
 
-      CoffeeChatAPI.createCoffeeChat(newCoffeeChat).then(() => {
-        setPendingChats((pending) => [...pending, newCoffeeChat]);
+      CoffeeChatAPI.createCoffeeChat(newCoffeeChat).then((coffeeChat) => {
+        setPendingChats((pending) => [...pending, coffeeChat]);
       });
       Emitters.generalSuccess.emit({
         headerMsg: 'Coffee Chat submitted!',

--- a/new-dti-website/.vscode/settings.json
+++ b/new-dti-website/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "typescript.tsdk": "../node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}


### PR DESCRIPTION
### Summary <!-- Required -->
This PR does a few things:
- There was a bug where if you created a few coffee chats and then delete one, all would be deleted. This is because we weren't storing the UUID of the newly created coffee chats in the state, so when we clicked the delete button, instead of hitting DELETE `/coffee-chat/:uuid`, we'd hit DELETE `/coffee-chat`, since uuid was undefined, so for admins submitting coffee chats, it was possible to accidentally clear all coffee chats in the DB.

Fix that by plumbing the UUID back to the frontend.

- I'm also adding a guard on the frontend to prevent even submitting a request unless the `uuid` is populated
- Also, improve the error messages a bit to be more clear why a submission isn't allowed (split up category and member exists cases)

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Manual

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

