### PR TITLE
Coffee Chat: Show Error on Admin Side, Add Re-run Auto Checker Button, Fix checkMemberMeetsCategory Logic

### DIFF
--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -135,7 +135,7 @@ export const runAutoChecker = async (uuid: string, user: IdolMember): Promise<Co
   const canRunAutoChecker = await PermissionsManager.isLeadOrAdmin(user);
   if (!canRunAutoChecker)
     throw new PermissionError(
-      `User with email ${user.email} does not have permission to regrade dev portfolio submissions`
+      `User with email ${user.email} does not have permission to run auto checker`
     );
 
   const coffeeChat = await coffeeChatDao.getCoffeeChat(uuid);
@@ -189,54 +189,66 @@ export const checkMemberMeetsCategory = async (
 
   // If otherMember and submitter don't exist, status should stay undefined
   if (otherMember && submitter) {
+    // Member coffee chatted themselves
+    if (otherMember.netid === submitter.netid) {
+      return { status: 'fail', message };
+    }
+
     if (category === 'an alumni') {
       status = (await allMembers()).every((member) => member.email !== otherMember.email)
         ? 'pass'
         : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember.lastName} is not an alumni`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember.lastName} is not an alumni`;
+      }
     } else if (category === 'courseplan member') {
       status = otherMember.subteams.includes('courseplan') ? 'pass' : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember?.lastName} is not a CoursePlan member`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember?.lastName} is not a CoursePlan member`;
+      }
     } else if (category === 'business member') {
       status = otherMember.role === 'business' ? 'pass' : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember.lastName} is not a business member`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember.lastName} is not a business member`;
+      }
     } else if (category === 'idol member') {
       status = otherMember.subteams.includes('idol') ? 'pass' : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember.lastName} is not an IDOL member`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember.lastName} is not an IDOL member`;
+      }
     } else if (category === 'curaise member') {
       status = otherMember.subteams.includes('curaise') ? 'pass' : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember.lastName} is not a CURaise member`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember.lastName} is not a CURaise member`;
+      }
     } else if (category === 'cornellgo member') {
       status = otherMember.subteams.includes('cornellgo') ? 'pass' : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember.lastName} is not a CornellGo member`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember.lastName} is not a CornellGo member`;
+      }
     } else if (category === 'carriage member') {
       status = otherMember.subteams.includes('carriage') ? 'pass' : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember.lastName} is not a Carriage member`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember.lastName} is not a Carriage member`;
+      }
     } else if (category === 'qmi member') {
       status = otherMember.subteams.includes('queuemein') ? 'pass' : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember.lastName} is not a QMI member`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember.lastName} is not a QMI member`;
