### PR TITLE
Removed Sign In Form from Homepage and Forms Tab

### DIFF
--- a/frontend/src/components/Common/NavigationCard/NavigationCard.tsx
+++ b/frontend/src/components/Common/NavigationCard/NavigationCard.tsx
@@ -10,19 +10,20 @@ export type NavigationCardItem = {
   readonly description: string;
   readonly link: string;
   readonly adminOnly?: boolean;
+  readonly disabled?: boolean
 };
 
-type Props = { readonly testID?: string; readonly items: readonly NavigationCardItem[] };
+type Props = { readonly testID?: string; readonly items: readonly NavigationCardItem[]};
 
-export default function NavigationCard({ testID, items }: Props): JSX.Element {
+export default function NavigationCard({ testID, items}: Props): JSX.Element {
   const hasAdminPermission = useHasAdminPermission();
 
   return (
     <div data-testid={testID}>
       <Card.Group className={styles.cardsContainer}>
         {items.map(
-          ({ header, description, link, adminOnly }) =>
-            (!isProduction || !adminOnly || hasAdminPermission) && (
+          ({ header, description, link, adminOnly, disabled }) =>
+            !disabled && (!isProduction || !adminOnly || hasAdminPermission) && (
               <Card key={link}>
                 <Card.Content>
                   <Card.Header>{header}</Card.Header>

--- a/frontend/src/components/Common/NavigationCard/NavigationCard.tsx
+++ b/frontend/src/components/Common/NavigationCard/NavigationCard.tsx
@@ -10,12 +10,12 @@ export type NavigationCardItem = {
   readonly description: string;
   readonly link: string;
   readonly adminOnly?: boolean;
-  readonly disabled?: boolean
+  readonly disabled?: boolean;
 };
 
-type Props = { readonly testID?: string; readonly items: readonly NavigationCardItem[]};
+type Props = { readonly testID?: string; readonly items: readonly NavigationCardItem[] };
 
-export default function NavigationCard({ testID, items}: Props): JSX.Element {
+export default function NavigationCard({ testID, items }: Props): JSX.Element {
   const hasAdminPermission = useHasAdminPermission();
 
   return (
@@ -23,7 +23,8 @@ export default function NavigationCard({ testID, items}: Props): JSX.Element {
       <Card.Group className={styles.cardsContainer}>
         {items.map(
           ({ header, description, link, adminOnly, disabled }) =>
-            !disabled && (!isProduction || !adminOnly || hasAdminPermission) && (
+            !disabled &&
+            (!isProduction || !adminOnly || hasAdminPermission) && (
               <Card key={link}>
                 <Card.Content>
                   <Card.Header>{header}</Card.Header>

--- a/frontend/src/components/Homepage/Homepage/Homepage.tsx
+++ b/frontend/src/components/Homepage/Homepage/Homepage.tsx
@@ -16,7 +16,7 @@ const everyoneItems: readonly NavigationCardItem[] = [
     description: 'Edit your profile image.',
     link: '/forms/profileImage'
   },
-  { header: 'Sign-In Form', description: 'Sign in to an event.', link: '/forms/signin' },
+  { header: 'Sign-In Form', description: 'Sign in to an event.', link: '/forms/signin', disabled: true},
   {
     header: 'Shoutouts',
     description: 'Give someone a shoutout or view your past given shoutouts.',

--- a/frontend/src/components/Homepage/Homepage/Homepage.tsx
+++ b/frontend/src/components/Homepage/Homepage/Homepage.tsx
@@ -16,7 +16,12 @@ const everyoneItems: readonly NavigationCardItem[] = [
     description: 'Edit your profile image.',
     link: '/forms/profileImage'
   },
-  { header: 'Sign-In Form', description: 'Sign in to an event.', link: '/forms/signin', disabled: true},
+  {
+    header: 'Sign-In Form',
+    description: 'Sign in to an event.',
+    link: '/forms/signin',
+    disabled: true
+  },
   {
     header: 'Shoutouts',
     description: 'Give someone a shoutout or view your past given shoutouts.',

--- a/frontend/src/pages/forms/index.tsx
+++ b/frontend/src/pages/forms/index.tsx
@@ -6,7 +6,12 @@ import { ENABLE_COFFEE_CHAT } from '../../consts';
 import styles from './index.module.css';
 
 const navCardItems: readonly NavigationCardItem[] = [
-  { header: 'Sign-In Form', description: 'Sign in to an event!', link: '/forms/signin', disabled: true },
+  {
+    header: 'Sign-In Form',
+    description: 'Sign in to an event!',
+    link: '/forms/signin',
+    disabled: true
+  },
   {
     header: 'Shoutouts',
     description: 'Give someone a shoutout or view your past given shoutouts.',

--- a/frontend/src/pages/forms/index.tsx
+++ b/frontend/src/pages/forms/index.tsx
@@ -6,7 +6,7 @@ import { ENABLE_COFFEE_CHAT } from '../../consts';
 import styles from './index.module.css';
 
 const navCardItems: readonly NavigationCardItem[] = [
-  { header: 'Sign-In Form', description: 'Sign in to an event!', link: '/forms/signin' },
+  { header: 'Sign-In Form', description: 'Sign in to an event!', link: '/forms/signin', disabled: true },
   {
     header: 'Shoutouts',
     description: 'Give someone a shoutout or view your past given shoutouts.',


### PR DESCRIPTION
### Summary 

Added a disable feature to NavigationCardItem and disabled the Sign-In Form Navigation card on the Homepage and Forms Tab. 

<img width="1470" alt="Screenshot 2024-11-16 at 3 25 22 PM" src="https://github.com/user-attachments/assets/e439390a-8e62-4b7c-a73d-6cc3dc3deaac">
<img width="1470" alt="Screenshot 2024-11-16 at 3 27 46 PM" src="https://github.com/user-attachments/assets/47f41fd2-9040-4572-b403-aaca9e154e34">

