### PR TITLE
Apply page: secondary btn styling

### DIFF
--- a/new-dti-website/src/app/apply/page.tsx
+++ b/new-dti-website/src/app/apply/page.tsx
@@ -79,7 +79,7 @@ const ApplyCoffeeChat = () => (
         <a href={config.coffeeChatLink} className="primary-button">
           Coffee chat with us
         </a>
-        <a href={config.coffeeChatFormLink} className="secondary-button !border-black">
+        <a href={config.coffeeChatFormLink} className="secondary-button secondary-button--red">
           Don't know who to chat with?
         </a>
       </div>


### PR DESCRIPTION
fixes [this ](https://www.notion.so/Idol-Lead-Sync-781de97ad403492b94b420349f829ea5?pvs=4#1550ad723ce1805bab14fb021c01d950)


|Before|After|
|-|-|
|<img width="1469" alt="Screenshot 2024-12-07 at 6 27 18 PM" src="https://github.com/user-attachments/assets/73a4b6b5-9bb5-4220-8bed-46de201df676">|<img width="1469" alt="Screenshot 2024-12-07 at 6 27 29 PM" src="https://github.com/user-attachments/assets/3606b8ba-5de3-4d76-80f2-c742736a1e51">|
