### PR TITLE
ignore blank fields in dev portfolio submissions

### DIFF
--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -94,9 +94,9 @@ const DevPortfolioForm: React.FC = () => {
         contentMsg: 'Please paste a link to a opened and reviewed PR!'
       });
     } else if (
-      (!openedEmpty && openPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null)) ||
-      (!reviewedEmpty && reviewPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null)) ||
-      (!otherEmpty && otherPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null))
+      (!openedEmpty && openPRs.some((pr) => pr !== '' && pr.match(GITHUB_PR_REGEX) === null)) ||
+      (!reviewedEmpty && reviewPRs.some((pr) => pr !== '' && pr.match(GITHUB_PR_REGEX) === null)) ||
+      (!otherEmpty && otherPRs.some((pr) => pr !== '' && pr.match(GITHUB_PR_REGEX) === null))
     ) {
       Emitters.generalError.emit({
         headerMsg: 'Invalid PR link',

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -128,9 +128,9 @@ const DevPortfolioForm: React.FC = () => {
         contentMsg: 'Please select another dev portfolio.'
       });
     } else {
-      const finalPRs = openPRs.filter((pr) => pr !== "");
-      const finalReviewedPRs = reviewPRs.filter((pr) => pr !== "");
-      const finalOtherPRs = otherPRs.filter((pr) => pr !== "");
+      const finalPRs = openPRs.filter((pr) => pr !== '');
+      const finalReviewedPRs = reviewPRs.filter((pr) => pr !== '');
+      const finalOtherPRs = otherPRs.filter((pr) => pr !== '');
       const newDevPortfolioSubmission: DevPortfolioSubmission = {
         member: userInfo,
         openedPRs: finalPRs.map((pr) => ({

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -128,17 +128,20 @@ const DevPortfolioForm: React.FC = () => {
         contentMsg: 'Please select another dev portfolio.'
       });
     } else {
+      const finalPRs = openPRs.filter((pr) => pr !== "");
+      const finalReviewedPRs = reviewPRs.filter((pr) => pr !== "");
+      const finalOtherPRs = otherPRs.filter((pr) => pr !== "");
       const newDevPortfolioSubmission: DevPortfolioSubmission = {
         member: userInfo,
-        openedPRs: openPRs.map((pr) => ({
+        openedPRs: finalPRs.map((pr) => ({
           url: pr,
           status: 'pending'
         })),
-        reviewedPRs: reviewPRs.map((pr) => ({
+        reviewedPRs: finalReviewedPRs.map((pr) => ({
           url: pr,
           status: 'pending'
         })),
-        otherPRs: otherPRs.map((pr) => ({
+        otherPRs: finalOtherPRs.map((pr) => ({
           url: pr,
           status: 'pending'
         })),
@@ -146,6 +149,7 @@ const DevPortfolioForm: React.FC = () => {
         documentationText,
         ...(text && { text })
       };
+      console.log(newDevPortfolioSubmission);
       sendSubmissionRequest(newDevPortfolioSubmission, devPortfolio);
     }
   };

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -75,9 +75,6 @@ const DevPortfolioForm: React.FC = () => {
     const finalPRs = openPRs.filter((pr) => pr !== '');
     const finalReviewedPRs = reviewPRs.filter((pr) => pr !== '');
     const finalOtherPRs = otherPRs.filter((pr) => pr !== '');
-    setOpenPRs(finalPRs);
-    setReviewedPRs(finalReviewedPRs);
-    setOtherPRs(finalOtherPRs);
     const openedEmpty = !finalPRs[0] || finalPRs[0].length === 0;
     const reviewedEmpty = !finalReviewedPRs[0] || finalReviewedPRs[0].length === 0;
     const otherEmpty = !finalOtherPRs[0] || finalOtherPRs[0].length === 0;

--- a/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
+++ b/frontend/src/components/Forms/DevPortfolioForm/DevPortfolioForm.tsx
@@ -72,9 +72,15 @@ const DevPortfolioForm: React.FC = () => {
   };
 
   const submitDevPortfolio = () => {
-    const openedEmpty = !openPRs[0] || openPRs[0].length === 0;
-    const reviewedEmpty = !reviewPRs[0] || reviewPRs[0].length === 0;
-    const otherEmpty = !otherPRs[0] || otherPRs[0].length === 0;
+    const finalPRs = openPRs.filter((pr) => pr !== '');
+    const finalReviewedPRs = reviewPRs.filter((pr) => pr !== '');
+    const finalOtherPRs = otherPRs.filter((pr) => pr !== '');
+    setOpenPRs(finalPRs);
+    setReviewedPRs(finalReviewedPRs);
+    setOtherPRs(finalOtherPRs);
+    const openedEmpty = !finalPRs[0] || finalPRs[0].length === 0;
+    const reviewedEmpty = !finalReviewedPRs[0] || finalReviewedPRs[0].length === 0;
+    const otherEmpty = !finalOtherPRs[0] || finalOtherPRs[0].length === 0;
     const textEmpty = !text;
 
     if (!devPortfolio) {
@@ -94,9 +100,9 @@ const DevPortfolioForm: React.FC = () => {
         contentMsg: 'Please paste a link to a opened and reviewed PR!'
       });
     } else if (
-      (!openedEmpty && openPRs.some((pr) => pr !== '' && pr.match(GITHUB_PR_REGEX) === null)) ||
-      (!reviewedEmpty && reviewPRs.some((pr) => pr !== '' && pr.match(GITHUB_PR_REGEX) === null)) ||
-      (!otherEmpty && otherPRs.some((pr) => pr !== '' && pr.match(GITHUB_PR_REGEX) === null))
+      (!openedEmpty && finalPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null)) ||
+      (!reviewedEmpty && finalReviewedPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null)) ||
+      (!otherEmpty && finalOtherPRs.some((pr) => pr.match(GITHUB_PR_REGEX) === null))
     ) {
       Emitters.generalError.emit({
         headerMsg: 'Invalid PR link',
@@ -128,9 +134,6 @@ const DevPortfolioForm: React.FC = () => {
         contentMsg: 'Please select another dev portfolio.'
       });
     } else {
-      const finalPRs = openPRs.filter((pr) => pr !== '');
-      const finalReviewedPRs = reviewPRs.filter((pr) => pr !== '');
-      const finalOtherPRs = otherPRs.filter((pr) => pr !== '');
       const newDevPortfolioSubmission: DevPortfolioSubmission = {
         member: userInfo,
         openedPRs: finalPRs.map((pr) => ({
@@ -149,7 +152,6 @@ const DevPortfolioForm: React.FC = () => {
         documentationText,
         ...(text && { text })
       };
-      console.log(newDevPortfolioSubmission);
       sendSubmissionRequest(newDevPortfolioSubmission, devPortfolio);
     }
   };


### PR DESCRIPTION
## Summary

This PR allows users to submit dev portfolios with blank fields as long as the first field as long as there exists a valid GitHub link. It also ignores the empty fields in the actual submission. 
[https://www.notion.so/Dev-Portfolios-Ignore-Blank-PR-Fields-When-Submitting-13c0ad723ce1804d9a0ffcbda920e031](url)
https://github.com/user-attachments/assets/21212050-92b6-4593-8ba9-5fa388928023

