### PR TITLE
added hover state to footer social icons

### DIFF
--- a/new-dti-website/components/footer.tsx
+++ b/new-dti-website/components/footer.tsx
@@ -66,7 +66,7 @@ const Footer: React.FC<FooterProps> = ({ theme }) => (
             href={icon.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="w-9 h-9 relative"
+            className="w-9 h-9 relative hover:opacity-60"
           >
             <Image
               className={`${theme === 'dark' ? 'invert-0' : 'invert'} w-full h-full`}


### PR DESCRIPTION
[notion ](https://www.notion.so/Idol-Lead-Sync-781de97ad403492b94b420349f829ea5?pvs=4)


|Before|After|
|-|-|
|<img width="905" alt="Screenshot 2024-12-22 at 6 29 49 PM" src="https://github.com/user-attachments/assets/a5a544ed-2719-4697-9b8a-b6c4a78996d8" />|<img width="905" alt="Screenshot 2024-12-22 at 6 29 25 PM" src="https://github.com/user-attachments/assets/7713433a-af0b-4307-9ee9-5c4ba036d3c5" />|
