### PR TITLE
Apply page: FAQ section styling

### DIFF
--- a/new-dti-website/components/apply/ApplyFAQ.tsx
+++ b/new-dti-website/components/apply/ApplyFAQ.tsx
@@ -10,7 +10,7 @@ type FAQAccordionProps = {
 };
 
 const FAQAccordion = ({ header, children }: FAQAccordionProps) => (
-  <details className="border-transparent border-b-black border-2 cursor-pointer">
+  <details className="border-transparent border-b-[#d5d5d5] border-2 cursor-pointer hover:border-b-[#000000]">
     <summary className="section-subheading">{header}</summary>
     <div className="md:py-5 xs:py-3">{children}</div>
   </details>


### PR DESCRIPTION
fixes [this](https://www.notion.so/Idol-Lead-Sync-781de97ad403492b94b420349f829ea5?pvs=4#1550ad723ce18091ae12e6dcb40809d9)

- made border gray 
- but on hover it becomes black


|State|Before|After|
|-|-|-|
|Default|<img width="1649" alt="Screenshot 2024-12-07 at 6 24 06 PM" src="https://github.com/user-attachments/assets/92140e43-16e4-40a0-8c60-ad306b7bbe77">|<img width="1649" alt="Screenshot 2024-12-07 at 6 23 51 PM" src="https://github.com/user-attachments/assets/3193adb7-f0e5-451c-80e4-b69d4e803e12">|
|Hover|<img width="1649" alt="Screenshot 2024-12-07 at 6 24 12 PM" src="https://github.com/user-attachments/assets/bd35c7d0-99d6-4f4d-9781-e1fad1478a3a">|<img width="1649" alt="Screenshot 2024-12-07 at 6 23 55 PM" src="https://github.com/user-attachments/assets/fe121210-fa99-407e-b926-eb88dce62f89">|
