### PR TITLE
New Website: Show 'Technical PM' instead of 'Technical Product Manager' on Team Page

### DIFF
--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -5,7 +5,6 @@ import { ibm_plex_mono } from '../../src/app/layout';
 import teamRoles from './data/roles.json';
 import subteams from './data/subteams.json';
 import connectIcons from './data/connectIcons.json';
-import { getFullRoleFromDescription } from '../../src/utils/memberUtils';
 import useScreenSize from '../../src/hooks/useScreenSize';
 import { LAPTOP_BREAKPOINT, TABLET_BREAKPOINT } from '../../src/consts';
 
@@ -42,7 +41,7 @@ const MemberSummary: React.FC<MemberSummaryProps> = ({
         className={`w-fit px-3 py-1 rounded-2xl ${ibm_plex_mono.className} md:text-sm xs:text-xs`}
         style={{ backgroundColor: chipColor }}
       >
-        {getFullRoleFromDescription(roleDescription)}
+        {roleDescription}
       </p>
     </div>
   );

--- a/new-dti-website/src/utils/memberUtils.ts
+++ b/new-dti-website/src/utils/memberUtils.ts
@@ -49,15 +49,6 @@ export const populateMembers = (
     return { ...value, members: sortedMembers };
   });
 
-export const getFullRoleFromDescription = (roleDescription: RoleDescription): string => {
-  switch (roleDescription) {
-    case 'Technical PM':
-      return 'Technical Product Manager';
-    default:
-      return roleDescription;
-  }
-};
-
 export const getGeneralRole = (role: Role): Role => {
   switch (role) {
     case 'tpm':


### PR DESCRIPTION
### Summary <!-- Required -->
We originally wanted to show "Technical Product Manager" for a TPM's role on the team page, but after some discussion, we're changing it to "Technical PM" to be more succinct.

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/New-Website-Show-Technical-PM-instead-of-Technical-Product-Manager-on-Team-Page-13c0ad723ce18009b6ebd73828f7a56d?pvs=4

### Test Plan <!-- Required -->

Manual (see screenshot):
<img width="1157" alt="Screenshot 2024-11-12 at 7 49 30 AM" src="https://github.com/user-attachments/assets/de8dc3a0-3267-4c0a-b91d-71b6ce619a63">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

