### PR TITLE
New Website: Remove next/link

### DIFF
--- a/new-dti-website/components/apply/ApplicationTimeline.tsx
+++ b/new-dti-website/components/apply/ApplicationTimeline.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
+
 import config from '../../config.json';
 import timelineIcons from './data/timelineIcons.json';
 import { ibm_plex_mono } from '../../src/app/layout';
@@ -174,7 +174,7 @@ const TimelineNode: React.FC<RecruitmentEventProps> = ({
                 className={`${isNextEvent ? 'brightness-0' : ''}`}
               />
               <p className={event.link ? 'underline text-[#D63D3D]' : ''}>
-                {event.link ? <Link href={event.link}>{event.location}</Link> : event.location}
+                {event.link ? <a href={event.link}>{event.location}</a> : event.location}
               </p>
             </div>
           )}

--- a/new-dti-website/components/apply/ApplyFAQ.tsx
+++ b/new-dti-website/components/apply/ApplyFAQ.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useState } from 'react';
-import Link from 'next/link';
+
 import config from '../../config.json';
 import interviewPrep from './data/interviewPrep.json';
 
@@ -81,9 +81,9 @@ const ApplyFAQ = () => {
                   coffee, but should be 30 minutes like an actual coffee catch up with a friend. Get
                   the most out of the coffee chat by preparing your questions ahead of time and
                   researching the other person's experiences first. Find DTI members to chat{' '}
-                  <Link className="underline text-[#D63D3D]" href={config.coffeeChatLink}>
+                  <a className="underline text-[#D63D3D]" href={config.coffeeChatLink}>
                     here
-                  </Link>
+                  </a>
                   .
                 </p>
               </FAQAccordion>
@@ -92,9 +92,9 @@ const ApplyFAQ = () => {
                   Whether or not you receive an interview invitation, we will email you a definitive
                   decision within a week of applying! We're happy to answer any questions you have
                   during this time through our email,{' '}
-                  <Link className="underline text-[#D63D3D]" href="mailto:hello@cornelldti.org">
+                  <a className="underline text-[#D63D3D]" href="mailto:hello@cornelldti.org">
                     hello@cornelldti.org
-                  </Link>
+                  </a>
                   .
                 </p>
               </FAQAccordion>

--- a/new-dti-website/components/apply/RoleDescription.tsx
+++ b/new-dti-website/components/apply/RoleDescription.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
+
 import applicationData from './data/applications.json';
 import config from '../../config.json';
 import RedBlob from '../blob';
@@ -109,19 +109,18 @@ const RoleDescriptions = () => {
           })}
         </div>
         {isAppOpen() ? (
-          <Link key="Apply Page" href={config.applicationLink} className="primary-button">
+          <a key="Apply Page" href={config.applicationLink} className="primary-button">
             Apply now
-          </Link>
+          </a>
         ) : (
-          <Link
+          <button
             key="Apply Page"
-            href="#"
             className="primary-button opacity-50 cursor-not-allowed"
             onClick={(e) => e.preventDefault()}
             aria-disabled="true"
           >
             Apply now
-          </Link>
+          </button>
         )}
       </div>
       <RedBlob className="bottom-[-300px] left-[-350px] z-0" intensity={0.5} />

