### PR TITLE
Fix Initiatives Page Squished Image

### DIFF
--- a/new-dti-website/src/app/sponsor/page.tsx
+++ b/new-dti-website/src/app/sponsor/page.tsx
@@ -114,7 +114,7 @@ const SponsorPage = () => {
             alt="DTI 2024"
             width={width >= LAPTOP_BREAKPOINT ? 475 : 350}
             height={width >= LAPTOP_BREAKPOINT ? 320 : 236}
-            className="rounded-3xl mx-auto"
+            className="rounded-3xl mx-auto object-cover"
           />
           <div className="flex flex-col justify-center md:gap-5 xs:gap-3">
             <h3 className="font-semibold text-2xl">Become a sponsor!</h3>


### PR DESCRIPTION
### Summary <!-- Required -->
The team photo looks squished horizontally on the sponsors page. Making the component wider doesn't fix this because as you decrease the width, the image gets squished.

Adding `object-cover` to crop the image so that it keeps its shape.

Before:

<img width="1297" alt="Screenshot 2024-11-15 at 3 19 16 PM" src="https://github.com/user-attachments/assets/0a461725-d5cc-4c03-92f8-eb810bf48a71">


After:

https://github.com/user-attachments/assets/1858188b-b42a-4094-bc25-a1fbd5908c9d



### Notion/Figma Link <!-- Optional -->

https://www.notion.so/Website-Initiatives-Page-Image-Too-Narrow-13f0ad723ce1807d82b8c2961439c375?pvs=4

### Test Plan <!-- Required -->

https://github.com/user-attachments/assets/b2f62c27-463b-42ef-999c-819e0f7d745a


<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->


