### PR TITLE
Shoutouts Form: Fix Infinite Loading Bug

### DIFF
--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -25,11 +25,18 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
   const giveShoutout = async () => {
     setIsSubmitting(true);
     if (!receiver) {
+      setIsSubmitting(false);
       Emitters.generalError.emit({
         headerMsg: 'No Member Selected',
-        contentMsg: 'Please select a member!'
+        contentMsg: "Please fill in a member's name!"
       });
-    } else if (user && receiver && message !== '') {
+    } else if (message === '') {
+      setIsSubmitting(false);
+      Emitters.generalError.emit({
+        headerMsg: 'No message submitted.',
+        contentMsg: 'Please fill in a message!'
+      });
+    } else if (user && receiver) {
       let imageUrl = '';
 
       if (image) {
@@ -110,7 +117,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
       </div>
 
       <div className={styles.imageUploadContainer}>
-        <label className={styles.bold}>Upload a picture with your shoutout here!</label>
+        <label className={styles.bold}>[Optional] Upload a picture with your shoutout here!</label>
         <input
           ref={fileInputRef}
           id="newImage"


### PR DESCRIPTION
### Summary <!-- Required -->
Submitting the shoutouts form with a blank name or a blank message would lead to the button being stuck on "loading" forever. 

Set `isSubmitting` to stop the loading if the submission failed. 

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

