### PR TITLE
New Website: Fix Broken Links and Show Development Role Description First

### DIFF
--- a/new-dti-website/components/apply/RoleDescription.tsx
+++ b/new-dti-website/components/apply/RoleDescription.tsx
@@ -16,7 +16,7 @@ const applications = applicationData as {
 };
 
 const RoleDescriptions = () => {
-  const [role, setRole] = useState<string>('product');
+  const [role, setRole] = useState<string>('development');
 
   return (
     <div className="relative flex justify-center text-[#FEFEFE]">

--- a/new-dti-website/components/bottom.tsx
+++ b/new-dti-website/components/bottom.tsx
@@ -72,7 +72,7 @@ const Bottom: React.FC = () => (
               </p>
             </div>
           </div>
-          <Link href="/courses" className="primary-button">
+          <Link href="/course" className="primary-button">
             Learn more
           </Link>
         </div>
@@ -116,7 +116,7 @@ const Bottom: React.FC = () => (
             We strive to build initiatives not only at Cornell, but also in the{' '}
             <span className="font-bold">Ithaca community and beyond</span>.
           </p>
-          <Link href="/initiative" className="primary-button">
+          <Link href="/initiatives" className="primary-button">
             How we give back
           </Link>
         </div>


### PR DESCRIPTION
### Summary <!-- Required -->
Quick PR:
1. Fix the "Learn more" and "How we give back" button links on the home page
2. Select the "Development" button by default on the Apply page role descriptions (since that is the leftmost-positioned role)


### Notion/Figma Link <!-- Optional -->
https://www.notion.so/14d0ad723ce180b68867ed72b07378f4?pvs=4

### Test Plan <!-- Required -->

https://github.com/user-attachments/assets/fc8917bf-3130-4e43-9d46-048cf9aaf8d6



### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->
