### PR TITLE
Add Retiring Leads to Alumni Section

### DIFF
--- a/new-dti-website/components/team/data/alumni.json
+++ b/new-dti-website/components/team/data/alumni.json
@@ -357,5 +357,109 @@
     "subteams": ["cornellgo"],
     "roleDescription": "Technical PM",
     "email": "nk495@cornell.edu"
+  },
+  {
+    "formerSubteams": [],
+    "email": "sz266@cornell.edu",
+    "lastName": "Zhao",
+    "roleDescription": "Full Team Lead",
+    "role": "ops-lead",
+    "subteams": [
+      "leads"
+    ],
+    "firstName": "Sophie",
+    "graduation": "May 2025",
+    "netid": "sz266",
+    "semesterJoined": "Fall 2021",
+    "college": "eng",
+    "github": null,
+    "hometown": "Vancouver, Canada",
+    "website": null,
+    "minor": "CS",
+    "major": "ORIE",
+    "doubleMajor": null,
+    "coffeeChatLink": null,
+    "about": "Hello! I'm a senior in ORIE, previously the Community and Initiatives Lead then Full-Team Lead on DTI. My career experiences are in data analytics and modeling, and I also love music outside of academics. Feel free to reach out and chat about anything :)",
+    "pronouns": "she/her",
+    "linkedin": "https://www.linkedin.com/in/sophiezhao219/"
+  },
+
+{
+    "roleDescription": "Developer Lead",
+    "major": "Computer Science",
+    "email": "tpp38@cornell.edu",
+    "doubleMajor": null,
+    "lastName": "Pham",
+    "about": "I'm a Computer Science majored kid who is interested in Music, Cooking, and Novel! Come to talk with me for cooking recipes or just chilling around the campus.",
+    "role": "dev-lead",
+    "graduation": "May 2025",
+    "github ": "",
+    "hometown": "Ho Chi Minh, Vietnam",
+    "subteams": [
+      "leads"
+    ],
+    "formerSubteams": [
+      "cuapts"
+    ],
+    "firstName": "Sophia",
+    "minor": "Entrepreneur",
+    "github": "https://github.com/thuypham03",
+    "linkedin": "https://www.linkedin.com/in/thuypham03/",
+    "pronouns": "She/her",
+    "website": null,
+    "netid": "tpp38",
+    "semesterJoined": "Fall 2021"
+  },
+{
+    "formerSubteams": [],
+    "subteams": [
+      "leads",
+      "cuapts"
+    ],
+    "about": "Hey, I'm Ella! I'm a junior studying Computer Science in the College of Engineering and minoring in Business. I joined DTI Fall 2023 as a sophomore, and started out as the APM of CUApts. I was then the PM of CUApts for all of 2024, and Product Lead in Fall 2024. \n\nI'm interested in SWE and Product Engineering in my career, but am always eager to talk about DTI PM. I'm also always down to chat about dance, baking/cooking, books, music, theater, Cornell fun facts, or anything else! \n\nPlease reach out if you want to coffee chat (though I may be in Italy eating pizza by now...)",
+    "hometown": "Brooklyn, NY",
+    "firstName": "Ella",
+    "roleDescription": "Product Lead",
+    "college": "eng",
+    "role": "product-lead",
+    "website": null,
+    "major": "Computer Science",
+    "email": "egk46@cornell.edu",
+    "lastName": "Krechmer",
+    "netid": "egk46",
+    "doubleMajor": null,
+    "minor": "Business",
+    "github": "https://github.com/ellakrechmer",
+    "graduation": "May 2026",
+    "semesterJoined": "Fall 2023",
+    "coffeeChatLink": null,
+    "pronouns": "she/her",
+    "linkedin": "https://www.linkedin.com/in/ella-krechmer-a9360923a/"
+  },
+
+{
+    "major": "",
+    "firstName": "Brandon",
+    "lastName": "Lee",
+    "roleDescription": "Design Lead",
+    "netid": "bl628",
+    "email": "bl628@cornell.edu",
+    "linkedin": "",
+    "website": "",
+    "formerSubteams": [
+      "queuemein"
+    ],
+    "pronouns": "",
+    "about": "",
+    "github": "",
+    "role": "design-lead",
+    "minor": "",
+    "doubleMajor": "",
+    "hometown": "",
+    "subteams": [
+      "leads"
+    ],
+    "graduation": "May 2026",
+    "semesterJoined": "Spring 2023"
   }
 ]


### PR DESCRIPTION
### Summary <!-- Required -->
Add Sophie Zhao, Sophia Pham, Ella Krechmer, Brandon Lee to alumni section (they've been removed from IDOL and the team section already).

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<img width="604" alt="Screenshot 2024-12-23 at 9 41 19 AM" src="https://github.com/user-attachments/assets/621a0080-8aa6-4be0-822f-26453b547c77" />


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

