### PR TITLE
Bump Cron Times: Weekly instead of Daily, Profile Update Notification Sent Earlier

### DIFF
--- a/.github/workflows/profile-update-notification.yml
+++ b/.github/workflows/profile-update-notification.yml
@@ -1,8 +1,8 @@
 name: Profile Update Notification
 on:
   schedule:
-    # Runs script at 10PM UTC (5PM or 6PM ET) every day. This should be two hours before pull-from-idol
-    - cron: '0 23 * * *'
+    # Runs script at 5PM UTC (12PM or 1PM ET) every Monday. This should be seven hours before pull-from-idol
+    - cron: '0 17 * * MON'
 
 jobs:
   profile-update-notification:

--- a/.github/workflows/pull-from-idol-images.yml
+++ b/.github/workflows/pull-from-idol-images.yml
@@ -2,8 +2,8 @@ name: Pull from IDOL Images
 on:
   workflow_dispatch:
   schedule:
-    # Run the script at 0AM in UTC every day, which is 7PM or 8PM in ET.
-    - cron: '0 0 * * *'
+    # Run the script at 0AM in UTC every Tuesday, which is 7PM or 8PM on Monday in ET.
+    - cron: '0 0 * * TUE'
   pull_request:
     paths:
       - backend/scripts/pull-from-idol-images.ts

--- a/.github/workflows/pull-from-idol.yml
+++ b/.github/workflows/pull-from-idol.yml
@@ -4,8 +4,8 @@ on:
     types: pull-idol-changes
   workflow_dispatch:
   schedule:
-    # Run the script at 0AM in UTC every day, which is 7PM or 8PM in ET.
-    - cron: '0 0 * * *'
+    # Run the script at 0AM in UTC every Tuesday, which is 7PM or 8PM on Monday in ET.
+    - cron: '0 0 * * TUE'
   pull_request:
     paths:
       - new-dti-website/pull-from-idol.ts


### PR DESCRIPTION
Pull from IDOL and Pull from IDOL Images has been running for a few weeks now. People actually tend to update their profiles more frequently than I had anticipated, and the daily pings from it can get annoying. Also, leads agree that a weekly deploy cycle is fine.

Worst case, we can always manually run these jobs if we have an urgent update that needs to be deployed.

This PR:
- Makes Pull from IDOL, Pull from IDOL Images, and Profile Update Notifications happen Weekly
- Moves IDOL Profile Notifications to be 7 hours before Pull from IDOL (instead of 2 hours), so we have sufficient time to approve the changes