### PR TITLE
Website: Remove Wrapping a <button> in <a>

### DIFF
--- a/new-dti-website/components/apply/ApplicationTimeline.tsx
+++ b/new-dti-website/components/apply/ApplicationTimeline.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import config from '../../config.json';
 import timelineIcons from './data/timelineIcons.json';
 import { ibm_plex_mono } from '../../src/app/layout';
@@ -173,7 +174,7 @@ const TimelineNode: React.FC<RecruitmentEventProps> = ({
                 className={`${isNextEvent ? 'brightness-0' : ''}`}
               />
               <p className={event.link ? 'underline' : ''}>
-                {event.link ? <a href={event.link}>{event.location}</a> : event.location}
+                {event.link ? <Link href={event.link}>{event.location}</Link> : event.location}
               </p>
             </div>
           )}

--- a/new-dti-website/components/apply/ApplyFAQ.tsx
+++ b/new-dti-website/components/apply/ApplyFAQ.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import config from '../../config.json';
 import interviewPrep from './data/interviewPrep.json';
 
@@ -100,9 +101,9 @@ const ApplyFAQ = () => {
                   coffee, but should be 30 minutes like an actual coffee catch up with a friend. Get
                   the most out of the coffee chat by preparing your questions ahead of time and
                   researching the other person's experiences first. Find DTI members to chat{' '}
-                  <a className="underline" href={config.coffeeChatLink}>
+                  <Link className="underline" href={config.coffeeChatLink}>
                     here
-                  </a>
+                  </Link>
                   .
                 </p>
               </FAQAccordion>
@@ -111,9 +112,9 @@ const ApplyFAQ = () => {
                   Whether or not you receive an interview invitation, we will email you a definitive
                   decision within a week of applying! We're happy to answer any questions you have
                   during this time through our email,{' '}
-                  <a className="underline" href="mailto:hello@cornelldti.org">
+                  <Link className="underline" href="mailto:hello@cornelldti.org">
                     hello@cornelldti.org
-                  </a>
+                  </Link>
                   .
                 </p>
               </FAQAccordion>

--- a/new-dti-website/components/bottom.tsx
+++ b/new-dti-website/components/bottom.tsx
@@ -72,10 +72,10 @@ const Bottom: React.FC = () => (
               </p>
             </div>
           </div>
+          <Link href="/courses" className="primary-button">
+            Learn more
+          </Link>
         </div>
-        <a href="/courses">
-          <button className="primary-button">Learn more</button>
-        </a>
       </div>
     </div>
     <div className="flex flex-col h-fit justify-center items-start py-10 px-8 md:flex-row md:py-20 md:px-16">
@@ -141,12 +141,12 @@ const Bottom: React.FC = () => (
           <span className="font-bold">teach others from our experience.</span>
         </p>
         <div className="flex flex-row gap-x-3">
-          <a href="/team">
-            <button className="primary-button">Get to know us</button>
-          </a>
-          <a href="/apply">
-            <button className="secondary-button">Join us</button>
-          </a>
+          <Link href="/team" className="primary-button">
+            Get to know us
+          </Link>
+          <Link href="/apply" className="secondary-button">
+            Join us
+          </Link>
         </div>
       </div>
     </div>

--- a/new-dti-website/components/footer.tsx
+++ b/new-dti-website/components/footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 
 type Icon = {
   src: string;
@@ -55,7 +56,7 @@ const Footer: React.FC<FooterProps> = ({ theme }) => (
     </div>
     <div className="flex gap-5 md:h-fit h-screen">
       {socialIcons.map((icon, index) => (
-        <a
+        <Link
           key={index}
           href={icon.link}
           target="_blank"
@@ -69,7 +70,7 @@ const Footer: React.FC<FooterProps> = ({ theme }) => (
             height={36}
             alt={icon.alt}
           />
-        </a>
+        </Link>
       ))}
     </div>
   </div>

--- a/new-dti-website/components/navbar.tsx
+++ b/new-dti-website/components/navbar.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Image from 'next/image';
+import Link from 'next/link';
 
 const navbarItems = [
   {
@@ -44,7 +45,7 @@ const Navbar: React.FC = () => {
     <div className="relative z-20">
       <div className="w-full px-5 py-7 md:p-10 lg:pl-11 lg:py-10 lg:pr-7 !inline-flex !justify-between !flex-row">
         <div className="w-fit flex flex-col !justify-center z-40">
-          <a href="/">
+          <Link href="/">
             <Image
               className="md:h-12 h-8 w-auto"
               src="/dti_logo.svg"
@@ -52,11 +53,11 @@ const Navbar: React.FC = () => {
               height={62}
               alt="DTI Logo"
             />
-          </a>
+          </Link>
         </div>
         <div className="hidden !justify-self-end w-fit lg:inline-flex flex-row">
           {navbarItems.map((item) => (
-            <a
+            <Link
               className={`hover:underline cursor-pointer text-white p-4 underline-offset-8 decoration-2 decoration-white ${
                 pathname === item.url ? 'underline' : ''
               }`}
@@ -64,7 +65,7 @@ const Navbar: React.FC = () => {
               key={item.name}
             >
               {item.name}
-            </a>
+            </Link>
           ))}
         </div>
         <div className={`flex lg:hidden w-fit ${isMenuOpen ? 'z-50' : 'z-10'}`}>
@@ -97,13 +98,13 @@ const Navbar: React.FC = () => {
             </div>
             <div className="backdrop-blur-sm w-full px-8 py-4 md:px-14 md:py-4 h-full flex flex-col gap-y-6 landscape:gap-y-2 md:landscape:gap-y-6 text-right">
               {navbarItems.map((item) => (
-                <a
+                <Link
                   key={item.name}
                   className="hover:underline cursor-pointer text-white text-base md:text-2xl font-normal underline-offset-8 decoration-2 decoration-white"
                   href={item.url}
                 >
                   {item.name}
-                </a>
+                </Link>
               ))}
             </div>
           </div>

--- a/new-dti-website/components/team/MemberDisplay.tsx
+++ b/new-dti-website/components/team/MemberDisplay.tsx
@@ -83,7 +83,6 @@ const MemberDisplay: React.FC = () => {
           <div>
             {Object.keys(roles).map((role, index) => {
               const value = roles[role as GeneralRole];
-              // if (index > 1) return <></>;
               return (
                 <MemberGroup
                   key={value.roleName}

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -1,5 +1,6 @@
 import { useState, RefObject } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { Card } from '../ui/card';
 import { ibm_plex_mono } from '../../src/app/layout';
 import teamRoles from './data/roles.json';
@@ -184,25 +185,22 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
               </div>
             </div>
             <div className="md:block xs:hidden">
-              <a href={props.coffeeChatLink ?? `mailto:${props.email}`}>
-                <button
-                  onMouseEnter={mouseHandler}
-                  onMouseLeave={mouseHandler}
-                  className="py-3 px-5 bg-white rounded-xl text-[#A52424] border-[3px] border-[#A52424] 
-                hover:bg-[#A52424] hover:text-white stroke-white"
-                >
-                  <div className="flex gap-3 w-max">
-                    <Image
-                      src="/icons/red_calendar.svg"
-                      alt="calendar"
-                      width={24}
-                      height={24}
-                      className={hover ? 'brightness-0 invert' : ''}
-                    />
-                    <p className="font-bold text-lg text-inherit whitespace-nowrap">Chat with me</p>
-                  </div>
-                </button>
-              </a>
+              <Link
+                href={props.coffeeChatLink ?? `mailto:${props.email}`}
+                onMouseEnter={mouseHandler}
+                onMouseLeave={mouseHandler}
+                className="flex items-center justify-center gap-3 py-3 px-5 bg-white rounded-xl text-[#A52424] border-[3px] border-[#A52424] 
+             hover:bg-[#A52424] hover:text-white stroke-white w-max"
+              >
+                <Image
+                  src="/icons/red_calendar.svg"
+                  alt="calendar"
+                  width={24}
+                  height={24}
+                  className={hover ? 'brightness-0 invert' : ''}
+                />
+                <p className="font-bold text-lg text-inherit whitespace-nowrap">Chat with me</p>
+              </Link>
             </div>
           </div>
         </div>

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -155,9 +155,9 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
                 }`}
               >
                 {link ? (
-                  <a href={link} className="whitespace-nowrap">
+                  <Link href={link} className="whitespace-nowrap">
                     {name}
-                  </a>
+                  </Link>
                 ) : (
                   <p>{name}</p>
                 )}
@@ -171,14 +171,17 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
                   const link = props[icon.alt as keyof typeof props] as string | null;
                   return (
                     link && (
-                      <a href={icon.alt === 'email' ? `mailto:${link}` : `${link}`} key={icon.alt}>
+                      <Link
+                        href={icon.alt === 'email' ? `mailto:${link}` : `${link}`}
+                        key={icon.alt}
+                      >
                         <Image
                           src={icon.src}
                           alt={icon.alt}
                           height={icon.height}
                           width={icon.width}
                         />
-                      </a>
+                      </Link>
                     )
                   );
                 })}

--- a/new-dti-website/components/team/TeamFooter.tsx
+++ b/new-dti-website/components/team/TeamFooter.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import companies from './data/companies.json';
 import useScreenSize from '../../src/hooks/useScreenSize';
 import { TABLET_BREAKPOINT } from '../../src/consts';
@@ -57,9 +58,9 @@ const TeamFooter = () => {
             <h1 className="font-semibold lg:text-[32px] md:text-2xl">Want to join the family?</h1>
             <p className="lg:text-[22px] md:text-lg">{message}</p>
             {isAppOpen() && (
-              <a href={'/apply'} target="_blank" rel="noopener noreferrer">
-                <button className="primary-button">Apply here</button>
-              </a>
+              <Link href={'/apply'} className="primary-button">
+                Apply here
+              </Link>
             )}
           </div>
         </div>


### PR DESCRIPTION
### Summary <!-- Required -->
For accessibility purposes, remove all instances of wrapping a `<button>` in `<a>`, and use `Link` (from Next) instead.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Buttons work the same. Now tabbing behavior is correct, where the component only highlights once.

Grepping for instances of `<a>` wrapping a `button` should no longer exist.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
