### PR TITLE
New DTI Website: Make Icon Order in 'Applications' section Consistent

### DIFF
--- a/new-dti-website/components/apply/data/applications.json
+++ b/new-dti-website/components/apply/data/applications.json
@@ -1,18 +1,16 @@
 {
-  "product": {
-    "roleName": "Product Manager",
-    "icon": { "src": "/icons/product_sticker.svg", "width": 90, "height": 90 },
+  "development": {
+    "roleName": "Developer",
+    "icon": { "src": "/icons/dev_sticker.svg", "width": 96, "height": 90 },
     "skills": [
-      "excellent organization skills in either Notion, G-Suite, Jira, etc",
-      "understanding of the product and design cycle as well as the technical stack",
-      "knowledge of DTI's culture and product branding",
-      "eagerness to develop and maintain team culture!"
+      "a curious, inventive and communicative investigator",
+      "eagerness to learn new technologies and applications",
+      "experience in computer science or app/web development (specific technologies will be taught in DTI, so no expert knowledge required!)"
     ],
     "responsibilities": [
-      "delivering the product by guiding products throughout their execution cycle",
-      "bridging the communication gaps between designers and developers",
-      "prioritizing requirements and tasks for delivery",
-      "collaborating and working with other student organizations on campus"
+      "work as the backbone of the project to bring concepts to reality",
+      "front-end developers: implement mockups, balancing project constraints ",
+      "back-end developers: organize and manipulate processed data to create informed and practical data sources"
     ]
   },
   "design": {
@@ -31,20 +29,6 @@
       "Iterate based on critique, feedback and user testing"
     ]
   },
-  "development": {
-    "roleName": "Developer",
-    "icon": { "src": "/icons/dev_sticker.svg", "width": 96, "height": 90 },
-    "skills": [
-      "a curious, inventive and communicative investigator",
-      "eagerness to learn new technologies and applications",
-      "experience in computer science or app/web development (specific technologies will be taught in DTI, so no expert knowledge required!)"
-    ],
-    "responsibilities": [
-      "work as the backbone of the project to bring concepts to reality",
-      "front-end developers: implement mockups, balancing project constraints ",
-      "back-end developers: organize and manipulate processed data to create informed and practical data sources"
-    ]
-  },
   "business": {
     "roleName": "Business",
     "icon": { "src": "/icons/business_sticker.svg", "width": 90, "height": 90 },
@@ -59,6 +43,22 @@
       "reach out to corporate partners to become Sponsors for DTI",
       "innovate processes and create new team building events to boost team culture",
       "bolster social media presence and enhance the presence of DTI online"
+    ]
+  },
+  "product": {
+    "roleName": "Product Manager",
+    "icon": { "src": "/icons/product_sticker.svg", "width": 90, "height": 90 },
+    "skills": [
+      "excellent organization skills in either Notion, G-Suite, Jira, etc",
+      "understanding of the product and design cycle as well as the technical stack",
+      "knowledge of DTI's culture and product branding",
+      "eagerness to develop and maintain team culture!"
+    ],
+    "responsibilities": [
+      "delivering the product by guiding products throughout their execution cycle",
+      "bridging the communication gaps between designers and developers",
+      "prioritizing requirements and tasks for delivery",
+      "collaborating and working with other student organizations on campus"
     ]
   }
 }

--- a/new-dti-website/components/team/TeamAbout.tsx
+++ b/new-dti-website/components/team/TeamAbout.tsx
@@ -122,13 +122,7 @@ const TeamStatistics = () => {
     }, new Set());
 
   const emptyRoleStats: roleStatistics = {
-    designer: {
-      name: 'Design',
-      color: '#FFBCBC',
-      people: 0,
-      majors: new Set(),
-      colleges: new Set()
-    },
+    lead: { name: 'Leads', color: '#484848', people: 0, majors: new Set(), colleges: new Set() },
     developer: {
       name: 'Development',
       color: '#D63D3D',
@@ -136,7 +130,13 @@ const TeamStatistics = () => {
       majors: new Set(),
       colleges: new Set()
     },
-    pm: { name: 'Product', color: '#FFFFFF', people: 0, majors: new Set(), colleges: new Set() },
+    designer: {
+      name: 'Design',
+      color: '#FFBCBC',
+      people: 0,
+      majors: new Set(),
+      colleges: new Set()
+    },
     business: {
       name: 'Business',
       color: '#B7B7B7',
@@ -144,7 +144,7 @@ const TeamStatistics = () => {
       majors: new Set(),
       colleges: new Set()
     },
-    lead: { name: 'Leads', color: '#484848', people: 0, majors: new Set(), colleges: new Set() }
+    pm: { name: 'Product', color: '#FFFFFF', people: 0, majors: new Set(), colleges: new Set() }
   };
 
   const roleStats = populateObject(emptyRoleStats, (key, value) => {

--- a/new-dti-website/components/team/data/roleIcons.json
+++ b/new-dti-website/components/team/data/roleIcons.json
@@ -13,14 +13,14 @@
       "height": 66
     },
     {
-      "src": "/icons/design",
-      "altText": "Design",
-      "width": 66,
+      "src": "/icons/dev",
+      "altText": "Development",
+      "width": 72,
       "height": 66
     },
     {
-      "src": "/icons/product",
-      "altText": "Product",
+      "src": "/icons/design",
+      "altText": "Design",
       "width": 66,
       "height": 66
     },
@@ -31,9 +31,9 @@
       "height": 66
     },
     {
-      "src": "/icons/dev",
-      "altText": "Development",
-      "width": 72,
+      "src": "/icons/product",
+      "altText": "Product",
+      "width": 66,
       "height": 66
     }
   ]


### PR DESCRIPTION
### Summary <!-- Required -->
For the Product/Design/Development/Business icons, we should use the same order as on the “About” page.

Use the order based on number of ppl on each team:

1. Development
2. Design
3. Business
4. Product

### Notion/Figma Link <!-- Optional -->
https://www.notion.so/New-Website-APPLY-Icons-in-Applications-section-14d0ad723ce180f5be8ed66e0bda6355?pvs=4

### Test Plan <!-- Required -->
<img width="1027" alt="Screenshot 2024-11-28 at 8 56 29 PM" src="https://github.com/user-attachments/assets/73ddb4fd-61e9-418c-925a-16d492189f7c">
<img width="1045" alt="Screenshot 2024-11-28 at 8 56 16 PM" src="https://github.com/user-attachments/assets/50288eb7-a9ae-4caa-b867-7c6ac6e4036a">



### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

