### PR TITLE
Set Pull from IDOL Images to Daily

### DIFF
--- a/.github/workflows/pull-from-idol-images.yml
+++ b/.github/workflows/pull-from-idol-images.yml
@@ -2,8 +2,8 @@ name: Pull from IDOL Images
 on:
   workflow_dispatch:
   schedule:
-    # Run the script at 0AM in UTC every Monday, which is 7PM or 8PM in ET.
-    - cron: '0 0 * * MON'
+    # Run the script at 0AM in UTC every day, which is 7PM or 8PM in ET.
+    - cron: '0 0 * * *'
   pull_request:
     paths:
       - backend/scripts/pull-from-idol-images.ts


### PR DESCRIPTION
### Summary <!-- Required -->
Confirmed that there is proper diff checking being done for the images in the "Pull from IDOL Images" job. If there are no changes, there will not be a pull from IDOL images job. Example run where it did not trigger a PR: https://github.com/cornell-dti/idol/actions/runs/11875583268

Set Pull from IDOL Images to Daily.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
