### PR TITLE
Parenthesis Around Netid and Reseting Dropdown Value

### DIFF
--- a/frontend/src/components/Admin/CoffeeChats/CoffeeChats.tsx
+++ b/frontend/src/components/Admin/CoffeeChats/CoffeeChats.tsx
@@ -56,7 +56,7 @@ const CoffeeChats: React.FC = () => {
 
   const memberOptions = allMembers.map((member) => ({
     key: member.netid,
-    text: `${member.firstName} ${member.lastName} ${member.netid}`,
+    text: `${member.firstName} ${member.lastName} (${member.netid})`,
     value: member.netid
   }));
 
@@ -127,11 +127,11 @@ const CoffeeChats: React.FC = () => {
               placeholder={'View Member Bingo Board'}
               fluid
               selection
-              value={selectedMember ? selectedMember.netid : undefined}
+              value={selectedMember ? selectedMember.netid : 'View Member Bingo Board'}
               options={memberOptions}
               search
               onChange={(_, data) => {
-                const selectedId = data.value as string | null;
+                const selectedId = data.value as string | undefined;
                 const selected = allMembers.find((member) => member.netid === selectedId) || null;
                 setSelectedMember(selected);
                 if (selected != null) handleMemberClick(selected);

--- a/frontend/src/components/Admin/CoffeeChats/CoffeeChats.tsx
+++ b/frontend/src/components/Admin/CoffeeChats/CoffeeChats.tsx
@@ -17,6 +17,7 @@ const CoffeeChats: React.FC = () => {
   const [isChatLoading, setIsChatLoading] = useState<boolean>(true);
   const [selectedMember, setSelectedMember] = useState<IdolMember | null>(null);
 
+  const DEAFAULT_MEMBER_DROPDOWN_TEXT: string = 'View Member Bingo Board';
   const allMembers = useMembers();
 
   const chatCount = useMemo(
@@ -124,10 +125,10 @@ const CoffeeChats: React.FC = () => {
           </Button>
           <div className={styles.dropdownButton}>
             <Dropdown
-              placeholder={'View Member Bingo Board'}
+              placeholder={DEAFAULT_MEMBER_DROPDOWN_TEXT}
               fluid
               selection
-              value={selectedMember ? selectedMember.netid : 'View Member Bingo Board'}
+              value={selectedMember ? selectedMember.netid : DEAFAULT_MEMBER_DROPDOWN_TEXT}
               options={memberOptions}
               search
               onChange={(_, data) => {


### PR DESCRIPTION
### Summary <!-- Required -->

Added parenthesis around netid and made sure dropdown resets properly when going between specific member's bingo board and reviewing all coffee chats. 

### Test Plan <!-- Required -->

https://github.com/user-attachments/assets/b16b4f03-75fa-4c2d-86d0-5be27559409f

