### PR TITLE
fix candidate decider google docs links, other improvements requested from leads

### DIFF
--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -30,21 +30,41 @@ const ApplicantCredentials: React.FC<Props> = ({
     <p>{email}</p>
     <p>Class of {gradYear}</p>
     <div className={styles.iconsContainer}>
-      <a className={styles.icon} href={formatLink(resumeURL)}>
+      <a
+        className={styles.icon}
+        href={formatLink(resumeURL)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <FileIcon />
       </a>
       {githubURL && (
-        <a className={styles.icon} href={formatLink(githubURL, 'github')}>
+        <a
+          className={styles.icon}
+          href={formatLink(githubURL)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <GithubIcon />
         </a>
       )}
       {linkedinURL && (
-        <a className={styles.icon} href={formatLink(linkedinURL, 'linkedin')}>
+        <a
+          className={styles.icon}
+          href={formatLink(linkedinURL, 'linkedin')}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <LinkedinIcon />
         </a>
       )}
       {portfolioURL && (
-        <a className={styles.icon} href={formatLink(portfolioURL)}>
+        <a
+          className={styles.icon}
+          href={formatLink(portfolioURL)}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <GlobeIcon />
         </a>
       )}

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -172,7 +172,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
             options={instance.candidates.map((candidate) => ({
               value: candidate.id,
               key: candidate.id,
-              text: candidate.id
+              text: candidate.id + 1 // offset by 1 to account for 0-indexed array
             }))}
             onChange={(_, data) => {
               handleCandidateChange(data.value as number);

--- a/frontend/src/components/Candidate-Decider/SearchBar.tsx
+++ b/frontend/src/components/Candidate-Decider/SearchBar.tsx
@@ -22,7 +22,8 @@ const SearchBar: React.FC<Props> = ({ instance, setCurrentCandidate, currentCand
         options={instance.candidates.map((candidate) => ({
           value: candidate.id,
           key: candidate.id,
-          text: `${candidate.id} - ${
+          text: `${candidate.id + 1} - ${
+            // offset by 1 to account for 0-indexed array
             candidate.responses[firstNameIndex] !== '#N/A' &&
             candidate.responses[lastNameIndex] !== '#N/A'
               ? `${candidate.responses[firstNameIndex]} ${candidate.responses[lastNameIndex]} (${candidate.responses[netIDIndex]})`

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -43,7 +43,7 @@ describe('formatLink', () => {
 
   test('Extracts non-specific links correctly', () => {
     expect(formatLink('Look at my awesome website https://en.wikipedia.org/wiki/Cat!!')).toEqual(
-      'https://en.wikipedia.org/wiki/cat'
+      'https://en.wikipedia.org/wiki/Cat'
     );
   });
 });

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -171,10 +171,7 @@ export const formatLink = (link: string, linkType?: LinkType): string | undefine
     return undefined;
   }
 
-  const extractedLink = matches[0]
-    .trim()
-    .replace(/[.,)]+$/, '') // removes any trailing punctuation
-    .toLowerCase();
+  const extractedLink = matches[0].trim().replace(/[.,)]+$/, ''); // removes any trailing punctuation
 
   if (!extractedLink.startsWith('https://') && !extractedLink.startsWith('http://')) {
     return `https://${extractedLink}`;


### PR DESCRIPTION
### Summary <!-- Required -->

After setting up the candidate decider instance for SP25 I noticed that all the resumes were inaccessible due to a broken URL. After some testing, it looks like Google docs links are case sensitive, hence this small PR.

I've also included some small changes that were requested last semester by leads:
- 1-indexed dropdowns on the candidate search bar and candidate ID selector
- github, linkedin, resume, and portfolio links now open in a new tab 

### Notion/Figma Link <!-- Optional -->
N/A
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Testing was done manually to:
- ensure that parsed resume URLs now work properly
- check that other credential headers that contain URLs still work
- verify that the correct applicants are still rated despite new 1-indexed display text

### Notes <!-- Optional -->
