### PR TITLE
Coffee Chat: Fix getCoffeeChatsByUser to fetch by Supplied Email

### DIFF
--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -18,8 +18,20 @@ export const getAllCoffeeChats = (): Promise<CoffeeChat[]> => coffeeChatDao.getA
  * Gets all coffee chats for a user
  * @param user - user whose coffee chats should be fetched
  */
-export const getCoffeeChatsByUser = async (user: IdolMember): Promise<CoffeeChat[]> =>
-  coffeeChatDao.getCoffeeChatsByUser(user);
+export const getCoffeeChatsByUser = async (
+  user: IdolMember,
+  email: string
+): Promise<CoffeeChat[]> => {
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  if (!isLeadOrAdmin && email !== user.email) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to get coffee chats for user with email ${email}.`
+    );
+  }
+
+  const coffeeChats = coffeeChatDao.getCoffeeChatsByUser(email);
+  return coffeeChats;
+};
 
 /**
  * Creates a new coffee chat for member
@@ -44,12 +56,12 @@ export const createCoffeeChat = async (
   }
 
   const pendingChats = await coffeeChatDao.getCoffeeChatsByUser(
-    coffeeChat.submitter,
+    coffeeChat.submitter.email,
     'pending',
     coffeeChat.otherMember
   );
   const approvedChats = await coffeeChatDao.getCoffeeChatsByUser(
-    coffeeChat.submitter,
+    coffeeChat.submitter.email,
     'approved',
     coffeeChat.otherMember
   );

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -16,7 +16,8 @@ export const getAllCoffeeChats = (): Promise<CoffeeChat[]> => coffeeChatDao.getA
 
 /**
  * Gets all coffee chats for a user
- * @param user - user whose coffee chats should be fetched
+ * @param user - user requesting to fetch coffee chats
+ * @param email - email of user whose coffee chats should be fetched
  */
 export const getCoffeeChatsByUser = async (
   user: IdolMember,

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -308,8 +308,8 @@ loginCheckedDelete('/coffee-chat/:uuid', async (req, user) => {
   return {};
 });
 
-loginCheckedGet('/coffee-chat/:email', async (_, user) => {
-  const coffeeChats = await getCoffeeChatsByUser(user);
+loginCheckedGet('/coffee-chat/:email', async (req, user) => {
+  const coffeeChats = await getCoffeeChatsByUser(user, req.params.email);
   return { coffeeChats };
 });
 

--- a/backend/src/dao/CoffeeChatDao.ts
+++ b/backend/src/dao/CoffeeChatDao.ts
@@ -86,12 +86,12 @@ export default class CoffeeChatDao extends BaseDao<CoffeeChat, DBCoffeeChat> {
 
   /**
    * Gets all coffee chat that a user has submitted
-   * @param submitter - submitter whose coffee chats should be fetched
+   * @param submitterEmail - email of submitter whose coffee chats should be fetched
    * @param status - the status of fetched coffee chats (optional)
    * @param otherMember - additional filter for coffee chats with otherMember (optional)
    */
   async getCoffeeChatsByUser(
-    submitter: IdolMember,
+    submitterEmail: string,
     status?: Status,
     otherMember?: IdolMember
   ): Promise<CoffeeChat[]> {
@@ -99,7 +99,7 @@ export default class CoffeeChatDao extends BaseDao<CoffeeChat, DBCoffeeChat> {
       {
         field: 'submitter',
         comparisonOperator: '==',
-        value: memberCollection.doc(submitter.email)
+        value: memberCollection.doc(submitterEmail)
       }
     ];
 

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -95,6 +95,20 @@ describe('User is not lead or admin', () => {
       new PermissionError('Clearing all Coffee Chats is disabled')
     );
   });
+
+  test('getCoffeeChatsByUser user can fetch own coffee chats', async () => {
+    const coffeeChats = await getCoffeeChatsByUser(user, user.email);
+    expect(coffeeChats.length).toBeGreaterThan(0);
+    expect(CoffeeChatDao.prototype.getCoffeeChatsByUser).toBeCalled();
+  });
+
+  test("getCoffeeChatsByUser should throw error if non-admin requests for other user's coffee chats", async () => {
+    expect(getCoffeeChatsByUser(user, user2.email)).rejects.toThrow(
+      new PermissionError(
+        `User with email ${user.email} does not have permissions to get coffee chats for user with email ${user2.email}.`
+      )
+    );
+  });
 });
 
 describe('User is lead or admin', () => {
@@ -142,7 +156,7 @@ describe('User is lead or admin', () => {
   });
 
   test('getCoffeeChatsByUser should return user coffee chats', async () => {
-    const coffeeChats = await getCoffeeChatsByUser(adminUser);
+    const coffeeChats = await getCoffeeChatsByUser(adminUser, user.email);
     expect(coffeeChats.length).toBeGreaterThan(0);
     expect(CoffeeChatDao.prototype.getCoffeeChatsByUser).toBeCalled();
   });
@@ -180,7 +194,7 @@ describe('More complicated member meets category checks', () => {
   const user1 = { ...fakeIdolMember(), subteams: ['team1'], role: 'developer' as Role };
   const user2 = { ...fakeIdolMember(), role: 'pm' as Role, subteams: ['team2'] };
   const user3 = { ...fakeIdolMember(), role: 'pm' as Role, subteams: ['team1'] };
-  const user4 = { ...fakeIdolMember(), role: 'business' };
+  const user4 = { ...fakeIdolMember(), role: 'business' as Role };
   const user5 = { ...fakeIdolMember(), role: 'tpm' as Role, subteams: ['team3'] };
   const user6 = { ...fakeIdolMember(), role: 'tpm' as Role, subteams: ['team1'] };
   const user7 = { ...fakeIdolMember(), role: 'product-lead' as Role };

--- a/backend/tests/CoffeeChatDao.test.ts
+++ b/backend/tests/CoffeeChatDao.test.ts
@@ -5,7 +5,7 @@ import { coffeeChatsCollection } from '../src/firebase';
 const user = fakeIdolMember();
 const user2 = fakeIdolMember();
 const mockCC = { ...fakeCoffeeChat(), submitter: user };
-const mockCC2 = { ...fakeCoffeeChat(), status: 'accepted', submitter: user };
+const mockCC2 = { ...fakeCoffeeChat(), status: 'accepted' as Status, submitter: user };
 const mockCC3 = { ...fakeCoffeeChat(), submitter: user, otherMember: user2 };
 
 const coffeeChatDao = new CoffeeChatDao();
@@ -24,21 +24,21 @@ afterAll(async () => {
 });
 
 test('Get coffee chat by user', () =>
-  coffeeChatDao.getCoffeeChatsByUser(user).then((coffeeChats) => {
+  coffeeChatDao.getCoffeeChatsByUser(user.email).then((coffeeChats) => {
     expect(coffeeChats.some((submission) => submission === mockCC));
     expect(coffeeChats.some((submission) => submission === mockCC2));
     expect(coffeeChats.some((submission) => submission === mockCC3));
   }));
 
 test('Get coffee chat by user with status', () =>
-  coffeeChatDao.getCoffeeChatsByUser(user, 'accepted').then((coffeeChats) => {
+  coffeeChatDao.getCoffeeChatsByUser(user.email, 'accepted' as Status).then((coffeeChats) => {
     expect(coffeeChats.some((submission) => submission === mockCC)).toBe(false);
     expect(coffeeChats.some((submission) => submission === mockCC2));
     expect(coffeeChats.some((submission) => submission === mockCC3)).toBe(false);
   }));
 
 test('Get coffee chat by user with other member', () =>
-  coffeeChatDao.getCoffeeChatsByUser(user, undefined, user2).then((coffeeChats) => {
+  coffeeChatDao.getCoffeeChatsByUser(user.email, undefined, user2).then((coffeeChats) => {
     expect(coffeeChats.some((submission) => submission === mockCC)).toBe(false);
     expect(coffeeChats.some((submission) => submission === mockCC2)).toBe(false);
     expect(coffeeChats.some((submission) => submission === mockCC3));

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -58,6 +58,7 @@ export const fakeIdolMember = (): IdolMember => {
     hometown: faker.address.city(),
     about: faker.lorem.paragraph(),
     subteams: fakeSubteams(),
+    semesterJoined: fakeYear(),
     ...fakeRoleObject()
   };
   return member;
@@ -67,8 +68,8 @@ export const fakeIdolMember = (): IdolMember => {
 export const fakeIdolLead = (): IdolMember => {
   const member = {
     ...fakeIdolMember(),
-    role: 'ops-lead',
-    roleDescription: 'Full Team Lead'
+    role: 'ops-lead' as Role,
+    roleDescription: 'Full Team Lead' as RoleDescription
   };
   return member;
 };
@@ -97,7 +98,8 @@ export const fakeTeamEvent = (): TeamEvent => {
     requests: [fakeTeamEventAttendance()],
     attendees: [],
     uuid: faker.datatype.uuid(),
-    isInitiativeEvent: getRandomBoolean()
+    isInitiativeEvent: getRandomBoolean(),
+    maxCredits: ''
   };
   return TE;
 };
@@ -123,6 +125,7 @@ export const fakeDevPortfolioSubmission = (): DevPortfolioSubmission => {
     member: fakeIdolMember(),
     openedPRs: fakePRs(),
     reviewedPRs: fakePRs(),
+    otherPRs: fakePRs(),
     status: 'pending'
   };
   return DPSub;
@@ -204,7 +207,7 @@ export const fakeCandidateDeciderInstance = (): CandidateDeciderInstance => {
     headers: [''],
     candidates: [fakeCandidateDeciderCandidate()],
     authorizedMembers: [fakeIdolMember()],
-    authorizedRoles: [fakeRoleObject()]
+    authorizedRoles: [fakeRoleObject().role]
   };
   return CDI;
 };
@@ -218,8 +221,9 @@ export const fakeCoffeeChat = (): CoffeeChat => {
     isNonIDOLMember: false,
     slackLink: '',
     category: 'test',
-    status: 'pending',
-    date: Date.now()
+    status: 'pending' as Status,
+    date: Date.now(),
+    memberMeetsCategory: 'no data' as MemberMeetsCategoryStatus
   };
   return CC;
 };


### PR DESCRIPTION
### Summary <!-- Required -->
`getCoffeeChatsByUser` is supposed to return coffee chats of a given user, supplied by the email. Looks like we previously only fetched by the requester.

Fetch by email supplied by the request query param.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Added/updated unit tests.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

