### PR TITLE
Shoutouts: Rename Storage Bucket Folder Name from 'Shoutout Proofs' to 'Shoutout Images'

### DIFF
--- a/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
+++ b/frontend/src/components/Forms/ShoutoutsPage/ShoutoutForm.tsx
@@ -41,7 +41,7 @@ const ShoutoutForm: React.FC<ShoutoutFormProps> = ({ getGivenShoutouts }) => {
 
       if (image) {
         const blob = await fetch(image).then((res) => res.blob());
-        imageUrl = `shoutoutProofs/${user.email}/${new Date().toISOString()}`;
+        imageUrl = `shoutoutImages/${user.email}/${new Date().toISOString()}`;
         await ImagesAPI.uploadImage(blob, imageUrl);
       }
 


### PR DESCRIPTION
### Summary <!-- Required -->

Randomly noticed that we called the folder "shoutoutProofs", which doesn't make much sense. Let's rename to "shoutoutImages".

I'll manually move over the few images that made it to `shoutoutProofs` in the bucket and update the DB for shoutouts that have images that link to that folder, then I'll delete the `shoutoutProofs` folder.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

