### PR TITLE
Website: Home Page Responsiveness

### DIFF
--- a/new-dti-website/components/slideshow.tsx
+++ b/new-dti-website/components/slideshow.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Image from 'next/image';
+import { ibm_plex_mono } from '../src/app/layout';
 
 interface SlideshowProps {
   selectedImage: number | null;
@@ -15,41 +16,34 @@ const imageNames = [
   'initiative.png'
 ];
 
-const ImageHeader: React.FC<{ imageName: string; isVisible: boolean }> = ({
-  imageName,
-  isVisible
-}) => (
-  <div
-    className={`absolute top-0 left-0 w-full p-4 bg-white bg-opacity-100 flex items-center rounded-lg ${
-      isVisible ? 'opacity-100' : 'opacity-0'
-    }`}
-    style={{ zIndex: isVisible ? 1 : -1 }}
-  >
-    <img src="/images/folder_icon.png" alt="Folder" className="h-6 mr-2" />
-    <span className="font-medium">cornell-dti/{imageName}</span>
-    <span className="ml-auto font-medium">{imageName}</span>
+const ImageHeader: React.FC<{ imageName: string }> = ({ imageName }) => (
+  <div className="md:p-4 xs:p-2 flex items-center rounded-[20px] gap-2">
+    <img src="/images/folder_icon.png" alt="Folder" className="xs:h-3 md:h-6" />
+    <span className={`font-medium xs:text-[10px] md:text-[22px] ${ibm_plex_mono.className}`}>
+      cornell-dti
+    </span>
+    <span className={`ml-auto font-medium md:text-[14px] xs:text-[7px] ${ibm_plex_mono.className}`}>
+      {imageName}
+    </span>
   </div>
 );
 
-const Slideshow: React.FC<SlideshowProps> = ({ selectedImage }) => (
-  <div className="relative w-[600px] h-[500px] z-10 flex items-center overflow-hidden">
-    {imageNames.map((imageName, index) => (
-      <div key={imageName} className="absolute top-0 left-0 w-full h-full">
-        <ImageHeader imageName={imageName} isVisible={selectedImage === index} />
-        <div className="relative top-10 w-full h-[400px]">
-          <Image
-            width={600}
-            height={400}
-            src={`/images/${imageName}`}
-            alt={imageName.split('.')[0]}
-            className={`absolute top-0 left-1/2 transform -translate-x-1/2 max-w-full max-h-full border-8 border-white rounded-lg ${
-              selectedImage === index ? 'opacity-100' : 'opacity-0'
-            }`}
-          />
-        </div>
+const Slideshow: React.FC<SlideshowProps> = ({ selectedImage }) => {
+  const image = imageNames[selectedImage ?? 0];
+  return (
+    <div className="bg-white w-fit md:rounded-[20px] xs:rounded-lg relative z-20">
+      <ImageHeader imageName={image} />
+      <div>
+        <Image
+          width={600}
+          height={400}
+          src={`/images/${image}`}
+          alt={image.split('.')[0]}
+          className={`max-h-[400px] md:border-8 xs:border-4 border-white md:rounded-[20px] xs:rounded-lg object-cover`}
+        />
       </div>
-    ))}
-  </div>
-);
+    </div>
+  );
+};
 
 export default Slideshow;

--- a/new-dti-website/src/app/layout.tsx
+++ b/new-dti-website/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const ibm_plex_mono = IBM_Plex_Mono({
 
 const RootLayout = ({ children }: { children: React.ReactNode }): JSX.Element => (
   <html lang="en">
-    <body className={`${inter.className} bg-black overflow-x-hidden`}>
+    <body className={`${inter.className} bg-black relative overflow-x-hidden`}>
       <Page>{children}</Page>
     </body>
   </html>

--- a/new-dti-website/src/app/page.tsx
+++ b/new-dti-website/src/app/page.tsx
@@ -6,7 +6,7 @@ import Slideshow from '../../components/slideshow';
 import Bottom from '../../components/bottom';
 import RedBlob from '../../components/blob';
 import useScreenSize from '../hooks/useScreenSize';
-import { LAPTOP_BREAKPOINT, TABLET_BREAKPOINT } from '../consts';
+import { LAPTOP_BREAKPOINT } from '../consts';
 import { ibm_plex_mono } from './layout';
 
 const Home: React.FC = () => {

--- a/new-dti-website/src/app/page.tsx
+++ b/new-dti-website/src/app/page.tsx
@@ -5,6 +5,9 @@ import Icon from '../../components/icons';
 import Slideshow from '../../components/slideshow';
 import Bottom from '../../components/bottom';
 import RedBlob from '../../components/blob';
+import useScreenSize from '../hooks/useScreenSize';
+import { LAPTOP_BREAKPOINT, TABLET_BREAKPOINT } from '../consts';
+import { ibm_plex_mono } from './layout';
 
 const Home: React.FC = () => {
   const [selectedIcon, setSelectedIcon] = useState<number | null>(0);
@@ -84,17 +87,22 @@ const Home: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedIcon]);
 
+  const { width } = useScreenSize();
+
   return (
     <div>
-      <div className="flex flex-col bg-black bg-cover bg-center h-screen">
-        <RedBlob intensity={0.6} className="left-[-200px] top-[-100px]" />
-        <div className="flex flex-row justify-between items-center pl-[15%] pt-20 w-full">
-          <div className="flex flex-col mr-20">
-            <h2 className="text-white text-6xl z-10">
-              Cornell Digital <br /> Tech & Innovation
+      <div className="flex flex-col h-[calc(100vh-136px)] justify-between items-center">
+        <RedBlob intensity={0.6} className="left-[-250px] top-[-150px]" />
+        <div className="flex flex-row xs:items-center h-full justify-evenly lg:gap-28 items-center lg:px-24 md:px-10 xs:px-4 mt-5">
+          <div className="flex flex-col md:gap-8 xs:gap-4 xs:w-full lg:w-5/12">
+            <h2 className="text-white md:text-[40px] xs:text-[28px] z-10 font-medium">
+              Cornell Digital Tech & Innovation Project Team
             </h2>
             <RedBlob intensity={0.6} className="left-[200px] top-[450px]" />
-            <div className="flex items-center space-x-2 mt-5 h-28 z-10">
+            <div className="flex justify-center">
+              {width < LAPTOP_BREAKPOINT && <Slideshow selectedImage={selectedIcon} />}
+            </div>
+            <div className="flex xs:justify-center lg:justify-normal items-center gap-2 z-10 lg:min-h-[100px] xs:min-h-[45px]">
               {icons.map((icon, index) => (
                 <Icon
                   key={index}
@@ -107,24 +115,24 @@ const Home: React.FC = () => {
                     setSelectedIcon(index);
                     if (timer) clearTimeout(timer);
                   }}
-                  width={icon.width}
-                  height={icon.height}
+                  width={width >= LAPTOP_BREAKPOINT ? icon.width : icon.width / 2}
+                  height={width >= LAPTOP_BREAKPOINT ? icon.height : icon.height / 2}
                 />
               ))}
             </div>
           </div>
-          <div className="flex-grow">
-            <Slideshow selectedImage={selectedIcon} />
-          </div>
-          <div className="relative">
-            <RedBlob intensity={0.6} className="left-[-300px] top-[-250px]" />
+          <div className="lg:w-7/12 xs:w-none">
+            {width >= LAPTOP_BREAKPOINT && <Slideshow selectedImage={selectedIcon} />}
+            <div className="relative z-0">
+              <RedBlob intensity={0.6} className="left-[300px] top-[-500px]" />
+            </div>
           </div>
         </div>
-        <div className="flex justify-center self-center w-full mt-10 mb-10">
+        <div className="flex justify-center self-center w-full py-5">
           <button
             onClick={scrollToContent}
-            className="text-white text-lg font-semibold cursor-pointer flex flex-col items-center z-10"
-            style={{ transition: 'all 0.3s ease', marginTop: '2rem' }}
+            className={`text-white md:text-lg xs:text-[16px] font-semibold cursor-pointer flex flex-col items-center z-10 ${ibm_plex_mono.className}`}
+            style={{ transition: 'all 0.3s ease' }}
           >
             LEARN MORE
             <img src="/images/arrow.png" alt="Learn more" className="mt-3 w-auto h-6" />


### PR DESCRIPTION
### Summary <!-- Required -->
This PR adds responsiveness to the home page, primarily the hero component. The timeline was slightly reworked to only render one image at a time instead of all at once and changing visibility. The "Learn More" sign should be visible for almost all viewports (could not figure out some edge cases, but those are on weird dimension viewports).

### Notion/Figma Link <!-- Optional -->
[Notion](https://www.notion.so/Hero-Page-Mobile-Styling-a3192f43d4c44dc6a8f6ede779edb575)
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Before:
![image](https://github.com/user-attachments/assets/d4a96e94-7467-4c52-98a0-1fa4331c6d0f)

After:
![image](https://github.com/user-attachments/assets/d7cab61f-93a1-4640-8e4e-ccc4f652a760)

<!-- Provide screenshots or point out the additional unit tests -->
