### PR TITLE
Auto-scroll to Selected Event

### DIFF
--- a/new-dti-website/components/apply/ApplicationTimeline.tsx
+++ b/new-dti-website/components/apply/ApplicationTimeline.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import config from '../../config.json';
 import timelineIcons from './data/timelineIcons.json';
@@ -197,6 +197,9 @@ const TimelineNode: React.FC<RecruitmentEventProps> = ({
 
 const ApplicationTimeline = () => {
   const [cycle, setCycle] = useState<'freshmen' | 'upperclassmen'>('freshmen');
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const selectedNodeRef = useRef<HTMLDivElement>(null);
+  const { width } = useScreenSize();
 
   const season = config.semester.split(' ')[0].toLocaleLowerCase() as 'fall' | 'spring';
   const isFall = season === 'fall';
@@ -213,6 +216,17 @@ const ApplicationTimeline = () => {
 
   const nextEventIndex =
     1 + sortedEvents.findLastIndex((event) => getEndTime(getDate(event)) < Date.now());
+
+  const scrollToIndex =
+    nextEventIndex === sortedEvents.length ? nextEventIndex - 1 : nextEventIndex;
+
+  useEffect(() => {
+    if (timelineRef.current && selectedNodeRef.current && width >= TABLET_BREAKPOINT) {
+      const innerDiv = selectedNodeRef.current.getBoundingClientRect().top;
+      const outerDiv = timelineRef.current.getBoundingClientRect().top;
+      timelineRef.current.scrollTop += innerDiv - outerDiv;
+    }
+  });
 
   return (
     <div className="flex justify-center relative">
@@ -254,15 +268,18 @@ const ApplicationTimeline = () => {
           <div
             className="flex flex-col md:gap-10 xs:gap-7 md:max-h-[600px] md:overflow-y-scroll 
             xs:overflow-y-hidden py-8"
+            ref={timelineRef}
           >
             {sortedEvents.map((event, index) => (
-              <TimelineNode
-                event={event}
-                index={index}
-                nextEventIndex={nextEventIndex}
-                isLast={index === filteredEvents.length - 1}
-                dateTime={getDate(event)}
-              />
+              <div key={index} ref={index === scrollToIndex ? selectedNodeRef : undefined}>
+                <TimelineNode
+                  event={event}
+                  index={index}
+                  nextEventIndex={nextEventIndex}
+                  isLast={index === filteredEvents.length - 1}
+                  dateTime={getDate(event)}
+                />
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
### Summary <!-- Required -->
The timeline will automatically scroll to the next or current event, i.e the one that is selected. If there are no selected events, the timeline scrolls to the very bottom.
<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Notion/Figma Link <!-- Optional -->
[Figma](https://www.figma.com/design/1nUpvsfgc9eftTyoHt7XuN/Website-Designs-SP24?node-id=1138-3162&node-type=frame&t=tgZ5CxIR1S9Z6T57-0)
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

https://github.com/user-attachments/assets/a8a71a34-fd79-45ba-8e4f-06a1f6a3bf96


<!-- Provide screenshots or point out the additional unit tests -->