--- a/new-dti-website/components/bottom.tsx
+++ b/new-dti-website/components/bottom.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 
 const Bottom: React.FC = () => (
   <div className="flex flex-col w-screen h-fit text-white justify-center">
@@ -72,9 +71,9 @@ const Bottom: React.FC = () => (
               </p>
             </div>
           </div>
-          <Link href="/course" className="primary-button" aria-label="Courses page">
+          <a href="/course" className="primary-button" aria-label="Courses page">
             Learn more
-          </Link>
+          </a>
         </div>
       </div>
     </div>
@@ -116,9 +115,9 @@ const Bottom: React.FC = () => (
             We strive to build initiatives not only at Cornell, but also in the{' '}
             <span className="font-bold">Ithaca community and beyond</span>.
           </p>
-          <Link href="/initiatives" className="primary-button">
+          <a href="/initiatives" className="primary-button">
             How we give back
-          </Link>
+          </a>
         </div>
       </div>
     </div>
@@ -141,12 +140,12 @@ const Bottom: React.FC = () => (
           <span className="font-bold">teach others from our experience.</span>
         </p>
         <div className="flex flex-row gap-x-3">
-          <Link href="/team" className="primary-button">
+          <a href="/team" className="primary-button">
             Get to know us
-          </Link>
-          <Link href="/apply" className="secondary-button">
+          </a>
+          <a href="/apply" className="secondary-button">
             Join us
-          </Link>
+          </a>
         </div>
       </div>
     </div>

--- a/new-dti-website/components/footer.tsx
+++ b/new-dti-website/components/footer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 
 type Icon = {
   src: string;
@@ -58,7 +57,7 @@ const Footer: React.FC<FooterProps> = ({ theme }) => (
     </div>
     <div className="flex gap-5 md:h-fit h-screen">
       {socialIcons.map((icon, index) => (
-        <Link
+        <a
           key={index}
           href={icon.link}
           target="_blank"
@@ -72,7 +71,7 @@ const Footer: React.FC<FooterProps> = ({ theme }) => (
             height={36}
             alt={icon.alt}
           />
-        </Link>
+        </a>
       ))}
     </div>
   </div>

--- a/new-dti-website/components/navbar.tsx
+++ b/new-dti-website/components/navbar.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Image from 'next/image';
-import Link from 'next/link';
 
 const navbarItems = [
   {
@@ -45,7 +44,7 @@ const Navbar: React.FC = () => {
     <div className="relative z-[60]">
       <div className="w-full px-5 py-7 md:p-10 lg:pl-11 lg:py-10 lg:pr-7 !inline-flex !justify-between !flex-row">
         <div className="w-fit flex flex-col !justify-center z-40">
-          <Link href="/">
+          <a href="/">
             <Image
               className="md:h-12 h-8 w-auto"
               src="/dti_logo.svg"
@@ -53,11 +52,11 @@ const Navbar: React.FC = () => {
               height={62}
               alt="DTI Logo"
             />
-          </Link>
+          </a>
         </div>
         <div className="hidden !justify-self-end w-fit lg:inline-flex flex-row">
           {navbarItems.map((item) => (
-            <Link
+            <a
               className={`hover:underline cursor-pointer text-white p-4 underline-offset-8 decoration-2 decoration-white ${
                 pathname === item.url ? 'underline' : ''
               }`}
@@ -65,7 +64,7 @@ const Navbar: React.FC = () => {
               key={item.name}
             >
               {item.name}
-            </Link>
+            </a>
           ))}
         </div>
         <div className={`flex lg:hidden w-fit ${isMenuOpen ? 'z-50' : 'z-10'}`}>
@@ -100,13 +99,13 @@ const Navbar: React.FC = () => {
             </div>
             <div className="backdrop-blur-sm w-full px-8 py-4 md:px-14 md:py-4 h-full flex flex-col gap-y-6 landscape:gap-y-2 md:landscape:gap-y-6 text-right">
               {navbarItems.map((item) => (
-                <Link
+                <a
                   key={item.name}
                   className="hover:underline cursor-pointer text-white text-base md:text-2xl font-normal underline-offset-8 decoration-2 decoration-white"
                   href={item.url}
                 >
                   {item.name}
-                </Link>
+                </a>
               ))}
             </div>
           </div>

--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -1,6 +1,6 @@
 import { useState, RefObject } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
+
 import { Card } from '../ui/card';
 import teamRoles from './data/roles.json';
 import subteams from './data/subteams.json';
@@ -150,9 +150,9 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
                 }`}
               >
                 {link ? (
-                  <Link href={link} className="whitespace-nowrap">
+                  <a href={link} className="whitespace-nowrap">
                     {name}
-                  </Link>
+                  </a>
                 ) : (
                   <p>{name}</p>
                 )}
@@ -166,24 +166,21 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
                   const link = props[icon.alt as keyof typeof props] as string | null;
                   return (
                     link && (
-                      <Link
-                        href={icon.alt === 'email' ? `mailto:${link}` : `${link}`}
-                        key={icon.alt}
-                      >
+                      <a href={icon.alt === 'email' ? `mailto:${link}` : `${link}`} key={icon.alt}>
                         <Image
                           src={icon.src}
                           alt={icon.alt}
                           height={icon.height}
                           width={icon.width}
                         />
-                      </Link>
+                      </a>
                     )
                   );
                 })}
               </div>
             </div>
             <div className="md:block xs:hidden">
-              <Link
+              <a
                 href={props.coffeeChatLink ?? `mailto:${props.email}`}
                 onMouseEnter={mouseHandler}
                 onMouseLeave={mouseHandler}
@@ -199,7 +196,7 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
                   className={hover ? 'brightness-0 invert' : ''}
                 />
                 <p className="font-bold text-lg text-inherit whitespace-nowrap">Chat with me</p>
-              </Link>
+              </a>
             </div>
           </div>
         </div>
@@ -212,7 +209,7 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
         </button>
       </div>
       <div className="md:hidden xs:block">
-        <Link
+        <a
           href={props.coffeeChatLink ?? `mailto:${props.email}`}
           onMouseEnter={mouseHandler}
           onMouseLeave={mouseHandler}
@@ -230,7 +227,7 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
             />
             <p className="font-bold text-base text-inherit whitespace-nowrap">Chat with me</p>
           </div>
-        </Link>
+        </a>
       </div>
     </Card>
   );

--- a/new-dti-website/components/team/TeamFooter.tsx
+++ b/new-dti-website/components/team/TeamFooter.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+
 import companies from './data/companies.json';
 import useScreenSize from '../../src/hooks/useScreenSize';
 import { TABLET_BREAKPOINT } from '../../src/consts';
@@ -58,9 +58,9 @@ const TeamFooter = () => {
             <h2 className="font-semibold lg:text-[32px] md:text-2xl">Want to join the family?</h2>
             <p className="lg:text-[22px] md:text-lg">{message}</p>
             {isAppOpen() && (
-              <Link href={'/apply'} className="primary-button">
+              <a href={'/apply'} className="primary-button">
                 Apply here
-              </Link>
+              </a>
             )}
           </div>
         </div>

--- a/new-dti-website/src/app/apply/page.tsx
+++ b/new-dti-website/src/app/apply/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import ApplicationTimeline from '../../../components/apply/ApplicationTimeline';
 import config from '../../../config.json';
 import RoleDescriptions from '../../../components/apply/RoleDescription';
@@ -44,19 +43,18 @@ const ApplyHero = () => {
             applicants to apply regardless of experience. We'd love to work with someone like you.
           </p>
           {isApplicationOpen ? (
-            <Link key="Apply Page" href={config.applicationLink} className="primary-button">
+            <a key="Apply Page" href={config.applicationLink} className="primary-button">
               Apply now
-            </Link>
+            </a>
           ) : (
-            <Link
+            <button
               key="Apply Page"
-              href="#"
               className="primary-button opacity-50 cursor-not-allowed"
               onClick={(e) => e.preventDefault()}
               aria-disabled="true"
             >
               Apply now
-            </Link>
+            </button>
           )}
         </div>
       </div>
@@ -78,12 +76,12 @@ const ApplyCoffeeChat = () => (
         Feel free to chat with any of us over email, coffee, lunch-we're happy to help!
       </p>
       <div className="flex md:flex-row xs:flex-col gap-3">
-        <Link href={config.coffeeChatLink} className="primary-button">
+        <a href={config.coffeeChatLink} className="primary-button">
           Coffee chat with us
-        </Link>
-        <Link href={config.coffeeChatFormLink} className="secondary-button !border-black">
+        </a>
+        <a href={config.coffeeChatFormLink} className="secondary-button !border-black">
           Don't know who to chat with?
-        </Link>
+        </a>
       </div>
     </div>
   </section>

--- a/new-dti-website/src/app/course/page.tsx
+++ b/new-dti-website/src/app/course/page.tsx
@@ -2,7 +2,7 @@
 
 // *IMPORTS
 import Image from 'next/image';
-import Link from 'next/link';
+
 import React, { useRef, useState } from 'react';
 
 // *IMPORT DATA
@@ -131,21 +131,21 @@ export default function Courses() {
                 </div>
 
                 <div className="flex flex-row gap-x-6 mt-6">
-                  <Link
+                  <a
                     key="Trends Application"
                     href={config.trendsApplicationLink}
                     className="primary-button"
                   >
                     Apply Now
-                  </Link>
-                  <Link
+                  </a>
+                  <a
                     key="Trends Website"
                     href={config.trendsWebsiteLink}
                     className="secondary-button secondary-button--red"
                     aria-label="Trends Website"
                   >
                     Learn More
-                  </Link>
+                  </a>
                 </div>
               </div>
             </div>

--- a/new-dti-website/src/app/initiatives/page.tsx
+++ b/new-dti-website/src/app/initiatives/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import RedBlob from '../../../components/blob';
 import InitiativeDisplay from '../../../components/initiatives/InitiativeDisplay';
 
@@ -57,9 +56,9 @@ const InitiativePage = () => (
         <p className="md:text-[22px] md:leading-[26px] xs:text-[12px] xs:leading-[14px]">
           Feel free to coordinate with us over email, coffee, lunch-we're excited to work with you.
         </p>
-        <Link href="mailto:hello@cornelldti.org" className="primary-button">
+        <a href="mailto:hello@cornelldti.org" className="primary-button">
           Get in touch
-        </Link>
+        </a>
       </div>
     </section>
   </div>

--- a/new-dti-website/src/app/products/page.tsx
+++ b/new-dti-website/src/app/products/page.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+
 import ImageCarousel from '../../../components/products/imageCarousel';
 import Connector from '../../../components/products/lines';
 import products from '../../../components/products/products.json';
@@ -99,9 +99,9 @@ export default function Page() {
             We've learned that tackling the hardest problems is the only way to truly create value
             for the people around us.
           </p>
-          <Link href="mailto:hello@cornelldti.org" className="primary-button">
+          <a href="mailto:hello@cornelldti.org" className="primary-button">
             Contact us
-          </Link>
+          </a>
         </div>
       </div>
     </div>
@@ -168,9 +168,9 @@ const ProductDisplay = (props: {
         <h3 className="text-3xl font-semibold">{props.product.name}</h3>
         <p>{props.product.description}</p>
         <div className="-translate-x-0.5 translate-y-10" hidden={props.product.link === ''}>
-          <Link href={props.product.link} className="primary-button">
+          <a href={props.product.link} className="primary-button">
             View Product
-          </Link>
+          </a>
         </div>
       </div>
     </div>

--- a/new-dti-website/src/app/sponsor/page.tsx
+++ b/new-dti-website/src/app/sponsor/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
+
 import impactData from '../../../components/sponsor/data/impacts.json';
 import companyData from '../../../components/sponsor/data/sponsors.json';
 import SponsorshipTable from '../../../components/sponsor/SponsorshipTable';
@@ -43,9 +43,9 @@ const SponsorHero = () => {
             building products and hosting initiatives to{' '}
             <span className="font-bold">help the Cornell and Ithaca communities.</span>
           </p>
-          <Link href={config.donationLink} className="primary-button">
+          <a href={config.donationLink} className="primary-button">
             Donate now
-          </Link>
+          </a>
         </div>
       </div>
       {width >= TABLET_BREAKPOINT && (
@@ -103,9 +103,9 @@ const SponsorPage = () => {
                 harness the power of technology to drive change in our communities.
               </span>
             </p>
-            <Link href="mailto:hello@cornelldti.org" className="primary-button">
+            <a href="mailto:hello@cornelldti.org" className="primary-button">
               Contact us
-            </Link>
+            </a>
           </div>
         </div>
       </div>
@@ -131,9 +131,9 @@ const SponsorPage = () => {
         <p className="lg:text-[22px] xs:text-lg text-center">
           Want to learn more about how you can help us make an impact?
         </p>
-        <Link className="primary-button" href="mailto:hello@cornelldti.org">
+        <a className="primary-button" href="mailto:hello@cornelldti.org">
           Contact us
-        </Link>
+        </a>
       </div>
     </>
   );


### PR DESCRIPTION
### Summary <!-- Required -->
Per https://github.com/vercel/next.js/issues/50686, it seems like `next/link` causes a bug where navigating using the back and forward buttons leads to JavaScript bundles being downloaded mysteriously. I haven't gotten a clear answer as to why online, but it seems that removing them and switching out with the native `<a><a/>` tags removes that problem.

Let's remove all instances of `next/link` for now. If we find a proper way to incorporate them we can always add them back.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Repro steps:

On a prior deploy:
1. Start at home page
2. Click on products page
3. Click on DTI Logo to go back to home page
4. repeat 2 and 3 at least 5 times
5. Now hit the back button until you hit a prompt to download a file

On this deploy preview, repeat the same steps, observe that the bug no longer occurs.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

