### PR TITLE
DTI Website: Read ALL_ROLES from frontend/consts.ts and Remove constants.js

### DIFF
--- a/common-types/constants.d.ts
+++ b/common-types/constants.d.ts
@@ -1,2 +1,4 @@
-declare const ALL_ROLES: readonly Role[];
-export default ALL_ROLES;
+export const ALL_ROLES: readonly Role[];
+export const LEAD_ROLES: readonly Role[];
+export const BUSINESS_ROLES: readonly Role[];
+export const ADVISOR_ROLES: readonly Role[];

--- a/common-types/constants.js
+++ b/common-types/constants.js
@@ -1,3 +1,30 @@
-const ALL_ROLES = ['lead', 'tpm', 'pm', 'developer', 'designer', 'business', 'dev-advisor'];
-
-export default ALL_ROLES;
+export const ALL_ROLES = [
+  'lead',
+  'ops-lead',
+  'product-lead',
+  'dev-lead',
+  'design-lead',
+  'business-lead',
+  'tpm',
+  'pm',
+  'apm',
+  'developer',
+  'designer',
+  'business',
+  'internal-business',
+  'pmm',
+  'pm-advisor',
+  'dev-advisor',
+  'design-advisor',
+  'business-advisor'
+];
+export const LEAD_ROLES = [
+  'lead',
+  'ops-lead',
+  'product-lead',
+  'dev-lead',
+  'design-lead',
+  'business-lead'
+];
+export const BUSINESS_ROLES = ['business', 'internal-business', 'pmm'];
+export const ADVISOR_ROLES = ['pm-advisor', 'dev-advisor', 'design-advisor', 'business-advisor'];

--- a/frontend/src/components/Admin/AddUser/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser/AddUser.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import React, { useState } from 'react';
 import { Card, Button, Form, Input, Select, TextArea } from 'semantic-ui-react';
-import ALL_ROLES from 'common-types/constants';
+import { ALL_ROLES } from 'common-types/constants';
 import csvtojson from 'csvtojson';
 import styles from './AddUser.module.css';
 import { Member, MembersAPI } from '../../../API/MembersAPI';

--- a/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
+++ b/frontend/src/components/Admin/AdminCandidateDecider/AdminCandidateDecider.tsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { Button, Form, Loader, Header, Message, Card, Checkbox } from 'semantic-ui-react';
 import csv from 'csvtojson';
-import ALL_ROLES from 'common-types/constants';
+import { ALL_ROLES, LEAD_ROLES } from 'common-types/constants';
 import { MemberSearch, RoleSearch } from '../../Common/Search/Search';
 import CandidateDeciderAPI from '../../../API/CandidateDeciderAPI';
 import CandidateDeciderDeleteModal from '../../Modals/CandidateDeciderDeleteModal';
 import styles from './AdminCandidateDecider.module.css';
 import CandidateDeciderEditModal from '../../Modals/CandidateDeciderEditModal';
