### PR TITLE
Coffee Chats: Disable API Endpoint That Clears All Coffee Chats

### DIFF
--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -1,7 +1,6 @@
 import CoffeeChatDao from '../dao/CoffeeChatDao';
 import PermissionsManager from '../utils/permissionsManager';
 import { PermissionError } from '../utils/errors';
-import { DISABLE_DELETE_ALL_COFFEE_CHATS } from '../consts';
 
 const coffeeChatDao = new CoffeeChatDao();
 
@@ -106,8 +105,9 @@ export const deleteCoffeeChat = async (uuid: string, user: IdolMember): Promise<
  * @param user - The user that is requesting to delete all coffee chats
  */
 export const clearAllCoffeeChats = async (user: IdolMember): Promise<void> => {
-  if (DISABLE_DELETE_ALL_COFFEE_CHATS) {
-    return;
+  const isClearAllCoffeeChatsDisabled = await PermissionsManager.isClearAllCoffeeChatsDisabled();
+  if (isClearAllCoffeeChatsDisabled) {
+    throw new PermissionError('Clearing all Coffee Chats is disabled');
   }
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
   if (!isLeadOrAdmin) {

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -1,6 +1,7 @@
 import CoffeeChatDao from '../dao/CoffeeChatDao';
 import PermissionsManager from '../utils/permissionsManager';
 import { PermissionError } from '../utils/errors';
+import { DISABLE_DELETE_ALL_COFFEE_CHATS } from '../consts';
 
 const coffeeChatDao = new CoffeeChatDao();
 
@@ -105,6 +106,9 @@ export const deleteCoffeeChat = async (uuid: string, user: IdolMember): Promise<
  * @param user - The user that is requesting to delete all coffee chats
  */
 export const clearAllCoffeeChats = async (user: IdolMember): Promise<void> => {
+  if (DISABLE_DELETE_ALL_COFFEE_CHATS) {
+    return;
+  }
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
   if (!isLeadOrAdmin) {
     throw new PermissionError(

--- a/backend/src/consts.ts
+++ b/backend/src/consts.ts
@@ -6,3 +6,5 @@ const COFFEE_CHAT_BINGO_BOARD = [
 ];
 
 export default COFFEE_CHAT_BINGO_BOARD;
+
+export const DISABLE_DELETE_ALL_COFFEE_CHATS = true;

--- a/backend/src/utils/permissionsManager.ts
+++ b/backend/src/utils/permissionsManager.ts
@@ -1,3 +1,4 @@
+import { DISABLE_DELETE_ALL_COFFEE_CHATS } from '../consts';
 import { adminCollection } from '../firebase';
 
 export default class PermissionsManager {
@@ -52,6 +53,10 @@ export default class PermissionsManager {
 
   public static async isLeadOrAdmin(mem: IdolMember): Promise<boolean> {
     return mem.role === 'lead' || this.isAdmin(mem);
+  }
+
+  public static async isClearAllCoffeeChatsDisabled(): Promise<boolean> {
+    return DISABLE_DELETE_ALL_COFFEE_CHATS;
   }
 
   public static async canAccessCandidateDeciderInstance(

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -15,8 +15,8 @@ describe('User is not lead or admin', () => {
   beforeAll(() => {
     const mockIsLeadOrAdmin = jest.fn().mockResolvedValue(false);
     const mockGetCoffeeChatsByUser = jest.fn().mockResolvedValue([coffeeChat]);
-
     PermissionsManager.isLeadOrAdmin = mockIsLeadOrAdmin;
+    PermissionsManager.isClearAllCoffeeChatsDisabled = jest.fn().mockResolvedValue(false);
     CoffeeChatDao.prototype.getCoffeeChatsByUser = mockGetCoffeeChatsByUser;
   });
 
@@ -77,6 +77,13 @@ describe('User is not lead or admin', () => {
       new PermissionError(
         `User with email ${user.email} does not have sufficient permissions to delete all coffee chats.`
       )
+    );
+  });
+
+  test('clearAllCoffeeChats is disabled', async () => {
+    PermissionsManager.isClearAllCoffeeChatsDisabled = jest.fn().mockResolvedValue(true);
+    await expect(clearAllCoffeeChats(user)).rejects.toThrow(
+      new PermissionError('Clearing all Coffee Chats is disabled')
     );
   });
 });


### PR DESCRIPTION
### Summary <!-- Required -->
During our sync with the leads and testing the coffee chat tool out, we realized that the `clearAllCoffeeChats` operation is quite dangerous. Let's disable it for now.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

