### PR TITLE
Revert style of label in Course page

### DIFF
--- a/new-dti-website/src/app/course/page.tsx
+++ b/new-dti-website/src/app/course/page.tsx
@@ -115,7 +115,7 @@ export default function Courses() {
               </div>
 
               <div className="flex flex-col lg:w-1/2">
-                <div className="font-semibold text-sm md:text-xl">
+                <div className="font-semibold text-sm md:text-xl uppercase text-[16px] tracking-[1px] text-[#666]">
                   Modern industry-leading technology
                 </div>
 


### PR DESCRIPTION
- consulted with Vannessa and we wanted to revert the styling for this label on the Course page

|Before|After|
|-|-|
|<img width="1517" alt="Screenshot 2024-12-06 at 1 51 49 PM" src="https://github.com/user-attachments/assets/3ba2d185-12fa-48a7-bab4-668159287c89">|<img width="1517" alt="Screenshot 2024-12-06 at 1 51 34 PM" src="https://github.com/user-attachments/assets/46874fb7-0d28-46ea-ad38-22ddf569279e">|