-import { LEAD_ROLES } from '../../../consts';
 
 const allNonleadRoles: { role: Role }[] = ALL_ROLES.filter(
   (role) => !LEAD_ROLES.includes(role)

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { Table, Header, Loader, Button, Icon, Checkbox } from 'semantic-ui-react';
 import { ExportToCsv, Options } from 'export-to-csv';
+import { LEAD_ROLES } from 'common-types/constants';
 import { useMembers } from '../../Common/FirestoreDataProvider';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import {
   REQUIRED_LEAD_TEC_CREDITS,
   REQUIRED_MEMBER_TEC_CREDITS,
   REQUIRED_INITIATIVE_CREDITS,
-  INITIATIVE_EVENTS,
-  LEAD_ROLES
+  INITIATIVE_EVENTS
 } from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -1,9 +1,9 @@
 import { Progress } from 'semantic-ui-react';
+import { LEAD_ROLES } from 'common-types/constants';
 import styles from './ProgressPanel.module.css';
 import { useSelf } from '../Common/FirestoreDataProvider';
 import RatingsDisplay from './RatingsDisplay';
 import { ratingToString } from './ratings-utils';
-import { LEAD_ROLES } from '../../consts';
 
 type ProgressPanelProps = {
   showOtherVotes: boolean;

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -1,6 +1,7 @@
 import { Loader, Modal } from 'semantic-ui-react';
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import { onSnapshot } from 'firebase/firestore';
+import { LEAD_ROLES } from 'common-types/constants';
 import {
   adminsCollection,
   membersCollection,
@@ -11,7 +12,6 @@ import { useUserEmail } from './UserProvider/UserProvider';
 import { Team } from '../../API/TeamsAPI';
 import { isProduction, allowAdmin, environment } from '../../environment';
 import { MembersAPI } from '../../API/MembersAPI';
-import { LEAD_ROLES } from '../../consts';
 
 type ListenedFirestoreData = {
   readonly adminEmails?: readonly string[];

--- a/frontend/src/components/Common/Search/Search.tsx
+++ b/frontend/src/components/Common/Search/Search.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ALL_ROLES from 'common-types/constants';
+import { ALL_ROLES } from 'common-types/constants';
 import { Label, Segment, Search, SearchResultProps } from 'semantic-ui-react';
 import { Member } from '../../../API/MembersAPI';
 import { useMembers, useTeamNames } from '../FirestoreDataProvider';

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 import { Card, Loader, Message, Button, Modal, Header, Image } from 'semantic-ui-react';
+import { LEAD_ROLES } from 'common-types/constants';
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import styles from './TeamEventCreditsForm.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
@@ -10,8 +11,7 @@ import {
   REQUIRED_INITIATIVE_CREDITS,
   REQUIRED_LEAD_TEC_CREDITS,
   REQUIRED_MEMBER_TEC_CREDITS,
-  INITIATIVE_EVENTS,
-  LEAD_ROLES
+  INITIATIVE_EVENTS
 } from '../../../consts';
 
 const TeamEventCreditDashboard = (props: {

--- a/frontend/src/components/Forms/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/Forms/UserProfile/UserProfile.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { Form, TextArea } from 'semantic-ui-react';
+import { LEAD_ROLES } from 'common-types/constants';
 import { useUserEmail } from '../../Common/UserProvider/UserProvider';
 import { useSelf } from '../../Common/FirestoreDataProvider';
 import { Member, MembersAPI } from '../../../API/MembersAPI';
 import { getNetIDFromEmail, getRoleDescriptionFromRoleID, Emitters } from '../../../utils';
-import { LEAD_ROLES } from '../../../consts';
 
 const UserProfile: React.FC = () => {
   const userEmail = useUserEmail();

--- a/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
+++ b/frontend/src/components/Modals/CandidateDeciderEditModal.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Modal, Button, Card, Header, Form, Message } from 'semantic-ui-react';
-import ALL_ROLES from 'common-types/constants';
+import { ALL_ROLES, LEAD_ROLES } from 'common-types/constants';
 import { ExportToCsv, Options } from 'export-to-csv';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import { MemberSearch, RoleSearch } from '../Common/Search/Search';
 import styles from './CandidateDeciderEditModal.module.css';
 import { Emitters } from '../../utils';
 import { ratingToString } from '../Candidate-Decider/ratings-utils';
-import { LEAD_ROLES } from '../../consts';
 
 const allNonleadRoles: { role: Role }[] = ALL_ROLES.filter(
   (role) => !LEAD_ROLES.includes(role)

--- a/frontend/src/consts.ts
+++ b/frontend/src/consts.ts
@@ -4,38 +4,3 @@ export const REQUIRED_LEAD_TEC_CREDITS = 6;
 export const ALL_STATUS: Status[] = ['approved', 'pending', 'rejected'];
 export const INITIATIVE_EVENTS = false;
 export const ENABLE_COFFEE_CHAT = true;
-export const ALL_ROLES: Role[] = [
-  'lead',
-  'ops-lead',
-  'product-lead',
-  'dev-lead',
-  'design-lead',
-  'business-lead',
-  'tpm',
-  'pm',
-  'apm',
-  'developer',
-  'designer',
-  'business',
-  'internal-business',
-  'pmm',
-  'pm-advisor',
-  'dev-advisor',
-  'design-advisor',
-  'business-advisor'
-];
-export const LEAD_ROLES: Role[] = [
-  'lead',
-  'ops-lead',
-  'product-lead',
-  'dev-lead',
-  'design-lead',
-  'business-lead'
-];
-export const BUSINESS_ROLES: Role[] = ['business', 'internal-business', 'pmm'];
-export const ADVISOR_ROLES: Role[] = [
-  'pm-advisor',
-  'dev-advisor',
-  'design-advisor',
-  'business-advisor'
-];


### PR DESCRIPTION
### Summary <!-- Required -->

I noticed that the roles weren't showing up in the dropdown on IDOL.

Last follow up PR to https://github.com/cornell-dti/idol/pull/690. I accidentally had `ALL_ROLES` defined in both `constants.js` and `frontend/consts.ts` and forgot to update `constants.js` with the new roles. 

Since they're general to the codebase, not just the frontend, let's define the roles in `constants.js` and remove them from `frontend/consts.ts`.

Verify that the roles show in the dropdown on IDOL now:
![Screenshot 2024-11-14 at 12 34 10 PM](https://github.com/user-attachments/assets/01646932-4e78-4601-8cb9-defc14794cab)

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->



