### PR TITLE
New Website: Preserve Whitespace in About Section

### DIFF
--- a/new-dti-website/components/team/MemberGroup.tsx
+++ b/new-dti-website/components/team/MemberGroup.tsx
@@ -139,7 +139,9 @@ export const MemberDetails: React.FC<MemberDetailsProps> = (props: MemberDetails
           </div>
           <div className="flex flex-col gap-2">
             <h2 className="font-semibold md:text-xl xs:text-base">About</h2>
-            <p className="md:text-lg xs:text-sm">{props.about || 'An amazing member of DTI.'}</p>
+            <p className="md:text-lg xs:text-sm whitespace-pre-wrap">
+              {props.about || 'An amazing member of DTI.'}
+            </p>
           </div>
           <div className="flex justify-around">
             <div className="flex flex-col gap-2 md:w-1/3 xs:w-1/2">


### PR DESCRIPTION
### Summary <!-- Required -->
Quick PR. Preserve whitespace (newlines) in about section.

### Notion/Figma Link <!-- Optional -->


### Test Plan <!-- Required -->
Before:
![image](https://github.com/user-attachments/assets/5b8eaedc-90ac-408c-a008-ff59d8fd9b26)

<img width="770" alt="Screenshot 2024-12-06 at 10 50 51 PM" src="https://github.com/user-attachments/assets/7a7f4066-c6cb-479a-a404-d0091c8bae5e">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

