### PR TITLE
Home page: used same label styles for text containers

### DIFF
--- a/new-dti-website/components/bottom.tsx
+++ b/new-dti-website/components/bottom.tsx
@@ -37,7 +37,9 @@ const Bottom: React.FC = () => (
       </div>
       <div className="text-left w-full md:self-center max-w-[520px] relative z-10">
         <div className="flex flex-col gap-y-1 pb-3 md:gap-y-2">
-          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">Courses</p>
+          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">
+            Courses
+          </p>
           <h2 className="text-lg font-semibold md:text-xl lg:text-[32px]">
             Teaching the Cornell Community
           </h2>
@@ -114,7 +116,9 @@ const Bottom: React.FC = () => (
       <div className="text-left w-full md:py-10">
         <div className="flex flex-col gap-y-3 md:gap-y-4">
           <div className="flex flex-col gap-y-1 md:gap-y-2">
-          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">Outreach</p>
+            <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">
+              Outreach
+            </p>
             <h2 className="text-lg font-semibold md:text-xl lg:text-[32px]">
               Expanding reach to our community
             </h2>
@@ -143,7 +147,9 @@ const Bottom: React.FC = () => (
       />
       <div className="text-left w-full flex flex-col gap-y-3 md:self-center md:gap-y-5 ">
         <div className="flex flex-col gap-y-1 md:gap-y-2">
-        <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">Team</p>
+          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">
+            Team
+          </p>
           <h3 className="text-lg font-semibold md:text-xl lg:text-[32px]">We're a family</h3>
         </div>
         <p className="md:text-xs lg:text-lg">

--- a/new-dti-website/components/bottom.tsx
+++ b/new-dti-website/components/bottom.tsx
@@ -37,7 +37,7 @@ const Bottom: React.FC = () => (
       </div>
       <div className="text-left w-full md:self-center max-w-[520px] relative z-10">
         <div className="flex flex-col gap-y-1 pb-3 md:gap-y-2">
-          <p className="text-neutral-200 text-xs font-bold lg:text-lg">Courses</p>
+          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">Courses</p>
           <h2 className="text-lg font-semibold md:text-xl lg:text-[32px]">
             Teaching the Cornell Community
           </h2>
@@ -114,7 +114,7 @@ const Bottom: React.FC = () => (
       <div className="text-left w-full md:py-10">
         <div className="flex flex-col gap-y-3 md:gap-y-4">
           <div className="flex flex-col gap-y-1 md:gap-y-2">
-            <p className="text-neutral-200 text-xs font-bold lg:text-lg">Outreach</p>
+          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">Outreach</p>
             <h2 className="text-lg font-semibold md:text-xl lg:text-[32px]">
               Expanding reach to our community
             </h2>
@@ -143,7 +143,7 @@ const Bottom: React.FC = () => (
       />
       <div className="text-left w-full flex flex-col gap-y-3 md:self-center md:gap-y-5 ">
         <div className="flex flex-col gap-y-1 md:gap-y-2">
-          <p className="text-neutral-200 text-xs font-bold lg:text-lg">Team</p>
+        <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium lg:text-lg">Team</p>
           <h3 className="text-lg font-semibold md:text-xl lg:text-[32px]">We're a family</h3>
         </div>
         <p className="md:text-xs lg:text-lg">

--- a/new-dti-website/src/app/course/page.tsx
+++ b/new-dti-website/src/app/course/page.tsx
@@ -114,7 +114,7 @@ export default function Courses() {
               </div>
 
               <div className="flex flex-col lg:w-1/2">
-                <div className="font-semibold text-sm md:text-xl uppercase text-[16px] tracking-[1px] text-[#666]">
+                <div className="font-semibold text-sm md:text-xl uppercase !text-[18px] tracking-[1px] text-[#666]">
                   Modern industry-leading technology
                 </div>
 


### PR DESCRIPTION
fixes [this](https://www.notion.so/Idol-Lead-Sync-781de97ad403492b94b420349f829ea5?pvs=4#1550ad723ce18072bf79d0d4ac1a9705)


|Before|After|
|-|-|
|<img width="1649" alt="Screenshot 2024-12-07 at 5 36 04 PM" src="https://github.com/user-attachments/assets/b023ee3e-0aaa-414d-9f8a-2956f4c31367">|<img width="1649" alt="Screenshot 2024-12-07 at 5 35 51 PM" src="https://github.com/user-attachments/assets/d72731ff-cd49-4a54-a8c9-e57ad2c55fc9">|
