### PR TITLE
delete shoutout images w/ shoutout

### DIFF
--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -1,7 +1,7 @@
 import PermissionsManager from '../utils/permissionsManager';
 import { NotFoundError, PermissionError } from '../utils/errors';
 import ShoutoutsDao from '../dao/ShoutoutsDao';
-import { deleteImage } from 'backend/src/API/imageAPI';
+import { deleteImage } from './imageAPI';
 
 const shoutoutsDao = new ShoutoutsDao();
 

--- a/backend/src/API/shoutoutAPI.ts
+++ b/backend/src/API/shoutoutAPI.ts
@@ -1,6 +1,7 @@
 import PermissionsManager from '../utils/permissionsManager';
 import { NotFoundError, PermissionError } from '../utils/errors';
 import ShoutoutsDao from '../dao/ShoutoutsDao';
+import { deleteImage } from 'backend/src/API/imageAPI';
 
 const shoutoutsDao = new ShoutoutsDao();
 
@@ -79,6 +80,9 @@ export const deleteShoutout = async (uuid: string, user: IdolMember): Promise<vo
     throw new PermissionError(
       `You are not a lead or admin, so you can't delete a shoutout from a different user!`
     );
+  }
+  if (shoutout.images && shoutout.images.length > 0) {
+    await deleteImage(shoutout.images[0]);
   }
   await shoutoutsDao.deleteShoutout(uuid);
 };


### PR DESCRIPTION
Previously, if an IDOL user deleted a shoutout that had an image attached to it, the image wouldn't get deleted (taking up space in our storage).

I tested this by submitting shoutouts with images, seeing them get added to the Firebase, and removed when I deleted the shoutout from IDOL.