### PR TITLE
New Website: Apply Page, Reorder Timeline Tabs and Only Show Banner if Application is Closed

### DIFF
--- a/new-dti-website/components/apply/ApplicationTimeline.tsx
+++ b/new-dti-website/components/apply/ApplicationTimeline.tsx
@@ -19,7 +19,7 @@ type TabProps = {
 const Tab: React.FC<TabProps> = ({ isSelected, text, onClick, tabIndex }) => (
   <button
     className={`flex items-center lg:px-5 lg:py-4 md:px-4 md:py-3 xs:px-2 md:rounded-t-xl xs:rounded-t-lg ${
-      isSelected ? 'bg-[#FEFEFE] text-[#A52424]' : 'bg-[#7E2222CC] text-[#FEFEFE]'
+      isSelected ? 'bg-[#FEFEFE] text-[#A52424]' : 'text-[#FEFEFE]'
     } hover:cursor-pointer md:h-min xs:h-full`}
     onClick={onClick}
     role="tab"
@@ -263,14 +263,14 @@ const ApplicationTimeline = () => {
               {isFall ? (
                 <>
                   <Tab
-                    isSelected={cycle === 'freshmen'}
-                    text={'Freshmen/Transfer'}
-                    onClick={() => setCycle('freshmen')}
-                  />
-                  <Tab
                     isSelected={cycle === 'upperclassmen'}
                     text={'Upperclassmen'}
                     onClick={() => setCycle('upperclassmen')}
+                  />
+                  <Tab
+                    isSelected={cycle === 'freshmen'}
+                    text={'Freshmen/Transfer'}
+                    onClick={() => setCycle('freshmen')}
                   />
                 </>
               ) : (

--- a/new-dti-website/src/app/apply/page.tsx
+++ b/new-dti-website/src/app/apply/page.tsx
@@ -9,54 +9,60 @@ import ApplyFAQ from '../../../components/apply/ApplyFAQ';
 import Banner from '../../../components/apply/Banner';
 import { isAppOpen } from '../../utils/dateUtils';
 
-const ApplyHero = () => (
-  <div className="text-[#FEFEFE] min-h-[calc(100vh-136px)] flex items-center relative">
-    <Banner
-      message={`We're no longer accepting applications for ${config.semester}. Stay tuned for opportunities next semester!`}
-      variant={'accent'}
-    />
-    <div
-      className="flex lg:flex-row xs:flex-col gap-x-[60px] lg:ml-[90px] lg:mr-[169px]
+const ApplyHero = () => {
+  const isApplicationOpen = isAppOpen();
+
+  return (
+    <div className="text-[#FEFEFE] min-h-[calc(100vh-136px)] flex items-center relative">
+      {!isApplicationOpen && (
+        <Banner
+          message={`We're no longer accepting applications for ${config.semester}. Stay tuned for opportunities next semester!`}
+          variant={'accent'}
+        />
+      )}
+      <div
+        className="flex lg:flex-row xs:flex-col gap-x-[60px] lg:ml-[90px] lg:mr-[169px]
       xs:mx-6 md:mx-[65px]"
-    >
-      <h1 className="flex items-center md:text-header md:leading-header xs:text-[48px] xs:leading-header-xs font-semibold">
-        <div>
-          JOIN OUR <span className="text-[#FF4C4C]">COMMUNITY</span>
-        </div>
-      </h1>
-      <div className="flex flex-col gap-6">
-        <h2
-          className="font-bold md:text-subheader xs:text-[24px] md:leading-subheader
+      >
+        <h1 className="flex items-center md:text-header md:leading-header xs:text-[48px] xs:leading-header-xs font-semibold">
+          <div>
+            JOIN OUR <span className="text-[#FF4C4C]">COMMUNITY</span>
+          </div>
+        </h1>
+        <div className="flex flex-col gap-6">
+          <h2
+            className="font-bold md:text-subheader xs:text-[24px] md:leading-subheader
           xs:leading-[29px] text-hero-primary"
-        >
-          Down to innovate?
-        </h2>
-        <p className="md:text-lg xs:text-sm text-hero-secondary md:leading-body-text">
-          <span className="font-bold">We strive for inclusivity</span>, and encourage passionate
-          applicants to apply regardless of experience. We'd love to work with someone like you.
-        </p>
-        {isAppOpen() ? (
-          <Link key="Apply Page" href={config.applicationLink} className="primary-button">
-            Apply now
-          </Link>
-        ) : (
-          <Link
-            key="Apply Page"
-            href="#"
-            className="primary-button opacity-50 cursor-not-allowed"
-            onClick={(e) => e.preventDefault()}
-            aria-disabled="true"
           >
-            Apply now
-          </Link>
-        )}
+            Down to innovate?
+          </h2>
+          <p className="md:text-lg xs:text-sm text-hero-secondary md:leading-body-text">
+            <span className="font-bold">We strive for inclusivity</span>, and encourage passionate
+            applicants to apply regardless of experience. We'd love to work with someone like you.
+          </p>
+          {isApplicationOpen ? (
+            <Link key="Apply Page" href={config.applicationLink} className="primary-button">
+              Apply now
+            </Link>
+          ) : (
+            <Link
+              key="Apply Page"
+              href="#"
+              className="primary-button opacity-50 cursor-not-allowed"
+              onClick={(e) => e.preventDefault()}
+              aria-disabled="true"
+            >
+              Apply now
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="relative">
+        <RedBlob className={'right-[-300px]'} intensity={0.5} />
       </div>
     </div>
-    <div className="relative">
-      <RedBlob className={'right-[-300px]'} intensity={0.5} />
-    </div>
-  </div>
-);
+  );
+};
 
 const ApplyCoffeeChat = () => (
   <div className="relative flex justify-center bg-[#F5F5F5] md:py-[80px] xs:py-[80px]">


### PR DESCRIPTION
### Summary <!-- Required -->
- [x] Only Show Banner if Application is Closed
- [x] Reorder Timeline Tabs
- [x] Remove dark red background color on application timeline

Before:
<img width="1135" alt="Screenshot 2024-11-29 at 1 07 55 AM" src="https://github.com/user-attachments/assets/47828e77-4dd4-4bcb-890b-2c46ce2892dd">


After:
 
<img width="1081" alt="Screenshot 2024-11-29 at 1 07 45 AM" src="https://github.com/user-attachments/assets/995a6d0e-b248-4ef3-9622-50454de0a01e">


### Notion/Figma Link <!-- Optional -->
https://www.notion.so/New-Website-Only-Show-Banner-When-Applications-Are-Closed-14c0ad723ce18059b0a4fa259b029b8c?pvs=4

https://www.notion.so/New-Website-APPLY-Timeline-tabs-14d0ad723ce18017859ddad112809f55?pvs=4

### Test Plan <!-- Required -->
See screenshots.


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

