### PR TITLE
Pull from IDOL: Set Max Length for Diff Output in PR Description

### DIFF
--- a/new-dti-website/pull-from-idol.ts
+++ b/new-dti-website/pull-from-idol.ts
@@ -7,6 +7,8 @@ import { join } from 'path';
 import { Octokit } from '@octokit/rest';
 import fetch from 'node-fetch';
 
+const DIFF_OUTPUT_LIMIT = 65_000;
+
 async function getIdolMembers(): Promise<readonly IdolMember[]> {
   const { members } = await fetch(
     'https://idol.cornelldti.org/.netlify/functions/api/member?type=approved'
@@ -70,6 +72,12 @@ async function main(): Promise<void> {
     auth: `token ${process.env.BOT_TOKEN}`,
     userAgent: 'cornell-dti/big-diff-warning'
   });
+
+  // Don't place a diff output in PR description if it exceeds the char limit.
+  if (diffOutput.length > DIFF_OUTPUT_LIMIT) {
+    diffOutput = '<Output is too long to put in the PR description. See PR diff for details.>';
+  }
+
   const prBody = `## Diffs
   \`\`\`diff
   ${diffOutput}


### PR DESCRIPTION
### Summary <!-- Required -->
The "Pull from IDOL" job breaks when the JSON diff output is too large. 
```
RequestError [HttpError]: Validation Failed: {"resource":"Issue","code":"custom","field":"body","message":"body is too long (maximum is 65536 characters)"} - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
    at fetchWrapper (/home/runner/work/idol/idol/new-dti-website/node_modules/@octokit/request/dist-bundle/index.js:119:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async main (/home/runner/work/idol/idol/new-dti-website/pull-from-idol.ts:95:5) {
  status: 422,
  request: {
    method: 'POST',
    url: 'https://api.github.com/repos/cornell-dti/idol/pulls',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'cornell-dti/big-diff-warning octokit-rest.js/21.0.2 octokit-core.js/6.1.2 Node.js/20.18.0 (linux; x64)',
      authorization: 'token [REDACTED]',
      'content-type': 'application/json; charset=utf-8'

```
See this failed job: https://github.com/cornell-dti/idol/actions/runs/11904572855/job/33173605118

We can just omit the diff output from the PR body.

### Notion/Figma Link <!-- Optional -->

https://www.notion.so/Pull-from-IDOL-Breaks-When-JSON-is-Too-Large-1430ad723ce180e88b14c20faf59e8a8?pvs=4

### Test Plan <!-- Required -->
Check that job passes.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
