### PR TITLE
Website: Sponsor Page Improvements

### DIFF
--- a/new-dti-website/src/app/sponsor/page.tsx
+++ b/new-dti-website/src/app/sponsor/page.tsx
@@ -87,17 +87,17 @@ const SponsorPage = () => {
     <>
       <SponsorHero />
       <div className="bg-[#EDEDED] flex justify-center">
-        <div className="max-w-5xl flex justify-center p-5 py-14 lg:gap-20 md:gap-10 xs:gap-5 md:flex-row xs:flex-col">
+        <div className="max-w-5xl flex justify-center p-5 py-24 lg:gap-20 md:gap-10 xs:gap-5 md:flex-row xs:flex-col">
           <Image
             src="/images/dti_2024.png"
             alt="DTI 2024"
             width={width >= LAPTOP_BREAKPOINT ? 475 : 350}
             height={width >= LAPTOP_BREAKPOINT ? 320 : 236}
-            className="rounded-3xl mx-auto object-cover"
+            className="rounded-3xl object-cover md:w-5/12"
           />
-          <div className="flex flex-col justify-center md:gap-5 xs:gap-3">
-            <h3 className="font-semibold text-2xl">Become a sponsor!</h3>
-            <p className="text-lg">
+          <div className="flex flex-col justify-center md:gap-5 xs:gap-3 md:w-7/12">
+            <h3 className="md:text-4xl xs:text-2xl font-semibold">Become a sponsor!</h3>
+            <p className="text-lg mb-4">
               We would love to partner with organizations that share our vision of changing the
               world. Together, we can{' '}
               <span className="font-bold">

--- a/new-dti-website/src/app/sponsor/page.tsx
+++ b/new-dti-website/src/app/sponsor/page.tsx
@@ -58,50 +58,25 @@ const SponsorHero = () => {
   );
 };
 
-type SponsorCardProps = {
-  image: string;
-  title: string;
-  description: string;
-  alt: string;
-  width: number;
-  height: number;
-};
-
-const SponsorCard: React.FC<SponsorCardProps> = ({
-  image,
-  title,
-  description,
-  alt,
-  width,
-  height
-}) => (
-  <div className="flex flex-col gap-3 lg:w-[308px] md:w-60 max-w-lg items-center">
-    <Image src={image} alt={alt} height={height} width={width} />
-    <div
-      className="bg-white p-6 flex flex-col gap-3 rounded-2xl"
-      style={{ boxShadow: '4px 4px 8px 2px #00000014' }}
-    >
-      <h3 className="font-semibold lg:text-xl xs:text-lg text-center">{title}</h3>
-      <p className="lg:text-lg xs:text-sm">{description}</p>
-    </div>
-  </div>
-);
-
 const SponsorImpact = () => (
   <div
     className="max-w-5xl flex lg:gap-x-12 xs:gap-y-10 xs:gap-x-3 lg:py-24 xs:py-14 xs:flex-col 
-    md:flex-row p-5 items-center"
+    md:flex-row p-5"
   >
     {impacts.map((impact) => (
-      <SponsorCard
-        image={impact.image}
-        title={impact.title}
-        description={impact.description}
-        key={impact.key}
-        alt={impact.key}
-        width={impact.width}
-        height={impact.height}
-      />
+      <div className="flex flex-col gap-3 md:w-1/3">
+        <div className="flex items-center gap-1">
+          <Image
+            src={impact.image}
+            alt={impact.key}
+            height={impact.height}
+            width={impact.width}
+            className="h-24 h-auto md:w-[30%]"
+          />
+          <h3 className="font-semibold lg:text-xl xs:text-lg text-center">{impact.title}</h3>
+        </div>
+        <p className="lg:text-lg xs:text-sm">{impact.description}</p>
+      </div>
     ))}
   </div>
 );


### PR DESCRIPTION
### Summary <!-- Required -->
This PR addresses comments made about the sponsor page in the recent audit of the website.
* Changed the three features in a row to match the styling found on the course page.
* Fixed the "Become a Sponsor" section
  * increased vertical padding
  * increased image size
  * use more consistent header styling (took from "introducing the team" on the team page)
  * fixed text hierarchy 

### Notion/Figma Link <!-- Optional -->
[Figma](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/DTI-New-Landing-Website?node-id=0-1&node-type=canvas&t=LmR5zT7OWnRtXGUw-0)

[3 features in a row section fix](https://www.notion.so/Idol-FA24-1030ad723ce1804ca825d0ec8972c711?p=14a0ad723ce180baaf29ff419361586b&pm=s)
["Become a sponsor!" section fixes](https://www.notion.so/Idol-FA24-1030ad723ce1804ca825d0ec8972c711?p=14a0ad723ce180c7a9d7d08c14bb8822&pm=s)

### Test Plan <!-- Required -->
3 features before:
![image](https://github.com/user-attachments/assets/fb56bd62-4d97-4922-b12d-cc298c12a01f)
3 features after:
![image](https://github.com/user-attachments/assets/8f8f0ad9-4f10-4504-a560-d7d2cf9e1625)

Become a Sponsor before:
![image](https://github.com/user-attachments/assets/e6fadb3b-2b32-4a55-9da4-74aa79933e4d)
Become a Sponsor after, same viewport:
![image](https://github.com/user-attachments/assets/82dbb014-3b50-4e0a-9bd3-60dd6ece47c2)


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->

- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)