+      }
     } else if (category === 'cuapts member') {
       status = otherMember.subteams.includes('cuapts') ? 'pass' : 'fail';
-      status === 'fail' &&
-        (message = `${otherMember.firstName} ${otherMember.lastName} is not a CUApts member`);
+      if (status === 'fail') {
+        message = `${otherMember.firstName} ${otherMember.lastName} is not a CUApts member`;
+      }
     } else if (category === 'a pm (not your team)') {
       const isPm = otherMember.role === 'pm';
       const notSameTeam = haveNoCommonSubteams(submitter, otherMember);
       status = isPm && notSameTeam ? 'pass' : 'fail';
       if (status === 'fail') {
-        if (!isPm && !notSameTeam) {
-          message = `${otherMember.firstName} ${otherMember.lastName} is not a PM and is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
-        } else if (!isPm) {
+        if (!isPm) {
           message = `${otherMember.firstName} ${otherMember.lastName} is not a PM`;
-        } else if (!notSameTeam) {
+        } else {
           message = `${otherMember.firstName} ${otherMember.lastName} is a PM, but on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
         }
       }
@@ -245,11 +257,9 @@ export const checkMemberMeetsCategory = async (
       const notSameTeam = haveNoCommonSubteams(submitter, otherMember);
       status = isTpm && notSameTeam ? 'pass' : 'fail';
       if (status === 'fail') {
-        if (!isTpm && !notSameTeam) {
-          message = `${otherMember.firstName} ${otherMember.lastName} is not a TPM and is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
-        } else if (!isTpm) {
+        if (!isTpm) {
           message = `${otherMember.firstName} ${otherMember.lastName} is not a TPM`;
-        } else if (!notSameTeam) {
+        } else {
           message = `${otherMember.firstName} ${otherMember.lastName} is a TPM, but is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
         }
       }
@@ -259,52 +269,56 @@ export const checkMemberMeetsCategory = async (
     if (otherMemberProperties) {
       if (category === 'a newbie') {
         status = otherMemberProperties.newbie ? 'pass' : 'fail';
-        status === 'fail' &&
-          (message = `${otherMember.firstName} ${otherMember.lastName} is not a newbie`);
+        if (status === 'fail') {
+          message = `${otherMember.firstName} ${otherMember.lastName} is not a newbie`;
+        }
       } else if (category === 'is/was a TA') {
         status = otherMemberProperties.ta ? 'pass' : 'fail';
-        status === 'fail' &&
-          (message = `${otherMember.firstName} ${otherMember.lastName} was never a TA`);
+        if (status === 'fail') {
+          message = `${otherMember.firstName} ${otherMember.lastName} was never a TA`;
+        }
       } else if (category === 'major/minor that is not cs/infosci') {
         status = otherMemberProperties.notCsOrInfosci ? 'pass' : 'fail';
-        status === 'fail' &&
-          (message = `${otherMember.firstName} ${otherMember.lastName} is a CS or Infosci major`);
+        if (status === 'fail') {
+          message = `${otherMember.firstName} ${otherMember.lastName} is a CS or Infosci major`;
+        }
       }
 
       // If submitterProperties doesn't exist, status should stay undefined
       if (submitterProperties) {
         if (category === 'from a different college') {
           status = otherMemberProperties.college !== submitterProperties.college ? 'pass' : 'fail';
-          status === 'fail' &&
-            (message = `${otherMember.firstName} ${otherMember.lastName} is from the same college as ${submitter.firstName} ${submitter.lastName} (${otherMemberProperties.college})`);
+          if (status === 'fail') {
+            message = `${otherMember.firstName} ${otherMember.lastName} is from the same college as ${submitter.firstName} ${submitter.lastName} (${otherMemberProperties.college})`;
+          }
         }
       }
+    }
 
-      if (category === 'a lead (not your role)') {
-        const isLead = otherMember.role === 'lead';
-        let diffRole;
+    if (category === 'a lead (not your role)') {
+      const isLead = otherMember.role === 'lead';
+      if (!isLead) {
+        status = 'fail';
+        message = `${otherMember.firstName} ${otherMember.lastName} is not a lead`;
+      }
 
+      let diffRole;
+      // If otherMember is a lead, but otherMemberProperties doesn't exist, status should stay undefined
+      if (otherMemberProperties) {
         if (submitter.role !== 'lead') {
           diffRole = otherMemberProperties.leadType !== submitter.role;
+          // If submitter is a lead, but submitterProperties doesn't exist, status should stay undefined
         } else if (submitterProperties) {
           diffRole = otherMemberProperties.leadType !== submitterProperties.leadType;
         } else {
           diffRole = undefined;
         }
+      }
 
-        // If submitter is a lead, but submitterProperties doesn't exist, status should stay undefined
-        if (diffRole !== undefined) {
-          status = isLead && diffRole;
-
-          if (!status) {
-            if (!isLead && !diffRole) {
-              message = `${otherMember.firstName} ${otherMember.lastName} is not a lead and is from the same role as ${submitter.firstName} ${submitter.lastName}`;
-            } else if (!isLead) {
-              message = `${otherMember.firstName} ${otherMember.lastName} is not a lead`;
-            } else if (!diffRole) {
-              message = `${otherMember.firstName} ${otherMember.lastName} is a lead, but from the same role (${submitter.role}) as ${submitter.firstName} ${submitter.lastName}`;
-            }
-          }
+      if (diffRole !== undefined) {
+        status = isLead && diffRole;
+        if (!status) {
+          message = `${otherMember.firstName} ${otherMember.lastName} is a lead, but from the same role (${submitter.role}) as ${submitter.firstName} ${submitter.lastName}`;
         }
       }
     }

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -163,19 +163,18 @@ export const runAutoChecker = async (uuid: string, user: IdolMember): Promise<Co
  * Checks if a member meets a category.
  * @param otherMemberEmail - the email of the member we are checking.
  * @param submitterEmail - the email of the member that submitted the coffee chat.
- * @param encodedCategory - the category we are checking with (encoded).
+ * @param category - the category we are checking with.
  * @returns 'pass' if a member meets a category, 'fail' if not, 'no data' if not enough data to know.
  */
 export const checkMemberMeetsCategory = async (
   otherMemberEmail: string,
   submitterEmail: string,
-  encodedCategory: string
+  category: string
 ): Promise<{ status: MemberMeetsCategoryStatus; message: string }> => {
   const otherMemberProperties = await CoffeeChatDao.getMemberProperties(otherMemberEmail);
   const submitterProperties = await CoffeeChatDao.getMemberProperties(submitterEmail);
   const otherMember = await getMember(otherMemberEmail);
   const submitter = await getMember(submitterEmail);
-  const category = decodeURIComponent(encodedCategory);
   const haveNoCommonSubteams = (member1: IdolMember, member2: IdolMember): boolean =>
     member2.subteams.every((team) => !member1.subteams.includes(team)) &&
     member1.subteams.every((team) => !member2.subteams.includes(team));
@@ -244,7 +243,7 @@ export const checkMemberMeetsCategory = async (
         if (!isPm) {
           message = `${otherMember.firstName} ${otherMember.lastName} is not a PM`;
         } else {
-          message = `${otherMember.firstName} ${otherMember.lastName} is a PM, but on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
+          message = `${otherMember.firstName} ${otherMember.lastName} is a PM, but is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
         }
       }
     } else if (category === 'a tpm (not your team)') {

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -148,129 +148,129 @@ export const checkMemberMeetsCategory = async (
   let status: boolean | undefined;
   let message: string = '';
 
-  if (category === 'an alumni') {
-    status = (await allMembers()).every((member) => member.email !== otherMember?.email);
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not an alumni`;
-    }
+  // If otherMember doesn't exist in the DB, assume they are an alumni
+  if (!otherMember && category === 'an alumni') {
+    return { status: true, message };
   }
-  if (category === 'courseplan member') {
-    status = otherMember?.subteams.includes('courseplan');
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a CoursePlan member`;
+
+  // If otherMember and submitter don't exist, status should stay undefined
+  if (otherMember && submitter) {
+    if (category === 'an alumni') {
+      status = (await allMembers()).every((member) => member.email !== otherMember.email);
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember.lastName} is not an alumni`);
+    } else if (category === 'courseplan member') {
+      status = otherMember.subteams.includes('courseplan');
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember?.lastName} is not a CoursePlan member`);
+    } else if (category === 'business member') {
+      status = otherMember.role === 'business';
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember.lastName} is not a business member`);
+    } else if (category === 'idol member') {
+      status = otherMember.subteams.includes('idol');
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember.lastName} is not an IDOL member`);
+    } else if (category === 'curaise member') {
+      status = otherMember.subteams.includes('curaise');
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember.lastName} is not a CURaise member`);
+    } else if (category === 'cornellgo member') {
+      status = otherMember.subteams.includes('cornellgo');
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember.lastName} is not a CornellGo member`);
+    } else if (category === 'carriage member') {
+      status = otherMember.subteams.includes('carriage');
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember.lastName} is not a Carriage member`);
+    } else if (category === 'qmi member') {
+      status = otherMember.subteams.includes('queuemein');
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember.lastName} is not a QMI member`);
+    } else if (category === 'cuapts member') {
+      status = otherMember.subteams.includes('cuapts');
+      status === false &&
+        (message = `${otherMember.firstName} ${otherMember.lastName} is not a CUApts member`);
+    } else if (category === 'a pm (not your team)') {
+      const isPm = otherMember.role === 'pm';
+      const notSameTeam = haveNoCommonSubteams(submitter, otherMember);
+      status = isPm && notSameTeam;
+      if (status === false) {
+        if (!isPm && !notSameTeam) {
+          message = `${otherMember.firstName} ${otherMember.lastName} is not a PM and is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
+        } else if (!isPm) {
+          message = `${otherMember.firstName} ${otherMember.lastName} is not a PM`;
+        } else if (!notSameTeam) {
+          message = `${otherMember.firstName} ${otherMember.lastName} is a PM, but on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
+        }
+      }
+    } else if (category === 'a tpm (not your team)') {
+      const isTpm = otherMember.role === 'tpm';
+      const notSameTeam = haveNoCommonSubteams(submitter, otherMember);
+      status = isTpm && notSameTeam;
+      if (status === false) {
+        if (!isTpm && !notSameTeam) {
+          message = `${otherMember.firstName} ${otherMember.lastName} is not a TPM and is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
+        } else if (!isTpm) {
+          message = `${otherMember.firstName} ${otherMember.lastName} is not a TPM`;
+        } else if (!notSameTeam) {
+          message = `${otherMember.firstName} ${otherMember.lastName} is a TPM, but is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
+        }
+      }
     }
-  }
-  if (category === 'a pm (not your team)') {
-    const isPm = otherMember?.role === 'pm';
-    const notSameTeam = otherMember && submitter && haveNoCommonSubteams(submitter, otherMember);
-    status = isPm && notSameTeam;
-    if (status === false && !isPm) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a PM`;
-    }
-    if (status === false && !notSameTeam) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is a PM, but on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
-    }
-    if (status === false && !isPm && !notSameTeam) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a PM and is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
-    }
-  }
-  if (category === 'business member') {
-    status = otherMember?.role === 'business';
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a business member`;
-    }
-  }
-  if (category === 'is/was a TA') {
-    status = otherMemberProperties ? otherMemberProperties.ta : undefined;
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} was never a TA`;
-    }
-  }
-  if (category === 'major/minor that is not cs/infosci') {
-    status = otherMemberProperties ? otherMemberProperties.notCsOrInfosci : undefined;
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is a CS or Infosci major`;
-    }
-  }
-  if (category === 'idol member') {
-    status = otherMember?.subteams.includes('idol');
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not an IDOL member`;
-    }
-  }
-  if (category === 'a newbie') {
-    status = otherMemberProperties ? otherMemberProperties.newbie : undefined;
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a newbie`;
-    }
-  }
-  if (category === 'from a different college') {
-    status =
-      otherMemberProperties && submitterProperties
-        ? otherMemberProperties.college !== submitterProperties.college
-        : undefined;
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is from the same college as ${submitter?.firstName} ${submitter?.lastName} (${otherMemberProperties?.college})`;
-    }
-  }
-  if (category === 'curaise member') {
-    status = otherMember?.subteams.includes('curaise');
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a CURaise member`;
-    }
-  }
-  if (category === 'cornellgo member') {
-    status = otherMember?.subteams.includes('cornellgo');
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a CornellGo member`;
-    }
-  }
-  if (category === 'a tpm (not your team)') {
-    const isTpm = otherMember?.role === 'tpm';
-    const notSameTeam = otherMember && submitter && haveNoCommonSubteams(submitter, otherMember);
-    status = isTpm && notSameTeam;
-    if (status === false && !isTpm) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a TPM`;
-    }
-    if (status === false && !notSameTeam) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is a TPM, but is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
-    }
-    if (status === false && !isTpm && !notSameTeam) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a TPM and is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
-    }
-  }
-  if (category === 'carriage member') {
-    status = otherMember?.subteams.includes('carriage');
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a Carriage member`;
-    }
-  }
-  if (category === 'qmi member') {
-    status = otherMember?.subteams.includes('queuemein');
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a QMI member`;
-    }
-  }
-  if (category === 'a lead (not your role)') {
-    const isLead = otherMember?.role === 'lead' && submitter?.role !== 'lead';
-    const diffRole = isLead
-      ? otherMemberProperties?.leadType !== submitter?.role
-      : otherMemberProperties?.leadType !== submitterProperties?.leadType;
-    status = isLead && diffRole;
-    if (status === false && !isLead) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a lead`;
-    }
-    if (status === false && !diffRole) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is a lead, but from the same role (${submitter?.role}) as ${submitter?.firstName} ${submitter?.lastName}`;
-    }
-    if (status === false && !isLead && !diffRole) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a lead and is from the same role as ${submitter?.firstName} ${submitter?.lastName}`;
-    }
-  }
-  if (category === 'cuapts member') {
-    status = otherMember?.subteams.includes('cuapts');
-    if (status === false) {
-      message = `${otherMember?.firstName} ${otherMember?.lastName} is not a CUApts member`;
+
+    // If otherMemberProperties doesn't exist, status should stay undefined
+    if (otherMemberProperties) {
+      if (category === 'a newbie') {
+        status = otherMemberProperties.newbie;
+        status === false &&
+          (message = `${otherMember.firstName} ${otherMember.lastName} is not a newbie`);
+      } else if (category === 'is/was a TA') {
+        status = otherMemberProperties.ta;
+        status === false &&
+          (message = `${otherMember.firstName} ${otherMember.lastName} was never a TA`);
+      } else if (category === 'major/minor that is not cs/infosci') {
+        status = otherMemberProperties.notCsOrInfosci;
+        status === false &&
+          (message = `${otherMember.firstName} ${otherMember.lastName} is a CS or Infosci major`);
+      }
+
+      // If submitterProperties doesn't exist, status should stay undefined
+      if (submitterProperties) {
+        if (category === 'from a different college') {
+          status = otherMemberProperties.college !== submitterProperties.college;
+          status === false &&
+            (message = `${otherMember.firstName} ${otherMember.lastName} is from the same college as ${submitter.firstName} ${submitter.lastName} (${otherMemberProperties.college})`);
+        }
+      }
+
+      if (category === 'a lead (not your role)') {
+        const isLead = otherMember.role === 'lead';
+        let diffRole;
+
+        if (submitter.role !== 'lead') {
+          diffRole = otherMemberProperties.leadType !== submitter.role;
+        } else if (submitterProperties) {
+          diffRole = otherMemberProperties.leadType !== submitterProperties.leadType;
+        } else {
+          diffRole = undefined;
+        }
+
+        // If submitter is a lead, but submitterProperties doesn't exist, status should stay undefined
+        if (diffRole !== undefined) {
+          status = isLead && diffRole;
+
+          if (!status) {
+            if (!isLead && !diffRole) {
+              message = `${otherMember.firstName} ${otherMember.lastName} is not a lead and is from the same role as ${submitter.firstName} ${submitter.lastName}`;
+            } else if (!isLead) {
+              message = `${otherMember.firstName} ${otherMember.lastName} is not a lead`;
+            } else if (!diffRole) {
+              message = `${otherMember.firstName} ${otherMember.lastName} is a lead, but from the same role (${submitter.role}) as ${submitter.firstName} ${submitter.lastName}`;
+            }
+          }
+        }
+      }
     }
   }
   return { status, message };

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -316,7 +316,7 @@ export const checkMemberMeetsCategory = async (
       }
 
       if (diffRole !== undefined) {
-        status = isLead && diffRole;
+        status = diffRole;
         if (!status) {
           message = `${otherMember.firstName} ${otherMember.lastName} is a lead, but from the same role (${submitter.role}) as ${submitter.firstName} ${submitter.lastName}`;
         }

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -189,11 +189,6 @@ export const checkMemberMeetsCategory = async (
 
   // If otherMember and submitter don't exist, status should stay undefined
   if (otherMember && submitter) {
-    // Member coffee chatted themselves
-    if (otherMember.netid === submitter.netid) {
-      return { status: 'fail', message };
-    }
-
     if (category === 'an alumni') {
       status = (await allMembers()).every((member) => member.email !== otherMember.email)
         ? 'pass'

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -300,11 +300,10 @@ export const checkMemberMeetsCategory = async (
       if (!isLead) {
         status = 'fail';
         message = `${otherMember.firstName} ${otherMember.lastName} is not a lead`;
-      }
 
-      let diffRole;
-      // If otherMember is a lead, but otherMemberProperties doesn't exist, status should stay undefined
-      if (otherMemberProperties) {
+        // If otherMember is a lead, but otherMemberProperties doesn't exist, status should stay undefined
+      } else if (otherMemberProperties) {
+        let diffRole;
         if (submitter.role !== 'lead') {
           diffRole = otherMemberProperties.leadType !== submitter.role;
           // If submitter is a lead, but submitterProperties doesn't exist, status should stay undefined
@@ -313,12 +312,11 @@ export const checkMemberMeetsCategory = async (
         } else {
           diffRole = undefined;
         }
-      }
-
-      if (diffRole !== undefined) {
-        status = diffRole;
-        if (!status) {
-          message = `${otherMember.firstName} ${otherMember.lastName} is a lead, but from the same role (${submitter.role}) as ${submitter.firstName} ${submitter.lastName}`;
+        if (diffRole !== undefined) {
+          status = diffRole ? 'pass' : 'fail';
+          if (!diffRole) {
+            message = `${otherMember.firstName} ${otherMember.lastName} is a lead, but from the same role (${submitter.role}) as ${submitter.firstName} ${submitter.lastName}`;
+          }
         }
       }
     }

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -324,7 +324,7 @@ loginCheckedGet('/coffee-chat/:otherMemberEmail/:submitterEmail/:category', asyn
   const result = await checkMemberMeetsCategory(
     req.params.otherMemberEmail,
     req.params.submitterEmail,
-    req.params.category
+    decodeURIComponent(req.params.category)
   );
   return { result };
 });

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -326,15 +326,15 @@ loginCheckedGet('/coffee-chat/:otherMemberEmail/:submitterEmail/:category', asyn
     req.params.category
   );
 
-  let result;
-  if (res === true) {
-    result = 'pass';
-  } else if (res === false) {
-    result = 'fail';
+  let output;
+  if (res.status === true) {
+    output = 'pass';
+  } else if (res.status === false) {
+    output = 'fail';
   } else {
-    result = 'no data';
+    output = 'no data';
   }
-
+  const result = { status: output, message: res.message };
   return { result };
 });
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -40,7 +40,8 @@ import {
   deleteCoffeeChat,
   clearAllCoffeeChats,
   getCoffeeChatBingoBoard,
-  checkMemberMeetsCategory
+  checkMemberMeetsCategory,
+  runAutoChecker
 } from './API/coffeeChatAPI';
 import {
   allSignInForms,
@@ -320,23 +321,17 @@ loginCheckedGet('/coffee-chat-bingo-board', async () => {
 });
 
 loginCheckedGet('/coffee-chat/:otherMemberEmail/:submitterEmail/:category', async (req) => {
-  const res = await checkMemberMeetsCategory(
+  const result = await checkMemberMeetsCategory(
     req.params.otherMemberEmail,
     req.params.submitterEmail,
     req.params.category
   );
-
-  let output;
-  if (res.status === true) {
-    output = 'pass';
-  } else if (res.status === false) {
-    output = 'fail';
-  } else {
-    output = 'no data';
-  }
-  const result = { status: output, message: res.message };
   return { result };
 });
+
+loginCheckedPut('/coffee-chat/autocheck/:uuid/', async (req, user) => ({
+  coffeeChat: await runAutoChecker(req.params.uuid, user)
+}));
 
 // Pull from IDOL
 loginCheckedPost('/pullIDOLChanges', (_, user) => requestIDOLPullDispatch(user));

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -115,6 +115,7 @@ export type DBCoffeeChat = {
   category: string;
   status: Status;
   date: number;
+  memberMeetsCategory: MemberMeetsCategoryStatus;
   reason?: string;
   errorMessage?: string;
 };

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -116,4 +116,5 @@ export type DBCoffeeChat = {
   status: Status;
   date: number;
   reason?: string;
+  errorMessage?: string;
 };

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -8,7 +8,6 @@ import {
   updateCoffeeChat,
   deleteCoffeeChat,
   clearAllCoffeeChats
-  // checkMemberMeetsCategory
 } from '../src/API/coffeeChatAPI';
 import { PermissionError } from '../src/utils/errors';
 
@@ -166,77 +165,3 @@ describe('User is lead or admin', () => {
     expect(CoffeeChatDao.prototype.deleteCoffeeChat).toBeCalled();
   });
 });
-
-// describe('More complicated member meets category checks', () => {
-//   test('pm that is not on same team', async () => {
-//     const result = await checkMemberMeetsCategory('al853@cornell.edu', 'ph444@cornell.edu', 'a pm (not your team)')
-//     expect(result.status).toBe('pass')
-//     expect(result.message).toBe('')
-//   });
-
-//   test('pm that is on same team', async () => {
-//     const result = await checkMemberMeetsCategory('ar2345@cornell.edu', 'ph444@cornell.edu', 'a pm (not your team)')
-//     expect(result.status).toBe('fail')
-//     expect(result.message).toBe('Amelie Rosso is a PM, but is on the same team as Patricia Huang')
-//   });
-
-//   test('not a pm', async () => {
-//     const result = await checkMemberMeetsCategory('atl82@cornell.edu', 'ph444@cornell.edu', 'a pm (not your team)')
-//     expect(result.status).toBe('fail')
-//     expect(result.message).toBe('An Le is not a PM')
-//   });
-
-//   test('tpm that is not on same team', async () => {
-//     const result = await checkMemberMeetsCategory('nm549@cornell.edu', 'ph444@cornell.edu', 'a tpm (not your team)')
-//     expect(result.status).toBe('pass')
-//     expect(result.message).toBe('')
-//   });
-
-//   test('tpm that is on same team', async () => {
-//     const result = await checkMemberMeetsCategory('axc2@cornell.edu', 'ph444@cornell.edu', 'a tpm (not your team)')
-//     expect(result.status).toBe('fail')
-//     expect(result.message).toBe('Andrew Chen is a TPM, but is on the same team as Patricia Huang')
-//   });
-
-//   test('not a tpm', async () => {
-//     const result = await checkMemberMeetsCategory('atl82@cornell.edu', 'ph444@cornell.edu', 'a tpm (not your team)')
-//     expect(result.status).toBe('fail')
-//     expect(result.message).toBe('An Le is not a TPM')
-//   });
-
-//   test('a lead that is not same role', async () => {
-//     const result = await checkMemberMeetsCategory('egk46@cornell.edu', 'ph444@cornell.edu', 'a lead (not your role)')
-//     expect(result.status).toBe('pass')
-//     expect(result.message).toBe('')
-//   });
-
-//   test('a lead that is the same role', async () => {
-//     const result = await checkMemberMeetsCategory('ow39@cornell.edu', 'ph444@cornell.edu', 'a lead (not your role)')
-//     expect(result.status).toBe('fail')
-//     expect(result.message).toBe('Oscar Wang is a lead, but from the same role (developer) as Patricia Huang')
-//   });
-
-//   test('not a lead', async () => {
-//     const result = await checkMemberMeetsCategory('atl82@cornell.edu', 'ph444@cornell.edu', 'a lead (not your role)')
-//     expect(result.status).toBe('fail')
-//     expect(result.message).toBe('An Le is not a lead')
-//   });
-
-//   test('should pass but otherMemberProperties undefined', async () => {
-//     const result = await checkMemberMeetsCategory('sz266@cornell.edu', 'ph444@cornell.edu', 'a lead (not your role)')
-//     expect(result.status).toBe('no data')
-//     expect(result.message).toBe('')
-//   });
-
-//   test('should pass but submitterProperties undefined', async () => {
-//     const result = await checkMemberMeetsCategory('egk46@cornell.edu', 'sz266@cornell.edu', 'a lead (not your role)')
-//     expect(result.status).toBe('no data')
-//     expect(result.message).toBe('')
-//   });
-
-//   test('both submitterProperties and otherMemberProperties undefined', async () => {
-//     const result = await checkMemberMeetsCategory('sz266@cornell.edu', 'szw3@cornell.edu', 'a lead (not your role)')
-//     expect(result.status).toBe('no data')
-//     expect(result.message).toBe('')
-//   });
-// });

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -8,6 +8,7 @@ import {
   updateCoffeeChat,
   deleteCoffeeChat,
   clearAllCoffeeChats
+  // checkMemberMeetsCategory
 } from '../src/API/coffeeChatAPI';
 import { PermissionError } from '../src/utils/errors';
 
@@ -165,3 +166,77 @@ describe('User is lead or admin', () => {
     expect(CoffeeChatDao.prototype.deleteCoffeeChat).toBeCalled();
   });
 });
+
+// describe('More complicated member meets category checks', () => {
+//   test('pm that is not on same team', async () => {
+//     const result = await checkMemberMeetsCategory('al853@cornell.edu', 'ph444@cornell.edu', 'a pm (not your team)')
+//     expect(result.status).toBe('pass')
+//     expect(result.message).toBe('')
+//   });
+
+//   test('pm that is on same team', async () => {
+//     const result = await checkMemberMeetsCategory('ar2345@cornell.edu', 'ph444@cornell.edu', 'a pm (not your team)')
+//     expect(result.status).toBe('fail')
+//     expect(result.message).toBe('Amelie Rosso is a PM, but is on the same team as Patricia Huang')
+//   });
+
+//   test('not a pm', async () => {
+//     const result = await checkMemberMeetsCategory('atl82@cornell.edu', 'ph444@cornell.edu', 'a pm (not your team)')
+//     expect(result.status).toBe('fail')
+//     expect(result.message).toBe('An Le is not a PM')
+//   });
+
+//   test('tpm that is not on same team', async () => {
+//     const result = await checkMemberMeetsCategory('nm549@cornell.edu', 'ph444@cornell.edu', 'a tpm (not your team)')
+//     expect(result.status).toBe('pass')
+//     expect(result.message).toBe('')
+//   });
+
+//   test('tpm that is on same team', async () => {
+//     const result = await checkMemberMeetsCategory('axc2@cornell.edu', 'ph444@cornell.edu', 'a tpm (not your team)')
+//     expect(result.status).toBe('fail')
+//     expect(result.message).toBe('Andrew Chen is a TPM, but is on the same team as Patricia Huang')
+//   });
+
+//   test('not a tpm', async () => {
+//     const result = await checkMemberMeetsCategory('atl82@cornell.edu', 'ph444@cornell.edu', 'a tpm (not your team)')
+//     expect(result.status).toBe('fail')
+//     expect(result.message).toBe('An Le is not a TPM')
+//   });
+
+//   test('a lead that is not same role', async () => {
+//     const result = await checkMemberMeetsCategory('egk46@cornell.edu', 'ph444@cornell.edu', 'a lead (not your role)')
+//     expect(result.status).toBe('pass')
+//     expect(result.message).toBe('')
+//   });
+
+//   test('a lead that is the same role', async () => {
+//     const result = await checkMemberMeetsCategory('ow39@cornell.edu', 'ph444@cornell.edu', 'a lead (not your role)')
+//     expect(result.status).toBe('fail')
+//     expect(result.message).toBe('Oscar Wang is a lead, but from the same role (developer) as Patricia Huang')
+//   });
+
+//   test('not a lead', async () => {
+//     const result = await checkMemberMeetsCategory('atl82@cornell.edu', 'ph444@cornell.edu', 'a lead (not your role)')
+//     expect(result.status).toBe('fail')
+//     expect(result.message).toBe('An Le is not a lead')
+//   });
+
+//   test('should pass but otherMemberProperties undefined', async () => {
+//     const result = await checkMemberMeetsCategory('sz266@cornell.edu', 'ph444@cornell.edu', 'a lead (not your role)')
+//     expect(result.status).toBe('no data')
+//     expect(result.message).toBe('')
+//   });
+
+//   test('should pass but submitterProperties undefined', async () => {
+//     const result = await checkMemberMeetsCategory('egk46@cornell.edu', 'sz266@cornell.edu', 'a lead (not your role)')
+//     expect(result.status).toBe('no data')
+//     expect(result.message).toBe('')
+//   });
+
+//   test('both submitterProperties and otherMemberProperties undefined', async () => {
+//     const result = await checkMemberMeetsCategory('sz266@cornell.edu', 'szw3@cornell.edu', 'a lead (not your role)')
+//     expect(result.status).toBe('no data')
+//     expect(result.message).toBe('')
+//   });
+// });

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -220,6 +220,7 @@ interface CoffeeChat {
   readonly status: Status;
   readonly date: number;
   readonly reason?: string;
+  readonly errorMessage?: string;
 }
 
 interface MemberProperties {
@@ -229,5 +230,5 @@ interface MemberProperties {
   readonly ta: boolean;
   readonly leadType?: Role;
 }
-
 type MemberMeetsCategoryStatus = 'pass' | 'fail' | 'no data';
+type MemberMeetsCategoryType = { status: MemberMeetsCategoryStatus; message: string };

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -219,6 +219,7 @@ interface CoffeeChat {
   readonly category: string;
   readonly status: Status;
   readonly date: number;
+  readonly memberMeetsCategory: MemberMeetsCategoryStatus;
   readonly reason?: string;
   readonly errorMessage?: string;
 }

--- a/frontend/src/API/CoffeeChatAPI.ts
+++ b/frontend/src/API/CoffeeChatAPI.ts
@@ -45,6 +45,12 @@ export default class CoffeeChatAPI {
     return res.board as string[][];
   }
 
+  public static async runAutoChecker(uuid: string): Promise<DevPortfolio> {
+    return APIWrapper.put(`${backendURL}/coffee-chat/autocheck/${uuid}/`, {}).then(
+      (res) => res.data.coffeeChat
+    );
+  }
+
   public static checkMemberMeetsCategory(
     otherMember: IdolMember,
     submitter: IdolMember,

--- a/frontend/src/API/CoffeeChatAPI.ts
+++ b/frontend/src/API/CoffeeChatAPI.ts
@@ -49,7 +49,7 @@ export default class CoffeeChatAPI {
     otherMember: IdolMember,
     submitter: IdolMember,
     category: string
-  ): Promise<MemberMeetsCategoryStatus> {
+  ): Promise<MemberMeetsCategoryType> {
     const res = APIWrapper.get(
       `${backendURL}/coffee-chat/${otherMember.email}/${submitter.email}/${encodeURIComponent(category)}`
     ).then((res) => res.data);
@@ -59,9 +59,9 @@ export default class CoffeeChatAPI {
           headerMsg: "Couldn't check if member meets category",
           contentMsg: `Error was: ${val.err}`
         });
-        return 'no data';
+        return { status: 'no data', message: '' };
       }
-      const result = val.result as MemberMeetsCategoryStatus;
+      const result = val.result as MemberMeetsCategoryType;
       return result;
     });
   }

--- a/frontend/src/components/Admin/CoffeeChats/CoffeeChatDetails.module.css
+++ b/frontend/src/components/Admin/CoffeeChats/CoffeeChatDetails.module.css
@@ -66,3 +66,7 @@
   text-align: center;
   padding-bottom: 15px;
 }
+
+.warning {
+  color: #fc0000;
+}

--- a/frontend/src/components/Admin/CoffeeChats/CoffeeChatDetails.tsx
+++ b/frontend/src/components/Admin/CoffeeChats/CoffeeChatDetails.tsx
@@ -117,6 +117,31 @@ const CoffeeChatDetails: React.FC = () => {
     return map;
   }, [coffeeChats]);
 
+  const runAutoCheckerForCategory = async (category: string) => {
+    setLoading(true);
+
+    const coffeeChats = categoryToChats.get(category);
+    if (coffeeChats) {
+      await Promise.all(
+        coffeeChats.map(async (chat) => {
+          const result = await CoffeeChatAPI.checkMemberMeetsCategory(
+            chat.otherMember,
+            chat.submitter,
+            chat.category
+          );
+          const updatedChat: CoffeeChat = {
+            ...chat,
+            memberMeetsCategory: result.status,
+            errorMessage: result.message
+          };
+          await CoffeeChatAPI.updateCoffeeChat(updatedChat);
+        })
+      );
+    }
+
+    setLoading(false);
+  };
+
   useEffect(() => {
     const cb = () => {
       setLoading(true);
@@ -144,6 +169,9 @@ const CoffeeChatDetails: React.FC = () => {
         <Link href="/admin/coffee-chats">
           <span className={styles.arrow}>&#8592;</span>
         </Link>
+        {category && (
+          <Button onClick={() => runAutoCheckerForCategory(category)}>Re-run autochecker</Button>
+        )}
       </div>
 
       <h1 className={styles.categoryName}>Category: {category}</h1>

--- a/frontend/src/components/Admin/CoffeeChats/CoffeeChatDetails.tsx
+++ b/frontend/src/components/Admin/CoffeeChats/CoffeeChatDetails.tsx
@@ -35,8 +35,8 @@ const CoffeeChatCard: React.FC<CoffeeChatCardProps> = ({ status, chat }) => {
 
   useEffect(() => {
     CoffeeChatAPI.checkMemberMeetsCategory(chat.otherMember, chat.submitter, chat.category).then(
-      (check) => {
-        setMemberMeetsCategory(check);
+      (result) => {
+        setMemberMeetsCategory(result.status);
         setIsLoading(false);
       }
     );
@@ -58,6 +58,9 @@ const CoffeeChatCard: React.FC<CoffeeChatCardProps> = ({ status, chat }) => {
           Coffee Chat with {chat.otherMember.firstName} {chat.otherMember.lastName}{' '}
           {!chat.isNonIDOLMember ? `(${chat.otherMember.netid})` : ''}
         </Card.Meta>
+        {memberMeetsCategory === 'fail' && chat.errorMessage && (
+          <div className={styles.warning}>{chat.errorMessage}</div>
+        )}
         <a href={chat.slackLink} target="_blank" rel="noopener noreferrer">
           Slack link
         </a>

--- a/frontend/src/components/Admin/CoffeeChats/CoffeeChatDetails.tsx
+++ b/frontend/src/components/Admin/CoffeeChats/CoffeeChatDetails.tsx
@@ -124,17 +124,7 @@ const CoffeeChatDetails: React.FC = () => {
     if (coffeeChats) {
       await Promise.all(
         coffeeChats.map(async (chat) => {
-          const result = await CoffeeChatAPI.checkMemberMeetsCategory(
-            chat.otherMember,
-            chat.submitter,
-            chat.category
-          );
-          const updatedChat: CoffeeChat = {
-            ...chat,
-            memberMeetsCategory: result.status,
-            errorMessage: result.message
-          };
-          await CoffeeChatAPI.updateCoffeeChat(updatedChat);
+          CoffeeChatAPI.runAutoChecker(chat.uuid);
         })
       );
     }

--- a/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
+++ b/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
@@ -22,6 +22,7 @@ const CoffeeChatsForm: React.FC = () => {
   const [bingoBoard, setBingoBoard] = useState<string[][]>([[]]);
   const [memberMeetsCategory, setMemberMeetsCategory] =
     useState<MemberMeetsCategoryStatus>('no data');
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
   useEffect(() => {
     MembersAPI.getAllMembers().then((members) => setMembersList(members));
@@ -36,9 +37,10 @@ const CoffeeChatsForm: React.FC = () => {
 
   useEffect(() => {
     if (member && category) {
-      CoffeeChatAPI.checkMemberMeetsCategory(member, userInfo, category).then((check) =>
-        setMemberMeetsCategory(check)
-      );
+      CoffeeChatAPI.checkMemberMeetsCategory(member, userInfo, category).then((result) => {
+        setMemberMeetsCategory(result.status);
+        setErrorMessage(result.message);
+      });
     }
   }, [category, member, userInfo]);
 
@@ -105,7 +107,8 @@ const CoffeeChatsForm: React.FC = () => {
         slackLink,
         category,
         status: 'pending' as Status,
-        date: new Date().getTime()
+        date: new Date().getTime(),
+        errorMessage
       };
 
       CoffeeChatAPI.createCoffeeChat(newCoffeeChat).then((coffeeChat) => {
@@ -216,11 +219,8 @@ const CoffeeChatsForm: React.FC = () => {
               setCategory(foundCategory || '');
             }}
           />
-          {memberMeetsCategory === 'fail' ? (
-            <div className={styles.warning}>
-              Warning: {member?.firstName} {member?.lastName} does not meet the category '{category}
-              '
-            </div>
+          {memberMeetsCategory === 'fail' && errorMessage ? (
+            <div className={styles.warning}>Warning: {errorMessage}</div>
           ) : (
             ''
           )}

--- a/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
+++ b/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
@@ -195,6 +195,11 @@ const CoffeeChatsForm: React.FC = () => {
               }}
             />
           )}
+          {member?.netid === userInfo.netid ? (
+            <div className={styles.warning}>Warning: Cannot coffee chat yourself</div>
+          ) : (
+            ''
+          )}
         </div>
         <div className={styles.inline}>
           <label className={styles.bold}>

--- a/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
+++ b/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
@@ -108,6 +108,7 @@ const CoffeeChatsForm: React.FC = () => {
         category,
         status: 'pending' as Status,
         date: new Date().getTime(),
+        memberMeetsCategory,
         errorMessage
       };
 


### PR DESCRIPTION
### Summary <!-- Required -->

This PR customizes each error message depending on the category, and displays the error message on the admin side if a member does not meet the category. There is also now a button to re-run the auto checker on the admin side.

The previous logic for `checkMemberMeetsCategory` didn't correctly identify between false/fail and undefined/no data, so that is fixed.

### Demo

https://github.com/user-attachments/assets/1cc0b432-a7c4-4cd4-925f-bbf9a1d51e7d