### PR TITLE
Website: Bold Application Text and Fix Application Links

### DIFF
--- a/new-dti-website/config.json
+++ b/new-dti-website/config.json
@@ -12,7 +12,7 @@
       "description": "We're welcoming any and all students who are looking to make a difference through tech. Applicants are not considered on a rolling basis.",
       "location": "Google Form Application",
       "type": "application",
-      "link": "form link",
+      "link": "https://forms.gle/F9tFrW88a2Xoa9D49",
       "freshmen": { "date": "August 21", "isTentative": false },
       "upperclassmen": { "date": "August 21", "isTentative": false },
       "spring": { "date": "", "isTentative": false }
@@ -40,7 +40,7 @@
       "description": "We're welcoming any and all students who are looking to make a difference through tech. Applicants are not considered on a rolling basis.",
       "location": "Google Form Application",
       "type": "deadline",
-      "link": "link",
+      "link": "https://forms.gle/F9tFrW88a2Xoa9D49",
       "freshmen": { "date": "October 17", "isTentative": false },
       "upperclassmen": { "date": "September 4", "isTentative": false },
       "spring": { "date": "", "isTentative": false }


### PR DESCRIPTION
### Summary <!-- Required -->
~~We received leads feedback to show the “We are no longer accepting applicants” text everywhere where the apply button typically would be, so it doesn’t feel like a bug when applicants navigate back to the page and don’t see the apply button anymore.~~ We're going to redo this design to instead include a banner. Handled in a separate PR.

Also, fix application links on the Apply timeline.


### Notion/Figma Link <!-- Optional -->
https://www.notion.so/Website-Bold-Application-Text-and-Fix-Application-Links-1440ad723ce180e1879dc8bce2e069fe?pvs=4

### Test Plan <!-- Required -->
The two "Google Form Application" links lead to the application now.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

