### PR TITLE
Website: Make All Interactive Elements Buttons

### DIFF
--- a/new-dti-website/components/apply/ApplicationTimeline.tsx
+++ b/new-dti-website/components/apply/ApplicationTimeline.tsx
@@ -16,14 +16,14 @@ type TabProps = {
 };
 
 const Tab: React.FC<TabProps> = ({ isSelected, text, onClick }) => (
-  <div
+  <button
     className={`flex items-center lg:px-5 lg:py-4 md:px-4 md:py-3 xs:px-2 md:rounded-t-xl xs:rounded-t-lg ${
       isSelected ? 'bg-[#FEFEFE] text-[#A52424]' : 'bg-[#7E2222CC] text-[#FEFEFE]'
     } hover:cursor-pointer md:h-min xs:h-full`}
     onClick={onClick}
   >
     <p className="font-bold lg:text-lg md:text-[13px] xs:text-[10px]">{text}</p>
-  </div>
+  </button>
 );
 
 type DateTime = {

--- a/new-dti-website/components/apply/ApplicationTimeline.tsx
+++ b/new-dti-website/components/apply/ApplicationTimeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { KeyboardEvent, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import config from '../../config.json';
@@ -12,17 +12,23 @@ import { extractEndDate, extractEndTime, parseDate } from '../../src/utils/dateU
 type TabProps = {
   isSelected: boolean;
   text: string;
+  tabIndex?: number;
   onClick?: () => void;
 };
 
-const Tab: React.FC<TabProps> = ({ isSelected, text, onClick }) => (
+const Tab: React.FC<TabProps> = ({ isSelected, text, onClick, tabIndex }) => (
   <button
     className={`flex items-center lg:px-5 lg:py-4 md:px-4 md:py-3 xs:px-2 md:rounded-t-xl xs:rounded-t-lg ${
       isSelected ? 'bg-[#FEFEFE] text-[#A52424]' : 'bg-[#7E2222CC] text-[#FEFEFE]'
     } hover:cursor-pointer md:h-min xs:h-full`}
     onClick={onClick}
+    role="tab"
+    tabIndex={isSelected ? 0 : -1}
+    aria-selected={isSelected}
   >
-    <p className="font-bold lg:text-lg md:text-[13px] xs:text-[10px]">{text}</p>
+    <p className="font-bold lg:text-lg md:text-[13px] xs:text-[10px]" role="tabpanel">
+      {text}
+    </p>
   </button>
 );
 
@@ -221,6 +227,12 @@ const ApplicationTimeline = () => {
   const scrollToIndex =
     nextEventIndex === sortedEvents.length ? nextEventIndex - 1 : nextEventIndex;
 
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      setCycle(cycle === 'freshmen' ? 'upperclassmen' : 'freshmen');
+    }
+  };
+
   useEffect(() => {
     if (timelineRef.current && selectedNodeRef.current && width >= TABLET_BREAKPOINT) {
       const innerDiv = selectedNodeRef.current.getBoundingClientRect().top;
@@ -247,7 +259,7 @@ const ApplicationTimeline = () => {
             >
               cornell-dti/timeline
             </p>
-            <div className="flex items-end">
+            <div className="flex items-end" role="tablist" onKeyDown={handleKeyDown}>
               {isFall ? (
                 <>
                   <Tab

--- a/new-dti-website/components/apply/ApplyFAQ.tsx
+++ b/new-dti-website/components/apply/ApplyFAQ.tsx
@@ -15,7 +15,10 @@ const FAQAccordion = ({ header, children }: FAQAccordionProps) => {
   const handleClick = () => setIsOpen((prev) => !prev);
 
   return (
-    <button className="py-4 border-white border-b-black border-2 cursor-pointer text-left" onClick={handleClick}>
+    <button
+      className="py-4 border-white border-b-black border-2 cursor-pointer text-left"
+      onClick={handleClick}
+    >
       <div className="flex justify-between pr-4">
         <p className="section-subheading">{header}</p>
         <Image

--- a/new-dti-website/components/apply/ApplyFAQ.tsx
+++ b/new-dti-website/components/apply/ApplyFAQ.tsx
@@ -15,7 +15,7 @@ const FAQAccordion = ({ header, children }: FAQAccordionProps) => {
   const handleClick = () => setIsOpen((prev) => !prev);
 
   return (
-    <div className="py-4 border-white border-b-black border-2 cursor-pointer" onClick={handleClick}>
+    <button className="py-4 border-white border-b-black border-2 cursor-pointer text-left" onClick={handleClick}>
       <div className="flex justify-between pr-4">
         <p className="section-subheading">{header}</p>
         <Image
@@ -33,7 +33,7 @@ const FAQAccordion = ({ header, children }: FAQAccordionProps) => {
       >
         <div className="md:py-5 xs:py-3">{children}</div>
       </div>
-    </div>
+    </button>
   );
 };
 

--- a/new-dti-website/components/apply/RoleDescription.tsx
+++ b/new-dti-website/components/apply/RoleDescription.tsx
@@ -38,15 +38,17 @@ const RoleDescriptions = () => {
                 >
                   {application.charAt(0).toUpperCase() + application.substring(1)}
                 </h3>
-                <Image
-                  src={icon.src}
-                  alt={application}
-                  width={icon.width}
-                  height={icon.height}
-                  className={`${role === application ? '' : 'brightness-50'} cursor-pointer 
-                    lg:h-[90px] md:h-[73px] xs:h-[44px] w-auto`}
-                  onClick={() => setRole(application)}
-                />
+                <button onClick={() => setRole(application)}>
+                  <Image
+                    src={icon.src}
+                    alt=""
+                    aria-label={`Show ${application} questions`}
+                    width={icon.width}
+                    height={icon.height}
+                    className={`${role === application ? '' : 'brightness-50'}
+                      lg:h-[90px] md:h-[73px] xs:h-[44px] w-auto`}
+                  />
+                </button>
               </div>
             );
           })}

--- a/new-dti-website/components/apply/RoleDescription.tsx
+++ b/new-dti-website/components/apply/RoleDescription.tsx
@@ -38,11 +38,13 @@ const RoleDescriptions = () => {
                 >
                   {application.charAt(0).toUpperCase() + application.substring(1)}
                 </h3>
-                <button onClick={() => setRole(application)}>
+                <button
+                  onClick={() => setRole(application)}
+                  aria-label={`Show ${application} questions`}
+                >
                   <Image
                     src={icon.src}
                     alt=""
-                    aria-label={`Show ${application} questions`}
                     width={icon.width}
                     height={icon.height}
                     className={`${role === application ? '' : 'brightness-50'}

--- a/new-dti-website/components/course/DDProjects.tsx
+++ b/new-dti-website/components/course/DDProjects.tsx
@@ -30,8 +30,8 @@ export default function DDProjects({ title, description, imageSrc }: DDProjectsP
   };
 
   return (
-    <div
-      className={`transition-all duration-300 ease-in-out ${
+    <button
+      className={`transition-all duration-300 ease-in-out text-left ${
         isOpen ? 'bg-red-500' : 'bg-white'
       } w-full max-w-8xl rounded-xl drop-shadow-sm px-10 py-8 border-1 border-[#E4E4E4]`}
       onClick={toggleCard}
@@ -58,6 +58,6 @@ export default function DDProjects({ title, description, imageSrc }: DDProjectsP
           <img src={imageSrc} alt={title} className="mt-4 w-full h-48 object-cover rounded-lg" />
         </div>
       </div>
-    </div>
+    </button>
   );
 }

--- a/new-dti-website/components/course/DDProjects.tsx
+++ b/new-dti-website/components/course/DDProjects.tsx
@@ -40,11 +40,9 @@ export default function DDProjects({ title, description, imageSrc }: DDProjectsP
         <h3 className={`md:text-3xl text-xl font-bold ${isOpen ? 'text-white' : 'text-black'}`}>
           {title}
         </h3>
-        <button
-          className={`md:text-4xl text-2xl font-thin ${isOpen ? 'text-white' : 'text-gray-700'}`}
-        >
+        <p className={`md:text-4xl text-2xl font-thin ${isOpen ? 'text-white' : 'text-gray-700'}`}>
           {isOpen ? '−' : '+'}
-        </button>
+        </p>
       </div>
 
       {/* Smooth transition for the Additional Content onClick */}

--- a/new-dti-website/components/icons.tsx
+++ b/new-dti-website/components/icons.tsx
@@ -23,7 +23,6 @@ const Icon: React.FC<IconProps> = ({
   isActive,
   width,
   height,
-  ariaLabel,
   className
 }) => {
   const [isHovered, setIsHovered] = useState(false);
@@ -42,7 +41,6 @@ const Icon: React.FC<IconProps> = ({
       alt={altText}
       width={width}
       height={height}
-      aria-label={ariaLabel}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       className={`cursor-pointer ${className || ''}`}

--- a/new-dti-website/components/icons.tsx
+++ b/new-dti-website/components/icons.tsx
@@ -9,7 +9,7 @@ interface IconProps {
   activeIcon: string;
   altText: string;
   isActive: boolean;
-  onClick: () => void;
+  onClick?: () => void;
   width: number;
   height: number;
   className?: string;

--- a/new-dti-website/components/icons.tsx
+++ b/new-dti-website/components/icons.tsx
@@ -9,9 +9,9 @@ interface IconProps {
   activeIcon: string;
   altText: string;
   isActive: boolean;
-  onClick?: () => void;
   width: number;
   height: number;
+  ariaLabel?: string;
   className?: string;
 }
 
@@ -21,9 +21,9 @@ const Icon: React.FC<IconProps> = ({
   activeIcon,
   altText,
   isActive,
-  onClick,
   width,
   height,
+  ariaLabel,
   className
 }) => {
   const [isHovered, setIsHovered] = useState(false);
@@ -42,9 +42,9 @@ const Icon: React.FC<IconProps> = ({
       alt={altText}
       width={width}
       height={height}
+      aria-label={ariaLabel}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      onClick={onClick}
       className={`cursor-pointer ${className || ''}`}
     />
   );

--- a/new-dti-website/components/navbar.tsx
+++ b/new-dti-website/components/navbar.tsx
@@ -76,7 +76,8 @@ const Navbar: React.FC = () => {
                 src="/icons/hamburger_icon.svg"
                 width={56.5}
                 height={56.5}
-                alt="Hamburger Menu Icon"
+                alt=""
+                aria-label="Open navigation menu"
               />
             </button>
           ) : (
@@ -94,7 +95,8 @@ const Navbar: React.FC = () => {
                   src="/icons/close_icon.svg"
                   width={56.5}
                   height={56.5}
-                  alt="Close Menu Icon"
+                  alt=""
+                  aria-label="Close Menu Icon"
                 />
               </button>
             </div>

--- a/new-dti-website/components/navbar.tsx
+++ b/new-dti-website/components/navbar.tsx
@@ -70,14 +70,13 @@ const Navbar: React.FC = () => {
         </div>
         <div className={`flex lg:hidden w-fit ${isMenuOpen ? 'z-50' : 'z-10'}`}>
           {!isMenuOpen ? (
-            <button onClick={handleMenuClick}>
+            <button onClick={handleMenuClick} aria-label="Open navigation menu">
               <Image
                 className="h-12 w-auto md:h-14"
                 src="/icons/hamburger_icon.svg"
                 width={56.5}
                 height={56.5}
                 alt=""
-                aria-label="Open navigation menu"
               />
             </button>
           ) : (
@@ -89,14 +88,13 @@ const Navbar: React.FC = () => {
         <div className="fixed inset-0 bg-black bg-opacity-80 lg:hidden">
           <div className="w-full h-full">
             <div className="w-full p-6 md:p-10 flex flex-col items-end">
-              <button onClick={handleMenuClick}>
+              <button onClick={handleMenuClick} aria-label="Close Menu Icon">
                 <Image
                   className="h-12 w-auto md:h-14"
                   src="/icons/close_icon.svg"
                   width={56.5}
                   height={56.5}
                   alt=""
-                  aria-label="Close Menu Icon"
                 />
               </button>
             </div>

--- a/new-dti-website/components/navbar.tsx
+++ b/new-dti-website/components/navbar.tsx
@@ -42,7 +42,7 @@ const Navbar: React.FC = () => {
   };
 
   return (
-    <div className="relative z-20">
+    <div className="relative z-[60]">
       <div className="w-full px-5 py-7 md:p-10 lg:pl-11 lg:py-10 lg:pr-7 !inline-flex !justify-between !flex-row">
         <div className="w-fit flex flex-col !justify-center z-40">
           <Link href="/">
@@ -70,14 +70,15 @@ const Navbar: React.FC = () => {
         </div>
         <div className={`flex lg:hidden w-fit ${isMenuOpen ? 'z-50' : 'z-10'}`}>
           {!isMenuOpen ? (
-            <Image
-              className="h-12 w-auto md:h-14"
-              src="/icons/hamburger_icon.svg"
-              width={56.5}
-              height={56.5}
-              alt="Hamburger Menu Icon"
-              onClick={(e) => handleMenuClick()}
-            />
+            <button onClick={handleMenuClick}>
+              <Image
+                className="h-12 w-auto md:h-14"
+                src="/icons/hamburger_icon.svg"
+                width={56.5}
+                height={56.5}
+                alt="Hamburger Menu Icon"
+              />
+            </button>
           ) : (
             <div className="h-12 w-auto md:h-14" />
           )}
@@ -87,14 +88,15 @@ const Navbar: React.FC = () => {
         <div className="fixed inset-0 bg-black bg-opacity-80 lg:hidden">
           <div className="w-full h-full">
             <div className="w-full p-6 md:p-10 flex flex-col items-end">
-              <Image
-                className="h-12 w-auto md:h-14"
-                src="/icons/close_icon.svg"
-                width={56.5}
-                height={56.5}
-                alt="Close Menu Icon"
-                onClick={(e) => handleMenuClick()}
-              />
+              <button onClick={handleMenuClick}>
+                <Image
+                  className="h-12 w-auto md:h-14"
+                  src="/icons/close_icon.svg"
+                  width={56.5}
+                  height={56.5}
+                  alt="Close Menu Icon"
+                />
+              </button>
             </div>
             <div className="backdrop-blur-sm w-full px-8 py-4 md:px-14 md:py-4 h-full flex flex-col gap-y-6 landscape:gap-y-2 md:landscape:gap-y-6 text-right">
               {navbarItems.map((item) => (

--- a/new-dti-website/components/sponsor/SponsorshipTable.tsx
+++ b/new-dti-website/components/sponsor/SponsorshipTable.tsx
@@ -25,11 +25,13 @@ const SponsorshipTableMobile = () => {
         <div className="flex h-fit justify-between">
           {Object.keys(medals).map((medal) => (
             <div className="flex justify-center items-center" key={medal}>
-              <button onClick={() => setSelectedMedal(medal as Tier)}>
+              <button
+                onClick={() => setSelectedMedal(medal as Tier)}
+                aria-label={`Show ${medal} tier`}
+              >
                 <Image
                   src={medals[medal as Tier][selectedMedal === medal ? 'sticker' : 'shadow']}
                   alt=""
-                  aria-label={`Show ${medal} tier`}
                   height={selectedMedal === medal ? medalSelectedHeight : medalHeight}
                   width={medals[medal as Tier][selectedMedal === medal ? 'widthSelected' : 'width']}
                 />

--- a/new-dti-website/components/sponsor/SponsorshipTable.tsx
+++ b/new-dti-website/components/sponsor/SponsorshipTable.tsx
@@ -25,13 +25,14 @@ const SponsorshipTableMobile = () => {
         <div className="flex h-fit justify-between">
           {Object.keys(medals).map((medal) => (
             <div className="flex justify-center items-center" key={medal}>
-              <Image
-                src={medals[medal as Tier][selectedMedal === medal ? 'sticker' : 'shadow']}
-                alt={medal}
-                onClick={() => setSelectedMedal(medal as Tier)}
-                height={selectedMedal === medal ? medalSelectedHeight : medalHeight}
-                width={medals[medal as Tier][selectedMedal === medal ? 'widthSelected' : 'width']}
-              />
+              <button onClick={() => setSelectedMedal(medal as Tier)}>
+                <Image
+                  src={medals[medal as Tier][selectedMedal === medal ? 'sticker' : 'shadow']}
+                  alt={medal}
+                  height={selectedMedal === medal ? medalSelectedHeight : medalHeight}
+                  width={medals[medal as Tier][selectedMedal === medal ? 'widthSelected' : 'width']}
+                />
+              </button>
             </div>
           ))}
         </div>

--- a/new-dti-website/components/sponsor/SponsorshipTable.tsx
+++ b/new-dti-website/components/sponsor/SponsorshipTable.tsx
@@ -28,7 +28,8 @@ const SponsorshipTableMobile = () => {
               <button onClick={() => setSelectedMedal(medal as Tier)}>
                 <Image
                   src={medals[medal as Tier][selectedMedal === medal ? 'sticker' : 'shadow']}
-                  alt={medal}
+                  alt=""
+                  aria-label={`Show ${medal} tier`}
                   height={selectedMedal === medal ? medalSelectedHeight : medalHeight}
                   width={medals[medal as Tier][selectedMedal === medal ? 'widthSelected' : 'width']}
                 />

--- a/new-dti-website/components/team/MemberDisplay.tsx
+++ b/new-dti-website/components/team/MemberDisplay.tsx
@@ -42,7 +42,10 @@ const MemberDisplay: React.FC = () => {
       onClick={(event) => {
         const target = event.target as HTMLElement;
         if (
-          !(target.id === 'memberCard' || target.parentElement?.id === 'memberCard') &&
+          !(
+            target.classList.contains('memberCard') ||
+            target.parentElement?.classList.contains('memberCard')
+          ) &&
           !memberDetailsRef.current?.contains(target)
         )
           setSelectedMember(undefined);
@@ -77,7 +80,8 @@ const MemberDisplay: React.FC = () => {
                     icon={`${role.src}_base.svg`}
                     hoverIcon={`${role.src}_sticker.svg`}
                     activeIcon={`${role.src}_shadow.svg`}
-                    altText={role.altText}
+                    altText={''}
+                    ariaLabel={`Show ${role.altText}`}
                     isActive={selectedRole === role.altText}
                     width={role.width}
                     height={role.height}

--- a/new-dti-website/components/team/MemberDisplay.tsx
+++ b/new-dti-website/components/team/MemberDisplay.tsx
@@ -67,22 +67,25 @@ const MemberDisplay: React.FC = () => {
                 key={role.altText}
               >
                 <h3 className="font-semibold md:text-xl xs:text-base mb-4">{role.altText}</h3>
-                <Icon
-                  icon={`${role.src}_base.svg`}
-                  hoverIcon={`${role.src}_sticker.svg`}
-                  activeIcon={`${role.src}_shadow.svg`}
-                  altText={role.altText}
-                  isActive={selectedRole === role.altText}
+                <button
                   onClick={() => {
                     setSelectedRole(role.altText);
                     setSelectedMember(undefined);
                   }}
-                  width={role.width}
-                  height={role.height}
-                  className={`lg:h-[66px] xs:h-[50px] w-auto ${
-                    selectedRole === role.altText ? 'scale-125' : ''
-                  } hover:scale-125`}
-                />
+                >
+                  <Icon
+                    icon={`${role.src}_base.svg`}
+                    hoverIcon={`${role.src}_sticker.svg`}
+                    activeIcon={`${role.src}_shadow.svg`}
+                    altText={role.altText}
+                    isActive={selectedRole === role.altText}
+                    width={role.width}
+                    height={role.height}
+                    className={`lg:h-[66px] xs:h-[50px] w-auto ${
+                      selectedRole === role.altText ? 'scale-125' : ''
+                    } hover:scale-125`}
+                  />
+                </button>
               </div>
             ))}
           </div>

--- a/new-dti-website/components/team/MemberDisplay.tsx
+++ b/new-dti-website/components/team/MemberDisplay.tsx
@@ -41,6 +41,8 @@ const MemberDisplay: React.FC = () => {
       className="flex justify-center bg-[#f6f6f6]"
       onClick={(event) => {
         const target = event.target as HTMLElement;
+        console.log(target, target.classList);
+        console.log(target.parentElement, target.parentElement?.classList);
         if (
           !(
             target.classList.contains('memberCard') ||

--- a/new-dti-website/components/team/MemberDisplay.tsx
+++ b/new-dti-website/components/team/MemberDisplay.tsx
@@ -41,8 +41,6 @@ const MemberDisplay: React.FC = () => {
       className="flex justify-center bg-[#f6f6f6]"
       onClick={(event) => {
         const target = event.target as HTMLElement;
-        console.log(target, target.classList);
-        console.log(target.parentElement, target.parentElement?.classList);
         if (
           !(
             target.classList.contains('memberCard') ||

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -206,15 +206,12 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
             </div>
           </div>
         </div>
-        <button onClick={props.onClose} className="cursor-pointer h-min">
-          <Image
-            src="/icons/close.svg"
-            width={23}
-            height={23}
-            alt=""
-            aria-label="Close member details"
-            className="m-2 xs:w-4"
-          />
+        <button
+          onClick={props.onClose}
+          className="cursor-pointer h-min"
+          aria-label="Close member details"
+        >
+          <Image src="/icons/close.svg" width={23} height={23} alt="" className="m-2 xs:w-4" />
         </button>
       </div>
       <div className="md:hidden xs:block">
@@ -304,11 +301,12 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
   const onMemberCardClick = (member: IdolMember) => {
     setSelectedMember(member.netid === selectedMember?.netid ? undefined : member);
     if (member.netid !== selectedMember?.netid) {
-      requestAnimationFrame(() =>
-        memberDetailsRef.current?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center'
-        })
+      requestAnimationFrame(
+        () =>
+          memberDetailsRef.current?.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center'
+          })
       );
     }
   };

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -304,12 +304,11 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
   const onMemberCardClick = (member: IdolMember) => {
     setSelectedMember(member.netid === selectedMember?.netid ? undefined : member);
     if (member.netid !== selectedMember?.netid) {
-      requestAnimationFrame(
-        () =>
-          memberDetailsRef.current?.scrollIntoView({
-            behavior: 'smooth',
-            block: 'center'
-          })
+      requestAnimationFrame(() =>
+        memberDetailsRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center'
+        })
       );
     }
   };

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -301,12 +301,11 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
   const onMemberCardClick = (member: IdolMember) => {
     setSelectedMember(member === selectedMember ? undefined : member);
     if (member !== selectedMember) {
-      requestAnimationFrame(
-        () =>
-          memberDetailsRef.current?.scrollIntoView({
-            behavior: 'smooth',
-            block: 'center'
-          })
+      requestAnimationFrame(() =>
+        memberDetailsRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center'
+        })
       );
     }
   };

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -54,7 +54,6 @@ const MemberSummary: React.FC<MemberSummaryProps> = ({
 };
 
 type MemberCardProps = {
-  onClick?: () => void;
   firstName: string;
   lastName: string;
   role: string;
@@ -64,18 +63,15 @@ type MemberCardProps = {
 };
 
 const MemberCard: React.FC<MemberCardProps> = (props: MemberCardProps) => (
-  <button onClick={props.onClick}>
-    <Card
-      id="memberCard"
-      className={`w-fit md:p-3 md:pb-4 xs:p-2 xs:pb-3 h-fit justify-self-center ${
-        props.cardState ? 'opacity-70 hover:opacity-100' : 'opacity-100'
-      } ${
-        props.cardState === 0 && 'shadow-[0_4px_4px_0_#00000040]'
-      } hover:shadow-[0_4px_4px_0_#00000040] cursor-pointer`}
-    >
-      <MemberSummary {...props} enlarged={false} />
-    </Card>
-  </button>
+  <Card
+    className={`memberCard w-fit md:p-3 md:pb-4 xs:p-2 xs:pb-3 h-fit justify-self-center ${
+      props.cardState ? 'opacity-70 hover:opacity-100' : 'opacity-100'
+    } ${
+      props.cardState === 0 && 'shadow-[0_4px_4px_0_#00000040]'
+    } hover:shadow-[0_4px_4px_0_#00000040] cursor-pointer`}
+  >
+    <MemberSummary {...props} enlarged={false} />
+  </Card>
 );
 
 type MemberDetailsProps = {
@@ -211,7 +207,14 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
           </div>
         </div>
         <button onClick={props.onClose} className="cursor-pointer h-min">
-          <Image src="/icons/close.svg" width={23} height={23} alt="close" className="m-2 xs:w-4" />
+          <Image
+            src="/icons/close.svg"
+            width={23}
+            height={23}
+            alt=""
+            aria-label="Close member details"
+            className="m-2 xs:w-4"
+          />
         </button>
       </div>
       <div className="md:hidden xs:block">
@@ -299,13 +302,14 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
 
   const onCloseMemberDetails = () => setSelectedMember(undefined);
   const onMemberCardClick = (member: IdolMember) => {
-    setSelectedMember(member === selectedMember ? undefined : member);
-    if (member !== selectedMember) {
-      requestAnimationFrame(() =>
-        memberDetailsRef.current?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center'
-        })
+    setSelectedMember(member.netid === selectedMember?.netid ? undefined : member);
+    if (member.netid !== selectedMember?.netid) {
+      requestAnimationFrame(
+        () =>
+          memberDetailsRef.current?.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center'
+          })
       );
     }
   };
@@ -314,13 +318,14 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
     <div className="flex flex-row justify-center flex-wrap gap-x-14 gap-y-10">
       {members.map((member, index) => (
         <>
-          <MemberCard
-            {...member}
-            key={member.netid}
-            image={`team/${member.netid}.jpg`}
-            onClick={() => onMemberCardClick(member)}
-            cardState={selectedMember ? index - selectedMemberIndex : undefined}
-          />
+          <button onClick={() => onMemberCardClick(member)}>
+            <MemberCard
+              {...member}
+              key={member.netid}
+              image={`team/${member.netid}.jpg`}
+              cardState={selectedMember ? index - selectedMemberIndex : undefined}
+            />
+          </button>
           {selectedMember && canInsertMemberDetails(index) && (
             <div className="lg:col-span-4 md:col-span-3 xs:col-span-2" ref={memberDetailsRef}>
               <MemberDetails
@@ -346,13 +351,14 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
         >
           {members.map((member, index) => (
             <>
-              <MemberCard
-                {...member}
-                key={member.netid}
-                image={`team/${member.netid}.jpg`}
-                onClick={() => onMemberCardClick(member)}
-                cardState={selectedMember ? index - selectedMemberIndex : undefined}
-              />
+              <button onClick={() => onMemberCardClick(member)} className="memberCard">
+                <MemberCard
+                  {...member}
+                  key={member.netid}
+                  image={`team/${member.netid}.jpg`}
+                  cardState={selectedMember ? index - selectedMemberIndex : undefined}
+                />
+              </button>
               {selectedMember && canInsertMemberDetails(index) && displayDetails && (
                 <div
                   className="lg:col-span-4 md:col-span-3 xs:col-span-2"

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -314,7 +314,7 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
     <div className="flex flex-row justify-center flex-wrap gap-x-14 gap-y-10">
       {members.map((member, index) => (
         <>
-          <button onClick={() => onMemberCardClick(member)}>
+          <button onClick={() => onMemberCardClick(member)} className="memberCard">
             <MemberCard
               {...member}
               key={member.netid}

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -301,12 +301,11 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
   const onMemberCardClick = (member: IdolMember) => {
     setSelectedMember(member.netid === selectedMember?.netid ? undefined : member);
     if (member.netid !== selectedMember?.netid) {
-      requestAnimationFrame(
-        () =>
-          memberDetailsRef.current?.scrollIntoView({
-            behavior: 'smooth',
-            block: 'center'
-          })
+      requestAnimationFrame(() =>
+        memberDetailsRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center'
+        })
       );
     }
   };

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -30,7 +30,7 @@ const MemberSummary: React.FC<MemberSummaryProps> = ({
   const chipColor = teamRoles[getGeneralRole(role as Role)].color;
 
   return (
-    <div id="memberCard" className="flex flex-col md:gap-3 xs:gap-2">
+    <div className="memberCard flex flex-col md:gap-3 xs:gap-2">
       <img
         src={image}
         alt={`${firstName}-${lastName}`}

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -39,7 +39,9 @@ const MemberSummary: React.FC<MemberSummaryProps> = ({
         } object-cover`}
       />
       <h3
-        className={`xs:text-[16px] text-left font-${enlarged ? 'semibold md:text-2xl' : 'bold md:text-lg'}`}
+        className={`xs:text-[16px] text-left font-${
+          enlarged ? 'semibold md:text-2xl' : 'bold md:text-lg'
+        }`}
       >{`${firstName} ${lastName}`}</h3>
       <p
         className={`w-fit px-3 py-1 rounded-2xl ${ibm_plex_mono.className} md:text-sm xs:text-xs`}

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -39,7 +39,7 @@ const MemberSummary: React.FC<MemberSummaryProps> = ({
         } object-cover`}
       />
       <h3
-        className={`xs:text-[16px] font-${enlarged ? 'semibold md:text-2xl' : 'bold md:text-lg'}`}
+        className={`xs:text-[16px] text-left font-${enlarged ? 'semibold md:text-2xl' : 'bold md:text-lg'}`}
       >{`${firstName} ${lastName}`}</h3>
       <p
         className={`w-fit px-3 py-1 rounded-2xl ${ibm_plex_mono.className} md:text-sm xs:text-xs`}
@@ -62,17 +62,18 @@ type MemberCardProps = {
 };
 
 const MemberCard: React.FC<MemberCardProps> = (props: MemberCardProps) => (
-  <Card
-    id="memberCard"
-    className={`w-fit md:p-3 md:pb-4 xs:p-2 xs:pb-3 h-fit justify-self-center ${
-      props.cardState ? 'opacity-70 hover:opacity-100' : 'opacity-100'
-    } ${
-      props.cardState === 0 && 'shadow-[0_4px_4px_0_#00000040]'
-    } hover:shadow-[0_4px_4px_0_#00000040] cursor-pointer`}
-    onClick={props.onClick}
-  >
-    <MemberSummary {...props} enlarged={false} />
-  </Card>
+  <button onClick={props.onClick}>
+    <Card
+      id="memberCard"
+      className={`w-fit md:p-3 md:pb-4 xs:p-2 xs:pb-3 h-fit justify-self-center ${
+        props.cardState ? 'opacity-70 hover:opacity-100' : 'opacity-100'
+      } ${
+        props.cardState === 0 && 'shadow-[0_4px_4px_0_#00000040]'
+      } hover:shadow-[0_4px_4px_0_#00000040] cursor-pointer`}
+    >
+      <MemberSummary {...props} enlarged={false} />
+    </Card>
+  </button>
 );
 
 type MemberDetailsProps = {
@@ -207,15 +208,9 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
             </div>
           </div>
         </div>
-        <div onClick={props.onClose}>
-          <Image
-            src="/icons/close.svg"
-            width={23}
-            height={23}
-            alt="close"
-            className="m-2 cursor-pointer xs:w-4"
-          />
-        </div>
+        <button onClick={props.onClose} className="cursor-pointer h-min">
+          <Image src="/icons/close.svg" width={23} height={23} alt="close" className="m-2 xs:w-4" />
+        </button>
       </div>
       <div className="md:hidden xs:block">
         <button
@@ -304,11 +299,12 @@ const MemberGroup: React.FC<MemberGroupProps> = ({
   const onMemberCardClick = (member: IdolMember) => {
     setSelectedMember(member === selectedMember ? undefined : member);
     if (member !== selectedMember) {
-      requestAnimationFrame(() =>
-        memberDetailsRef.current?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center'
-        })
+      requestAnimationFrame(
+        () =>
+          memberDetailsRef.current?.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center'
+          })
       );
     }
   };

--- a/new-dti-website/components/team/TeamHero.tsx
+++ b/new-dti-website/components/team/TeamHero.tsx
@@ -62,11 +62,10 @@ const ImageModal: React.FC<ImageModalProps> = ({
                   <div className="flex items-center h-[440px] overflow-hidden rounded-md relative top-[10px] left-[10px]">
                     <img src={image.src} alt={image.alt} className="w-[730px] h-fit" />
                   </div>
-                  <button onClick={onClose}>
+                  <button onClick={onClose} aria-label="View previous carousel slide">
                     <img
                       src="/icons/close_icon.svg"
                       alt=""
-                      aria-label="View previous carousel slide"
                       width={47}
                       height={47}
                       className="absolute right-5 top-5 cursor-pointer"
@@ -91,14 +90,8 @@ const ImageModal: React.FC<ImageModalProps> = ({
             ))}
           </CarouselContent>
         </Carousel>
-        <button onClick={handleNext}>
-          <img
-            src="/icons/arrow.svg"
-            alt=""
-            aria-label="View next carousel slide"
-            width={20}
-            className="cursor-pointer rotate-180"
-          />
+        <button onClick={handleNext} aria-label="View next carousel slide">
+          <img src="/icons/arrow.svg" alt="" width={20} className="cursor-pointer rotate-180" />
         </button>
       </div>
     </div>

--- a/new-dti-website/components/team/TeamHero.tsx
+++ b/new-dti-website/components/team/TeamHero.tsx
@@ -102,6 +102,7 @@ const TeamHero = () => {
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
   const [carouselIndex, setCarouselIndex] = useState<number>(0);
   const [modalShown, setModalShown] = useState<boolean>(false);
+  const [focusableElements, setFocusableElements] = useState<NodeListOf<Element>>();
 
   const modalRef = useRef<HTMLButtonElement>(null);
 
@@ -109,10 +110,8 @@ const TeamHero = () => {
 
   const carouselLength = carouselImages.images.length;
 
-  let focusableElements: NodeListOf<Element>;
-
   useEffect(() => {
-    focusableElements = document.querySelectorAll('button, a');
+    setFocusableElements(document.querySelectorAll('button, a'));
   }, []);
 
   useEffect(() => {
@@ -128,7 +127,7 @@ const TeamHero = () => {
     if (modalShown) {
       modalRef.current?.focus();
     }
-  }, [modalShown]);
+  }, [focusableElements, modalShown]);
 
   return (
     <div className="flex flex-col">

--- a/new-dti-website/components/team/TeamHero.tsx
+++ b/new-dti-website/components/team/TeamHero.tsx
@@ -1,7 +1,6 @@
 import {
   Dispatch,
   KeyboardEvent,
-  Ref,
   RefObject,
   SetStateAction,
   useEffect,

--- a/new-dti-website/components/team/TeamHero.tsx
+++ b/new-dti-website/components/team/TeamHero.tsx
@@ -20,13 +20,9 @@ const ImageModal: React.FC<ImageModalProps> = ({ onClose, carouselIndex, carouse
   return (
     <div className="fixed w-full inset-0 bg-opacity-50 backdrop-blur-sm z-20 md:block xs:hidden">
       <div className="flex justify-center items-center h-full gap-[70px] md:scale-75 lg:scale-100">
-        <img
-          src="/icons/arrow.svg"
-          alt="left arrow"
-          width={20}
-          onClick={handlePrev}
-          className="cursor-pointer"
-        />
+        <button onClick={handlePrev}>
+          <img src="/icons/arrow.svg" alt="left arrow" width={20} className="cursor-pointer" />
+        </button>
         <Carousel
           opts={{
             startIndex: carouselIndex,
@@ -41,14 +37,15 @@ const ImageModal: React.FC<ImageModalProps> = ({ onClose, carouselIndex, carouse
                   <div className="flex items-center h-[440px] overflow-hidden rounded-md relative top-[10px] left-[10px]">
                     <img src={image.src} alt={image.alt} className="w-[730px] h-fit" />
                   </div>
-                  <img
-                    src="/icons/close_icon.svg"
-                    alt="close"
-                    width={47}
-                    height={47}
-                    className="absolute right-5 top-5 cursor-pointer"
-                    onClick={onClose}
-                  />
+                  <button onClick={onClose}>
+                    <img
+                      src="/icons/close_icon.svg"
+                      alt="close"
+                      width={47}
+                      height={47}
+                      className="absolute right-5 top-5 cursor-pointer"
+                    />
+                  </button>
                   <img
                     src={image.icon}
                     alt="icon"
@@ -68,13 +65,14 @@ const ImageModal: React.FC<ImageModalProps> = ({ onClose, carouselIndex, carouse
             ))}
           </CarouselContent>
         </Carousel>
-        <img
-          src="/icons/arrow.svg"
-          alt="right arrow"
-          width={20}
-          onClick={handleNext}
-          className="cursor-pointer rotate-180"
-        />
+        <button onClick={handleNext}>
+          <img
+            src="/icons/arrow.svg"
+            alt="right arrow"
+            width={20}
+            className="cursor-pointer rotate-180"
+          />
+        </button>
       </div>
     </div>
   );
@@ -161,7 +159,7 @@ const TeamHero = () => {
                     index === carouselIndex % carouselLength ? '' : 'opacity-50'
                   }`}
                 >
-                  <div
+                  <button
                     className="relative z-10"
                     onClick={() =>
                       setModalShown(index === carouselIndex && width >= TABLET_BREAKPOINT)
@@ -177,7 +175,7 @@ const TeamHero = () => {
                       height={50}
                       className="relative bottom-[62px] left-2"
                     />
-                  </div>
+                  </button>
                 </CarouselItem>
               ))}
             </CarouselContent>

--- a/new-dti-website/components/team/TeamHero.tsx
+++ b/new-dti-website/components/team/TeamHero.tsx
@@ -116,7 +116,11 @@ const TeamHero = () => {
 
   const carouselLength = carouselImages.images.length;
 
-  const focusableElements = document.querySelectorAll('button, a');
+  let focusableElements: NodeListOf<Element>;
+
+  useEffect(() => {
+    focusableElements = document.querySelectorAll('button, a');
+  }, []);
 
   useEffect(() => {
     if (carouselApi) {
@@ -127,7 +131,7 @@ const TeamHero = () => {
   }, [carouselIndex, carouselApi]);
 
   useEffect(() => {
-    focusableElements.forEach((el) => el.setAttribute('tabIndex', modalShown ? '-1' : '0'));
+    focusableElements?.forEach((el) => el.setAttribute('tabIndex', modalShown ? '-1' : '0'));
     if (modalShown) {
       modalRef.current?.focus();
     }

--- a/new-dti-website/components/team/TeamHero.tsx
+++ b/new-dti-website/components/team/TeamHero.tsx
@@ -1,4 +1,13 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import {
+  Dispatch,
+  KeyboardEvent,
+  Ref,
+  RefObject,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
 import Autoplay from 'embla-carousel-autoplay';
 import { ibm_plex_mono } from '../../src/app/layout';
 import { Carousel, CarouselContent, CarouselItem, type CarouselApi } from '../ui/carousel';
@@ -12,15 +21,32 @@ type ImageModalProps = {
   carouselIndex: number;
   setCarouselIndex: Dispatch<SetStateAction<number>>;
   carouselApi: CarouselApi;
+  modalRef: RefObject<HTMLButtonElement>;
+  isShown: boolean;
 };
 
-const ImageModal: React.FC<ImageModalProps> = ({ onClose, carouselIndex, carouselApi }) => {
+const ImageModal: React.FC<ImageModalProps> = ({
+  onClose,
+  carouselIndex,
+  carouselApi,
+  modalRef,
+  isShown
+}) => {
   const handleNext = () => carouselApi?.scrollNext();
   const handlePrev = () => carouselApi?.scrollPrev();
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
   return (
     <div className="fixed w-full inset-0 bg-opacity-50 backdrop-blur-sm z-20 md:block xs:hidden">
-      <div className="flex justify-center items-center h-full gap-[70px] md:scale-75 lg:scale-100">
-        <button onClick={handlePrev}>
+      <div
+        className="flex justify-center items-center h-full gap-[70px] md:scale-75 lg:scale-100"
+        onKeyDown={handleKeyDown}
+      >
+        <button onClick={handlePrev} ref={modalRef}>
           <img src="/icons/arrow.svg" alt="left arrow" width={20} className="cursor-pointer" />
         </button>
         <Carousel
@@ -40,7 +66,8 @@ const ImageModal: React.FC<ImageModalProps> = ({ onClose, carouselIndex, carouse
                   <button onClick={onClose}>
                     <img
                       src="/icons/close_icon.svg"
-                      alt="close"
+                      alt=""
+                      aria-label="View previous carousel slide"
                       width={47}
                       height={47}
                       className="absolute right-5 top-5 cursor-pointer"
@@ -68,7 +95,8 @@ const ImageModal: React.FC<ImageModalProps> = ({ onClose, carouselIndex, carouse
         <button onClick={handleNext}>
           <img
             src="/icons/arrow.svg"
-            alt="right arrow"
+            alt=""
+            aria-label="View next carousel slide"
             width={20}
             className="cursor-pointer rotate-180"
           />
@@ -83,9 +111,13 @@ const TeamHero = () => {
   const [carouselIndex, setCarouselIndex] = useState<number>(0);
   const [modalShown, setModalShown] = useState<boolean>(false);
 
+  const modalRef = useRef<HTMLButtonElement>(null);
+
   const { width } = useScreenSize();
 
   const carouselLength = carouselImages.images.length;
+
+  const focusableElements = document.querySelectorAll('button, a');
 
   useEffect(() => {
     if (carouselApi) {
@@ -95,6 +127,13 @@ const TeamHero = () => {
     }
   }, [carouselIndex, carouselApi]);
 
+  useEffect(() => {
+    focusableElements.forEach((el) => el.setAttribute('tabIndex', modalShown ? '-1' : '0'));
+    if (modalShown) {
+      modalRef.current?.focus();
+    }
+  }, [modalShown]);
+
   return (
     <div className="flex flex-col">
       {modalShown && (
@@ -103,6 +142,8 @@ const TeamHero = () => {
           carouselIndex={carouselIndex}
           setCarouselIndex={setCarouselIndex}
           carouselApi={carouselApi}
+          modalRef={modalRef}
+          isShown={modalShown}
         />
       )}
       <RedBlob intensity={0.7} className="left-[-300px] top-[-100px]" />

--- a/new-dti-website/components/ui/button.tsx
+++ b/new-dti-website/components/ui/button.tsx
@@ -35,14 +35,20 @@ const buttonVariants = cva(
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
+  ariaLabel?: string;
   asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, ariaLabel, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        aria-label={ariaLabel}
+        {...props}
+      />
     );
   }
 );

--- a/new-dti-website/src/app/course/page.tsx
+++ b/new-dti-website/src/app/course/page.tsx
@@ -74,7 +74,10 @@ export default function Courses() {
         onClick={(event) => {
           const target = event.target as HTMLElement;
           if (
-            !(target.id === 'memberCard' || target.parentElement?.id === 'memberCard') &&
+            !(
+              target.classList.contains('memberCard') ||
+              target.parentElement?.classList.contains('memberCard')
+            ) &&
             !memberDetailsRef.current?.contains(target)
           )
             setSelectedMember(undefined);

--- a/new-dti-website/src/app/page.tsx
+++ b/new-dti-website/src/app/page.tsx
@@ -108,6 +108,7 @@ const Home: React.FC = () => {
                     setSelectedIcon(index);
                     if (timer) clearTimeout(timer);
                   }}
+                  aria-label={icon.ariaLabel}
                 >
                   <Icon
                     key={index}
@@ -115,7 +116,6 @@ const Home: React.FC = () => {
                     hoverIcon={icon.hover}
                     activeIcon={icon.active}
                     altText=""
-                    aria-label={icon.ariaLabel}
                     isActive={selectedIcon === index}
                     width={width >= LAPTOP_BREAKPOINT ? icon.width : icon.width / 2}
                     height={width >= LAPTOP_BREAKPOINT ? icon.height : icon.height / 2}

--- a/new-dti-website/src/app/page.tsx
+++ b/new-dti-website/src/app/page.tsx
@@ -103,20 +103,23 @@ const Home: React.FC = () => {
             </div>
             <div className="flex xs:justify-center lg:justify-normal items-center gap-2 z-10 lg:min-h-[100px] xs:min-h-[45px]">
               {icons.map((icon, index) => (
-                <Icon
-                  key={index}
-                  icon={icon.src}
-                  hoverIcon={icon.hover}
-                  activeIcon={icon.active}
-                  altText={icon.altText}
-                  isActive={selectedIcon === index}
+                <button
                   onClick={() => {
                     setSelectedIcon(index);
                     if (timer) clearTimeout(timer);
                   }}
-                  width={width >= LAPTOP_BREAKPOINT ? icon.width : icon.width / 2}
-                  height={width >= LAPTOP_BREAKPOINT ? icon.height : icon.height / 2}
-                />
+                >
+                  <Icon
+                    key={index}
+                    icon={icon.src}
+                    hoverIcon={icon.hover}
+                    activeIcon={icon.active}
+                    altText={icon.altText}
+                    isActive={selectedIcon === index}
+                    width={width >= LAPTOP_BREAKPOINT ? icon.width : icon.width / 2}
+                    height={width >= LAPTOP_BREAKPOINT ? icon.height : icon.height / 2}
+                  />
+                </button>
               ))}
             </div>
           </div>

--- a/new-dti-website/src/app/page.tsx
+++ b/new-dti-website/src/app/page.tsx
@@ -18,7 +18,7 @@ const Home: React.FC = () => {
       src: '/images/DTI_notsel.png',
       hover: '/images/DTI_hover.png',
       active: '/images/DTI_current.png',
-      altText: 'DTI',
+      ariaLabel: 'Show full team slide',
       width: 80,
       height: 80
     },
@@ -26,7 +26,7 @@ const Home: React.FC = () => {
       src: '/images/Family_notsel.png',
       hover: '/images/Family_hover.png',
       active: '/images/Family_current.png',
-      altText: 'Family',
+      araiLabel: 'Show family slide',
       width: 80,
       height: 80
     },
@@ -34,7 +34,7 @@ const Home: React.FC = () => {
       src: '/images/Collaboration_notsel.png',
       hover: '/images/Collaboration_hover.png',
       active: '/images/Collaboration_current.png',
-      altText: 'Collaboration',
+      ariaLabel: 'Show collaboration slide',
       width: 100,
       height: 80
     },
@@ -42,7 +42,7 @@ const Home: React.FC = () => {
       src: '/images/Events_notsel.png',
       hover: '/images/Events_hover.png',
       active: '/images/Events_current.png',
-      altText: 'Events',
+      ariaLabel: 'Show events slide',
       width: 90,
       height: 90
     },
@@ -50,7 +50,7 @@ const Home: React.FC = () => {
       src: '/images/Initiatives_notsel.png',
       hover: '/images/Initiatives_hover.png',
       active: '/images/Initiatives_current.png',
-      altText: 'Initiatives',
+      ariaLabel: 'Show initiatives slide',
       width: 80,
       height: 80
     }
@@ -114,7 +114,8 @@ const Home: React.FC = () => {
                     icon={icon.src}
                     hoverIcon={icon.hover}
                     activeIcon={icon.active}
-                    altText={icon.altText}
+                    altText=""
+                    aria-label={icon.ariaLabel}
                     isActive={selectedIcon === index}
                     width={width >= LAPTOP_BREAKPOINT ? icon.width : icon.width / 2}
                     height={width >= LAPTOP_BREAKPOINT ? icon.height : icon.height / 2}


### PR DESCRIPTION
### Summary <!-- Required -->
Change all buttons that are interactive, i.e. some functionality that does not redirect the user, to use button elements. 
* All icons: Home carousel, Team carousel, Team roles, Sponsors medals
* Apply tabs
* Navbar hamburger and close icons
* Member cards 
* Accordions on course and apply

Also fixed z-index issues with the apply banner being over the navbar on small viewports.

### Notion/Figma Link <!-- Optional -->
[Notion](https://www.notion.so/Website-Make-Anything-Clickable-a-Button-1440ad723ce180a29baaf8ad535f6caf)

### Test Plan <!-- Required -->
Ensuring that tabbing through the page highlights all clickable elements.


