### PR TITLE
IDOL/New DTI Website: Remove Lead and Business Analyst Roles

### DIFF
--- a/backend/src/consts.ts
+++ b/backend/src/consts.ts
@@ -10,7 +10,6 @@ export default COFFEE_CHAT_BINGO_BOARD;
 export const DISABLE_DELETE_ALL_COFFEE_CHATS = true;
 
 export const ALL_ROLES: Role[] = [
-  'lead',
   'ops-lead',
   'product-lead',
   'dev-lead',
@@ -21,7 +20,6 @@ export const ALL_ROLES: Role[] = [
   'apm',
   'developer',
   'designer',
-  'business',
   'internal-business',
   'pmm',
   'pm-advisor',
@@ -31,14 +29,13 @@ export const ALL_ROLES: Role[] = [
 ];
 
 export const LEAD_ROLES: Role[] = [
-  'lead',
   'ops-lead',
   'product-lead',
   'dev-lead',
   'design-lead',
   'business-lead'
 ];
-export const BUSINESS_ROLES: Role[] = ['business', 'internal-business', 'pmm'];
+export const BUSINESS_ROLES: Role[] = ['internal-business', 'pmm'];
 export const ADVISOR_ROLES: Role[] = [
   'pm-advisor',
   'dev-advisor',

--- a/backend/src/utils/memberUtil.ts
+++ b/backend/src/utils/memberUtil.ts
@@ -88,3 +88,20 @@ export const computeMembersDiff = <M extends SimplifiedMember>(
 
   return diffs.sort((a, b) => a.email.localeCompare(b.email));
 };
+
+export const getGeneralRoleFromLeadType = (role: Role): GeneralRole => {
+  switch (role) {
+    case 'ops-lead':
+      return 'lead';
+    case 'product-lead':
+      return 'pm';
+    case 'dev-lead':
+      return 'developer';
+    case 'design-lead':
+      return 'designer';
+    case 'business-lead':
+      return 'business';
+    default:
+      throw new Error('Role must be a Lead type');
+  }
+};

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -283,34 +283,4 @@ describe('More complicated member meets category checks', () => {
     expect(result.status).toBe('fail');
     expect(result.message).toBe(`${user4.firstName} ${user4.lastName} is not a lead`);
   });
-
-  test('should pass but otherMemberProperties undefined', async () => {
-    const result = await checkMemberMeetsCategory(
-      user9.email,
-      user1.email,
-      'a lead (not your role)'
-    );
-    expect(result.status).toBe('no data');
-    expect(result.message).toBe('');
-  });
-
-  test('should pass but submitterProperties undefined', async () => {
-    const result = await checkMemberMeetsCategory(
-      user7.email,
-      user9.email,
-      'a lead (not your role)'
-    );
-    expect(result.status).toBe('no data');
-    expect(result.message).toBe('');
-  });
-
-  test('both submitterProperties and otherMemberProperties undefined', async () => {
-    const result = await checkMemberMeetsCategory(
-      user9.email,
-      user10.email,
-      'a lead (not your role)'
-    );
-    expect(result.status).toBe('no data');
-    expect(result.message).toBe('');
-  });
 });

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/API/coffeeChatAPI';
 import { setMember, deleteMember } from '../src/API/memberAPI';
 import { PermissionError } from '../src/utils/errors';
+import { getGeneralRoleFromLeadType } from '../src/utils/memberUtil';
 
 const user = fakeIdolMember();
 const user2 = fakeIdolMember();
@@ -176,24 +177,20 @@ describe('User is lead or admin', () => {
 
 describe('More complicated member meets category checks', () => {
   const admin = { ...fakeIdolLead() };
-  const user1 = { ...fakeIdolMember(), subteams: ['team1'], role: 'developer' };
-  const user2 = { ...fakeIdolMember(), role: 'pm', subteams: ['team2'] };
-  const user3 = { ...fakeIdolMember(), role: 'pm', subteams: ['team1'] };
+  const user1 = { ...fakeIdolMember(), subteams: ['team1'], role: 'developer' as Role };
+  const user2 = { ...fakeIdolMember(), role: 'pm' as Role, subteams: ['team2'] };
+  const user3 = { ...fakeIdolMember(), role: 'pm' as Role, subteams: ['team1'] };
   const user4 = { ...fakeIdolMember(), role: 'internal-business' };
-  const user5 = { ...fakeIdolMember(), role: 'tpm', subteams: ['team3'] };
-  const user6 = { ...fakeIdolMember(), role: 'tpm', subteams: ['team1'] };
-  const user7 = { ...fakeIdolMember(), role: 'product-lead' };
-  const memberProperties7 = { leadType: 'pm' };
-  const user8 = { ...fakeIdolMember(), role: 'dev-lead' };
-  const memberProperties8 = { leadType: 'developer' };
-  const user9 = { ...fakeIdolMember(), role: 'ops-lead' };
-  const user10 = { ...fakeIdolMember(), role: 'ops-lead' };
+  const user5 = { ...fakeIdolMember(), role: 'tpm' as Role, subteams: ['team3'] };
+  const user6 = { ...fakeIdolMember(), role: 'tpm' as Role, subteams: ['team1'] };
+  const user7 = { ...fakeIdolMember(), role: 'product-lead' as Role };
+  const user8 = { ...fakeIdolMember(), role: 'dev-lead' as Role };
+  const user9 = { ...fakeIdolMember(), role: 'ops-lead' as Role };
+  const user10 = { ...fakeIdolMember(), role: 'ops-lead' as Role };
 
   beforeAll(async () => {
     const users = [user1, user2, user3, user4, user5, user6, user7, user8, user9, user10];
     await Promise.all(users.map((user) => setMember(user, admin)));
-    await CoffeeChatDao.createMemberProperties(user7.email, memberProperties7);
-    await CoffeeChatDao.createMemberProperties(user8.email, memberProperties8);
   });
 
   afterAll(async () => {
@@ -273,7 +270,7 @@ describe('More complicated member meets category checks', () => {
     );
     expect(result.status).toBe('fail');
     expect(result.message).toBe(
-      `${user8.firstName} ${user8.lastName} is a lead, but from the same role (${memberProperties8.leadType}) as ${user1.firstName} ${user1.lastName}`
+      `${user8.firstName} ${user8.lastName} is a lead, but from the same role (${getGeneralRoleFromLeadType(user8.role)}) as ${user1.firstName} ${user1.lastName}`
     );
   });
 

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -68,8 +68,8 @@ export const fakeIdolMember = (): IdolMember => {
 export const fakeIdolLead = (): IdolMember => {
   const member = {
     ...fakeIdolMember(),
-    role: 'Lead',
-    roleDescription: 'ops-lead'
+    role: 'ops-lead',
+    roleDescription: 'Full Team Lead'
   };
   return member;
 };

--- a/common-types/constants.js
+++ b/common-types/constants.js
@@ -1,5 +1,4 @@
 export const ALL_ROLES = [
-  'lead',
   'ops-lead',
   'product-lead',
   'dev-lead',
@@ -10,7 +9,6 @@ export const ALL_ROLES = [
   'apm',
   'developer',
   'designer',
-  'business',
   'internal-business',
   'pmm',
   'pm-advisor',
@@ -18,13 +16,6 @@ export const ALL_ROLES = [
   'design-advisor',
   'business-advisor'
 ];
-export const LEAD_ROLES = [
-  'lead',
-  'ops-lead',
-  'product-lead',
-  'dev-lead',
-  'design-lead',
-  'business-lead'
-];
-export const BUSINESS_ROLES = ['business', 'internal-business', 'pmm'];
+export const LEAD_ROLES = ['ops-lead', 'product-lead', 'dev-lead', 'design-lead', 'business-lead'];
+export const BUSINESS_ROLES = ['internal-business', 'pmm'];
 export const ADVISOR_ROLES = ['pm-advisor', 'dev-advisor', 'design-advisor', 'business-advisor'];

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -5,7 +5,6 @@ type GeneralRole = 'lead' | 'designer' | 'pm' | 'business' | 'developer';
 
 /** All possible roles for a DTI member */
 type Role =
-  | 'lead'
   | 'ops-lead'
   | 'product-lead'
   | 'dev-lead'
@@ -16,7 +15,6 @@ type Role =
   | 'apm'
   | 'developer'
   | 'designer'
-  | 'business'
   | 'internal-business'
   | 'pmm'
   | 'pm-advisor'
@@ -26,7 +24,6 @@ type Role =
 
 /** The corresponding more human readable role description of all roles. */
 type RoleDescription =
-  | 'Lead'
   | 'Full Team Lead'
   | 'Product Lead'
   | 'Developer Lead'
@@ -37,7 +34,6 @@ type RoleDescription =
   | 'Associate PM'
   | 'Developer'
   | 'Designer'
-  | 'Business Analyst'
   | 'Internal Business'
   | 'PMM'
   | 'PM Advisor'
@@ -256,7 +252,6 @@ interface MemberProperties {
   readonly newbie: boolean;
   readonly notCsOrInfosci: boolean;
   readonly ta: boolean;
-  readonly leadType?: Role;
 }
 type MemberMeetsCategoryStatus = 'pass' | 'fail' | 'no data';
 type MemberMeetsCategoryType = { status: MemberMeetsCategoryStatus; message: string };

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -4,8 +4,6 @@ export const getNetIDFromEmail = (email: string): string => email.split('@')[0];
 
 export const getRoleDescriptionFromRoleID = (role: Role): RoleDescription => {
   switch (role) {
-    case 'lead':
-      return 'Lead';
     case 'ops-lead':
       return 'Full Team Lead';
     case 'product-lead':
@@ -26,8 +24,6 @@ export const getRoleDescriptionFromRoleID = (role: Role): RoleDescription => {
       return 'Developer';
     case 'designer':
       return 'Designer';
-    case 'business':
-      return 'Business Analyst';
     case 'internal-business':
       return 'Internal Business';
     case 'pmm':


### PR DESCRIPTION
### Summary <!-- Required -->
I've cut over all leads and business members to their more specific roles. This PR deletes the `'lead'` and `'business'` roles in favor of the more specific ones.

Also, modify the coffee chat checker logic to use the more specific lead role, instead of pulling from `member-properties`.

### Notion/Figma Link <!-- Optional -->

https://www.notion.so/New-Website-IDOL-Add-Specific-Lead-and-Business-Roles-Add-Advisor-Roles-13c0ad723ce180708c9af4cf0181d3c6?pvs=4

### Test Plan <!-- Required -->
Modified existing tests.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
