### PR TITLE
Disable Coffee Chats For Non-Admins

### DIFF
--- a/frontend/src/consts.ts
+++ b/frontend/src/consts.ts
@@ -3,4 +3,4 @@ export const REQUIRED_MEMBER_TEC_CREDITS = 3;
 export const REQUIRED_LEAD_TEC_CREDITS = 6;
 export const ALL_STATUS: Status[] = ['approved', 'pending', 'rejected'];
 export const INITIATIVE_EVENTS = false;
-export const ENABLE_COFFEE_CHAT = true;
+export const ENABLE_COFFEE_CHAT = false;


### PR DESCRIPTION
### Summary <!-- Required -->

Since coffee chat bingo on IDOL is not ready for public use yet (still undergoing internal testing), we should hide it.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

