### PR TITLE
Enable Coffee Chats on IDOL

### DIFF
--- a/frontend/src/consts.ts
+++ b/frontend/src/consts.ts
@@ -3,4 +3,4 @@ export const REQUIRED_MEMBER_TEC_CREDITS = 3;
 export const REQUIRED_LEAD_TEC_CREDITS = 6;
 export const ALL_STATUS: Status[] = ['approved', 'pending', 'rejected'];
 export const INITIATIVE_EVENTS = false;
-export const ENABLE_COFFEE_CHAT = false;
+export const ENABLE_COFFEE_CHAT = true;


### PR DESCRIPTION
### Summary <!-- Required -->
We're going to start rolling out coffee chats for DTI members. Rollout plan:
1. Enable on IDOL for non-members.
2. Have everyone on IDOL try it out
3. Select a few people who've submitted a lot of coffee chats to try the tool out
4. Launch at all-hands 11/9

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Manually verified that all non-admins can see the tool now.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
