### PR TITLE
IDOL: Interview Scheduler

### DIFF
--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -6,6 +6,12 @@ import PermissionsManager from '../utils/permissionsManager';
 const interviewSchedulerDao = new InterviewSchedulerDao();
 const interviewSlotDao = new InterviewSlotDao();
 
+const censoredApplicant: Applicant = {
+  email: '',
+  firstName: '',
+  lastName: ''
+};
+
 export const getAllApplicants = async (): Promise<string[]> => {
   const instances = await interviewSchedulerDao.getAllInstances();
   const applicants = new Set<string>();
@@ -110,25 +116,14 @@ export const getInterviewSlots = async (
   if (isApplicant) {
     return slots.map((slot) => ({
       ...slot,
-      lead: {
-        netid: '',
-        email: '',
-        firstName: '',
-        lastName: '',
-        pronouns: '',
-        semesterJoined: '',
-        graduation: '',
-        major: '',
-        hometown: '',
-        about: '',
-        subteams: [],
-        role: 'ops-lead',
-        roleDescription: 'Full Team Lead'
-      },
-      members: [],
-      applicant: slot.applicant === email ? email : ''
+      lead: null,
+      members: slot.members.map((_) => null),
+      applicant:
+        slot.applicant === null || slot.applicant.email === email
+          ? slot.applicant
+          : censoredApplicant
     }));
   }
-  
+
   return slots;
 };

--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -148,7 +148,8 @@ export const updateInterviewSlot = async (
 
   if (
     isApplicant &&
-    (!scheduler.applicants.some((applicant) => applicant.email === email) || // Applicants should be an applicant of the scheduler instance
+    (!scheduler.isOpen ||
+      !scheduler.applicants.some((applicant) => applicant.email === email) || // Applicants should be an applicant of the scheduler instance
       (slot.applicant && slot.applicant.email !== email) || // Applicants may not edit an occupied slot
       (edits.applicant && edits.applicant.email !== email)) // Applicants may not sign up or cancel other applicants
   )

--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -1,10 +1,9 @@
 import InterviewSchedulerDao from '../dao/InterviewSchedulerDao';
-import { PermissionError } from '../utils/errors';
+import { NotFoundError, PermissionError } from '../utils/errors';
 import PermissionsManager from '../utils/permissionsManager';
 
 const interviewSchedulerDao = new InterviewSchedulerDao();
 
-// eslint-disable-next-line import/prefer-default-export
 export const getAllApplicants = async (): Promise<string[]> => {
   const instances = await interviewSchedulerDao.getAllInstances();
   const applicants = new Set<string>();
@@ -22,4 +21,79 @@ export const createInterviewScheduler = async (
     );
 
   return interviewSchedulerDao.createInstance(instance);
+};
+
+export const getAllInterviewSchedulerInstances = async (
+  email: string,
+  isApplicant: boolean
+): Promise<InterviewScheduler[]> => {
+  const instances = await interviewSchedulerDao.getAllInstances();
+
+  if (!isApplicant) {
+    return instances;
+  }
+
+  const filteredInstances = instances
+    .filter((instance) => instance.applicants.some((applicant) => applicant.email === email))
+    .map((instance) => ({
+      ...instance,
+      applicants: []
+    }));
+  return filteredInstances;
+};
+
+export const getInterviewSchedulerInstance = async (
+  uuid: string,
+  email: string,
+  isApplicant: boolean
+): Promise<InterviewScheduler> => {
+  const instance = await interviewSchedulerDao.getInstance(uuid);
+
+  if (!instance)
+    throw new NotFoundError(`Interview scheduler instance with uuid ${uuid} does not exist!`);
+
+  if (isApplicant) {
+    if (instance.applicants.some((applicant) => applicant.email === email)) {
+      return { ...instance, applicants: [] };
+    }
+    throw new PermissionError('User does not have permission to get interview scheduler instance');
+  }
+
+  return instance;
+};
+
+export const updateInterviewSchedulerInstance = async (
+  user: IdolMember,
+  updates: InterviewSchedulerEdit
+): Promise<InterviewScheduler> => {
+  if (!PermissionsManager.isLeadOrAdmin(user))
+    throw new PermissionError(
+      'User does not have permission to update interview scheduler instance.'
+    );
+
+  const instance = await interviewSchedulerDao.getInstance(updates.uuid);
+
+  if (!instance)
+    throw new NotFoundError(
+      `Interview scheduler instance with uuid ${updates.uuid} does not exist!`
+    );
+
+  const newInstance: InterviewScheduler = {
+    ...instance,
+    ...updates
+  };
+
+  return interviewSchedulerDao.updateInstance(newInstance);
+};
+
+export const deleteInterviewSchedulerInstance = async (
+  uuid: string,
+  user: IdolMember
+): Promise<void> => {
+  if (!PermissionsManager.isLeadOrAdmin(user))
+    throw new PermissionError(
+      'User does not have permission to update interview scheduler instance.'
+    );
+
+  return interviewSchedulerDao.deleteInstance(uuid);
 };

--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -10,7 +10,8 @@ const interviewSlotDao = new InterviewSlotDao();
 const censoredApplicant: Applicant = {
   email: '',
   firstName: '',
-  lastName: ''
+  lastName: '',
+  netid: ''
 };
 
 export const getAllApplicants = async (): Promise<string[]> => {
@@ -137,7 +138,7 @@ export const updateInterviewSlot = async (
   const slot = await interviewSlotDao.getSlot(edits.uuid);
 
   if (!slot) throw new NotFoundError(`Interview slot with uuid ${edits.uuid} does not exist!`);
-  const scheduler = await getInterviewSchedulerInstance(edits.uuid, email, isApplicant);
+  const scheduler = await getInterviewSchedulerInstance(edits.interviewSchedulerUuid, email, isApplicant);
 
   if (
     isApplicant &&

--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -105,6 +105,8 @@ export const deleteInterviewSchedulerInstance = async (
       'User does not have permission to update interview scheduler instance.'
     );
 
+  const slots = await getInterviewSlots(uuid, user.email, false);
+  await Promise.all(slots.map((slot) => interviewSlotDao.deleteSlot(slot.uuid)));
   return interviewSchedulerDao.deleteInstance(uuid);
 };
 

--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -1,8 +1,10 @@
 import InterviewSchedulerDao from '../dao/InterviewSchedulerDao';
+import InterviewSlotDao from '../dao/InterviewSlotDao';
 import { NotFoundError, PermissionError } from '../utils/errors';
 import PermissionsManager from '../utils/permissionsManager';
 
 const interviewSchedulerDao = new InterviewSchedulerDao();
+const interviewSlotDao = new InterviewSlotDao();
 
 export const getAllApplicants = async (): Promise<string[]> => {
   const instances = await interviewSchedulerDao.getAllInstances();
@@ -96,4 +98,37 @@ export const deleteInterviewSchedulerInstance = async (
     );
 
   return interviewSchedulerDao.deleteInstance(uuid);
+};
+
+export const getInterviewSlots = async (
+  uuid: string,
+  email: string,
+  isApplicant: boolean
+): Promise<InterviewSlot[]> => {
+  const slots = await interviewSlotDao.getSlotsForScheduler(uuid);
+
+  if (isApplicant) {
+    return slots.map((slot) => ({
+      ...slot,
+      lead: {
+        netid: '',
+        email: '',
+        firstName: '',
+        lastName: '',
+        pronouns: '',
+        semesterJoined: '',
+        graduation: '',
+        major: '',
+        hometown: '',
+        about: '',
+        subteams: [],
+        role: 'ops-lead',
+        roleDescription: 'Full Team Lead'
+      },
+      members: [],
+      applicant: slot.applicant === email ? email : ''
+    }));
+  }
+  
+  return slots;
 };

--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -1,4 +1,6 @@
 import InterviewSchedulerDao from '../dao/InterviewSchedulerDao';
+import { PermissionError } from '../utils/errors';
+import PermissionsManager from '../utils/permissionsManager';
 
 const interviewSchedulerDao = new InterviewSchedulerDao();
 
@@ -6,8 +8,18 @@ const interviewSchedulerDao = new InterviewSchedulerDao();
 export const getAllApplicants = async (): Promise<string[]> => {
   const instances = await interviewSchedulerDao.getAllInstances();
   const applicants = new Set<string>();
-  instances
-    .filter((inst) => !inst.isArchived)
-    .forEach((inst) => inst.applicants.forEach((app) => applicants.add(app)));
+  instances.forEach((inst) => inst.applicants.forEach((app) => applicants.add(app.email)));
   return Array.from(applicants);
+};
+
+export const createInterviewScheduler = async (
+  instance: InterviewScheduler,
+  user: IdolMember
+): Promise<string> => {
+  if (!(await PermissionsManager.isAdmin(user)))
+    throw new PermissionError(
+      'User does not have permission to create new Candidate Decider instances.'
+    );
+
+  return interviewSchedulerDao.createInstance(instance);
 };

--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -138,7 +138,11 @@ export const updateInterviewSlot = async (
   const slot = await interviewSlotDao.getSlot(edits.uuid);
 
   if (!slot) throw new NotFoundError(`Interview slot with uuid ${edits.uuid} does not exist!`);
-  const scheduler = await getInterviewSchedulerInstance(edits.interviewSchedulerUuid, email, isApplicant);
+  const scheduler = await getInterviewSchedulerInstance(
+    edits.interviewSchedulerUuid,
+    email,
+    isApplicant
+  );
 
   if (
     isApplicant &&
@@ -163,7 +167,17 @@ export const updateInterviewSlot = async (
 
 export const deleteInterviewSlot = async (uuid: string, user: IdolMember): Promise<void> => {
   if (!PermissionsManager.isLeadOrAdmin(user))
-    throw new PermissionError('User does not have permission to update interview slot.');
+    throw new PermissionError('User does not have permission to update interview slots.');
 
   return interviewSlotDao.deleteSlot(uuid);
+};
+
+export const addInterviewSlots = async (
+  slots: InterviewSlot[],
+  user: IdolMember
+): Promise<InterviewSlot[]> => {
+  if (!PermissionsManager.isLeadOrAdmin(user))
+    throw new PermissionError('User does not have permission to create interview slots.');
+
+  return interviewSlotDao.addSlots(slots);
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -561,7 +561,7 @@ loginCheckedGet('/interview-slots/:uuid', async (req, user) => ({
   slots: await getInterviewSlots(req.params.uuid, user.email, false)
 }));
 
-loginCheckedPost('/interview-slots/:uuid', async (req, user) => ({
+loginCheckedPost('/interview-slots', async (req, user) => ({
   slots: await addInterviewSlots(req.body.slots, user)
 }));
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -99,6 +99,8 @@ import {
   deleteInterviewSchedulerInstance,
   getAllApplicants,
   getAllInterviewSchedulerInstances,
+  getInterviewSchedulerInstance,
+  getInterviewSlots,
   updateInterviewSchedulerInstance
 } from './API/interviewSchedulerAPI';
 
@@ -511,8 +513,30 @@ router.get(`/interview-scheduler/applicant`, async (req, res) => {
   });
 });
 
+router.get(`/interview-scheduler/applicant/:uuid`, async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    instance: await getInterviewSchedulerInstance(req.params.uuid, userEmail ?? '', true)
+  });
+});
+
+router.get('/interview-scheduler/applicant/:uuid/slots', async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    slots: await getInterviewSlots(req.params.uuid, userEmail ?? '', true)
+  });
+});
+
 loginCheckedGet('/interview-scheduler', async (req, user) => ({
   instances: await getAllInterviewSchedulerInstances(user.email, false)
+}));
+
+loginCheckedGet('/interview-scheduler/:uuid', async (req, user) => ({
+  instance: await getInterviewSchedulerInstance(req.params.uuid, user.email, false)
+}));
+
+loginCheckedGet('/interview-scheduler/:uuid/slots', async (req, user) => ({
+  slots: await getInterviewSlots(req.params.uuid, user.email, false)
 }));
 
 loginCheckedPost('/interview-scheduler', async (req, user) => ({

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -97,11 +97,13 @@ import { sendMail } from './API/mailAPI';
 import {
   createInterviewScheduler,
   deleteInterviewSchedulerInstance,
+  deleteInterviewSlot,
   getAllApplicants,
   getAllInterviewSchedulerInstances,
   getInterviewSchedulerInstance,
   getInterviewSlots,
-  updateInterviewSchedulerInstance
+  updateInterviewSchedulerInstance,
+  updateInterviewSlot
 } from './API/interviewSchedulerAPI';
 
 // Constants and configurations
@@ -520,13 +522,6 @@ router.get(`/interview-scheduler/applicant/:uuid`, async (req, res) => {
   });
 });
 
-router.get('/interview-scheduler/applicant/:uuid/slots', async (req, res) => {
-  const userEmail = await getUserEmailFromRequest(req);
-  res.status(200).send({
-    slots: await getInterviewSlots(req.params.uuid, userEmail ?? '', true)
-  });
-});
-
 loginCheckedGet('/interview-scheduler', async (req, user) => ({
   instances: await getAllInterviewSchedulerInstances(user.email, false)
 }));
@@ -535,20 +530,42 @@ loginCheckedGet('/interview-scheduler/:uuid', async (req, user) => ({
   instance: await getInterviewSchedulerInstance(req.params.uuid, user.email, false)
 }));
 
-loginCheckedGet('/interview-scheduler/:uuid/slots', async (req, user) => ({
-  slots: await getInterviewSlots(req.params.uuid, user.email, false)
-}));
-
 loginCheckedPost('/interview-scheduler', async (req, user) => ({
   uuid: await createInterviewScheduler(req.body, user)
 }));
 
-loginCheckedPut('/interview-scheduler/:uuid', async (req, user) => ({
+loginCheckedPut('/interview-scheduler', async (req, user) => ({
   instance: await updateInterviewSchedulerInstance(user, req.body)
 }));
 
 loginCheckedDelete('/interview-scheduler/:uuid', async (req, user) =>
   deleteInterviewSchedulerInstance(req.params.uuid, user).then(() => ({}))
+);
+
+router.get('/interview-slots/applicant/:uuid', async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    slots: await getInterviewSlots(req.params.uuid, userEmail ?? '', true)
+  });
+});
+
+router.put('/interview-slot/applicant', async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    success: await updateInterviewSlot(req.body, userEmail ?? '', true)
+  });
+});
+
+loginCheckedGet('/interview-slots/:uuid', async (req, user) => ({
+  slots: await getInterviewSlots(req.params.uuid, user.email, false)
+}));
+
+loginCheckedPut('/interview-slots', async (req, user) => ({
+  success: await updateInterviewSlot(req.body, user.email, false)
+}));
+
+loginCheckedDelete('/interview-slots/:uuid', async (req, user) =>
+  deleteInterviewSlot(req.params.uuid, user).then(() => ({}))
 );
 
 app.use('/.netlify/functions/api', router);

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -95,6 +95,7 @@ import DPSubmissionRequestLogDao from './dao/DPSubmissionRequestLogDao';
 import AdminsDao from './dao/AdminsDao';
 import { sendMail } from './API/mailAPI';
 import {
+  addInterviewSlots,
   createInterviewScheduler,
   deleteInterviewSchedulerInstance,
   deleteInterviewSlot,
@@ -558,6 +559,10 @@ router.put('/interview-slot/applicant', async (req, res) => {
 
 loginCheckedGet('/interview-slots/:uuid', async (req, user) => ({
   slots: await getInterviewSlots(req.params.uuid, user.email, false)
+}));
+
+loginCheckedPost('/interview-slots/:uuid', async (req, user) => ({
+  slots: await addInterviewSlots(req.body.slots, user)
 }));
 
 loginCheckedPut('/interview-slots', async (req, user) => ({

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -94,7 +94,13 @@ import { getWriteSignedURL, getReadSignedURL, deleteImage } from './API/imageAPI
 import DPSubmissionRequestLogDao from './dao/DPSubmissionRequestLogDao';
 import AdminsDao from './dao/AdminsDao';
 import { sendMail } from './API/mailAPI';
-import { createInterviewScheduler, getAllApplicants } from './API/interviewSchedulerAPI';
+import {
+  createInterviewScheduler,
+  deleteInterviewSchedulerInstance,
+  getAllApplicants,
+  getAllInterviewSchedulerInstances,
+  updateInterviewSchedulerInstance
+} from './API/interviewSchedulerAPI';
 
 // Constants and configurations
 const app = express();
@@ -498,9 +504,28 @@ loginCheckedPut('/dev-portfolio/:uuid/submission', async (req, user) => ({
 }));
 
 // Interview Scheduler
+router.get(`/interview-scheduler/applicant`, async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    instances: await getAllInterviewSchedulerInstances(userEmail ?? '', true)
+  });
+});
+
+loginCheckedGet('/interview-scheduler', async (req, user) => ({
+  instances: await getAllInterviewSchedulerInstances(user.email, false)
+}));
+
 loginCheckedPost('/interview-scheduler', async (req, user) => ({
   uuid: await createInterviewScheduler(req.body, user)
 }));
+
+loginCheckedPut('/interview-scheduler/:uuid', async (req, user) => ({
+  instance: await updateInterviewSchedulerInstance(user, req.body)
+}));
+
+loginCheckedDelete('/interview-scheduler/:uuid', async (req, user) =>
+  deleteInterviewSchedulerInstance(req.params.uuid, user).then(() => ({}))
+);
 
 app.use('/.netlify/functions/api', router);
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -94,7 +94,7 @@ import { getWriteSignedURL, getReadSignedURL, deleteImage } from './API/imageAPI
 import DPSubmissionRequestLogDao from './dao/DPSubmissionRequestLogDao';
 import AdminsDao from './dao/AdminsDao';
 import { sendMail } from './API/mailAPI';
-import { getAllApplicants } from './API/interviewSchedulerAPI';
+import { createInterviewScheduler, getAllApplicants } from './API/interviewSchedulerAPI';
 
 // Constants and configurations
 const app = express();
@@ -495,6 +495,11 @@ loginCheckedPut('/dev-portfolio/:uuid/submission/regrade', async (req, user) => 
 }));
 loginCheckedPut('/dev-portfolio/:uuid/submission', async (req, user) => ({
   portfolio: await updateSubmissions(req.params.uuid, req.body.updatedSubmissions, user)
+}));
+
+// Interview Scheduler
+loginCheckedPost('/interview-scheduler', async (req, user) => ({
+  uuid: await createInterviewScheduler(req.body, user)
 }));
 
 app.use('/.netlify/functions/api', router);

--- a/backend/src/dao/InterviewSchedulerDao.ts
+++ b/backend/src/dao/InterviewSchedulerDao.ts
@@ -15,9 +15,21 @@ export default class InterviewSchedulerDao extends BaseDao<InterviewScheduler, I
     return this.getDocuments();
   }
 
+  async getInstance(uuid: string): Promise<InterviewScheduler | null> {
+    return this.getDocument(uuid);
+  }
+
   async createInstance(instance: InterviewScheduler): Promise<string> {
     const uuid = uuidv4();
-    this.createDocument(uuid, instance);
+    this.createDocument(uuid, { ...instance, uuid });
     return uuid;
+  }
+
+  async updateInstance(instance: InterviewScheduler): Promise<InterviewScheduler> {
+    return this.updateDocument(instance.uuid, instance);
+  }
+
+  async deleteInstance(uuid: string): Promise<void> {
+    this.deleteDocument(uuid);
   }
 }

--- a/backend/src/dao/InterviewSchedulerDao.ts
+++ b/backend/src/dao/InterviewSchedulerDao.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import { interviewSchedulerCollection } from '../firebase';
 import BaseDao from './BaseDao';
 
@@ -12,5 +13,11 @@ export default class InterviewSchedulerDao extends BaseDao<InterviewScheduler, I
 
   async getAllInstances(): Promise<InterviewScheduler[]> {
     return this.getDocuments();
+  }
+
+  async createInstance(instance: InterviewScheduler): Promise<string> {
+    const uuid = uuidv4();
+    this.createDocument(uuid, instance);
+    return uuid;
   }
 }

--- a/backend/src/dao/InterviewSlotDao.ts
+++ b/backend/src/dao/InterviewSlotDao.ts
@@ -6,14 +6,18 @@ import BaseDao from './BaseDao';
 async function serializeInterviewSlot(instance: InterviewSlot): Promise<DBInterviewSlot> {
   return {
     ...instance,
-    lead: memberCollection.doc(instance.lead.email)
+    lead: instance.lead ? memberCollection.doc(instance.lead.email) : null,
+    members: instance.members.map((member) => (member ? memberCollection.doc(member.email) : null))
   };
 }
 
 async function materializeInterviewSlot(dbInstance: DBInterviewSlot): Promise<InterviewSlot> {
   return {
     ...dbInstance,
-    lead: await getMemberFromDocumentReference(dbInstance.lead)
+    lead: dbInstance.lead ? await getMemberFromDocumentReference(dbInstance.lead) : null,
+    members: await Promise.all(
+      dbInstance.members.map((member) => (member ? getMemberFromDocumentReference(member) : null))
+    )
   };
 }
 

--- a/backend/src/dao/InterviewSlotDao.ts
+++ b/backend/src/dao/InterviewSlotDao.ts
@@ -1,4 +1,5 @@
-import { interviewSlotCollection, memberCollection } from '../firebase';
+import { v4 as uuidv4 } from 'uuid';
+import { db, interviewSlotCollection, memberCollection } from '../firebase';
 import { DBInterviewSlot } from '../types/DataTypes';
 import { getMemberFromDocumentReference } from '../utils/memberUtil';
 import BaseDao from './BaseDao';
@@ -30,5 +31,51 @@ export default class InterviewSlotDao extends BaseDao<InterviewSlot, DBInterview
     return this.getDocuments([
       { field: 'interviewSchedulerUuid', comparisonOperator: '==', value: uuid }
     ]);
+  }
+
+  async getSlot(uuid: string): Promise<InterviewSlot | null> {
+    return this.getDocument(uuid);
+  }
+
+  async addSlots(slots: InterviewSlot[]): Promise<InterviewSlot[]> {
+    return Promise.all(
+      slots.map((slot) => {
+        const uuid = uuidv4();
+        return this.createDocument(uuid, {
+          ...slot,
+          uuid
+        });
+      })
+    );
+  }
+
+  async updateSlot(updatedSlot: InterviewSlot, adminBypass: boolean): Promise<boolean> {
+    const wasUpdated: boolean = await db.runTransaction(async (t) => {
+      const query = this.collection.where('uuid', '==', updatedSlot.uuid);
+      const snapshot = await t.get(query);
+      const oldSlot = await materializeInterviewSlot(snapshot.docs[0].data());
+
+      if (
+        !adminBypass &&
+        oldSlot.applicant &&
+        updatedSlot.applicant &&
+        oldSlot.applicant.email !== updatedSlot.applicant.email
+      ) {
+        return false;
+      }
+
+      const dbSlot = await serializeInterviewSlot({
+        ...oldSlot,
+        ...updatedSlot
+      });
+      t.update(this.collection.doc(dbSlot.uuid), dbSlot);
+      return true;
+    });
+
+    return wasUpdated;
+  }
+
+  async deleteSlot(uuid: string): Promise<void> {
+    return this.deleteDocument(uuid);
   }
 }

--- a/backend/src/dao/InterviewSlotDao.ts
+++ b/backend/src/dao/InterviewSlotDao.ts
@@ -1,0 +1,30 @@
+import { interviewSlotCollection, memberCollection } from '../firebase';
+import { DBInterviewSlot } from '../types/DataTypes';
+import { getMemberFromDocumentReference } from '../utils/memberUtil';
+import BaseDao from './BaseDao';
+
+async function serializeInterviewSlot(instance: InterviewSlot): Promise<DBInterviewSlot> {
+  return {
+    ...instance,
+    lead: memberCollection.doc(instance.lead.email)
+  };
+}
+
+async function materializeInterviewSlot(dbInstance: DBInterviewSlot): Promise<InterviewSlot> {
+  return {
+    ...dbInstance,
+    lead: await getMemberFromDocumentReference(dbInstance.lead)
+  };
+}
+
+export default class InterviewSlotDao extends BaseDao<InterviewSlot, DBInterviewSlot> {
+  constructor() {
+    super(interviewSlotCollection, materializeInterviewSlot, serializeInterviewSlot);
+  }
+
+  async getSlotsForScheduler(uuid: string): Promise<InterviewSlot[]> {
+    return this.getDocuments([
+      { field: 'interviewSchedulerUuid', comparisonOperator: '==', value: uuid }
+    ]);
+  }
+}

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -7,7 +7,8 @@ import {
   DevPortfolioSubmissionRequestLog,
   DBTeamEventAttendance,
   DBCandidateDeciderReview,
-  DBCoffeeChat
+  DBCoffeeChat,
+  DBInterviewSlot
 } from './types/DataTypes';
 import { configureAccount } from './utils/firebase-utils';
 
@@ -190,5 +191,16 @@ export const interviewSchedulerCollection: admin.firestore.CollectionReference<I
     },
     toFirestore(interviewSchedulerData: InterviewScheduler) {
       return interviewSchedulerData;
+    }
+  });
+
+export const interviewSlotCollection: admin.firestore.CollectionReference<DBInterviewSlot> = db
+  .collection('interview-slots')
+  .withConverter({
+    fromFirestore(snapshot): DBInterviewSlot {
+      return snapshot.data() as DBInterviewSlot;
+    },
+    toFirestore(interviewSlotData: DBInterviewSlot) {
+      return interviewSlotData;
     }
   });

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -124,7 +124,8 @@ export type DBInterviewSlot = {
   readonly interviewSchedulerUuid: string;
   readonly startTime: number;
   readonly room: string;
-  lead: firestore.DocumentReference;
-  members: string[];
-  applicant: string;
+  readonly uuid: string;
+  lead: firestore.DocumentReference | null;
+  members: (firestore.DocumentReference | null)[];
+  applicant: Applicant | null;
 };

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -266,14 +266,21 @@ interface MemberDetails {
 
 type CoffeeChatSuggestions = { [k: string]: MemberDetails[] };
 
+type Applicant = {
+  firstName: string;
+  lastName: string;
+  email: string;
+};
+
 interface InterviewScheduler {
   readonly name: string;
   readonly duration: number;
   readonly membersPerSlot: number;
   readonly isOpen: boolean;
-  readonly isArchived: boolean;
+  readonly startDate: number;
+  readonly endDate: number;
   readonly deadline: number;
-  readonly applicants: string[];
+  readonly applicants: Applicant[];
 }
 
 interface InterviewSlot {

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -287,9 +287,10 @@ interface InterviewSlot {
   readonly interviewSchedulerUuid: string;
   readonly startTime: number;
   readonly room: string;
-  readonly lead: IdolMember;
-  readonly members: string[];
-  readonly applicant: string;
+  readonly lead: IdolMember | null;
+  readonly members: (IdolMember | null)[];
+  readonly applicant: Applicant | null;
+  readonly uuid: string;
 }
 
 interface InterviewSchedulerEdit {

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -279,8 +279,8 @@ interface InterviewScheduler {
   readonly isOpen: boolean;
   readonly startDate: number;
   readonly endDate: number;
-  readonly deadline: number;
   readonly applicants: Applicant[];
+  readonly uuid: string;
 }
 
 interface InterviewSlot {
@@ -290,4 +290,11 @@ interface InterviewSlot {
   readonly lead: IdolMember;
   readonly members: string[];
   readonly applicant: string;
+}
+
+interface InterviewSchedulerEdit {
+  readonly uuid: string;
+  isOpen?: boolean;
+  startDate?: number;
+  endDate?: number;
 }

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -270,7 +270,10 @@ type Applicant = {
   firstName: string;
   lastName: string;
   email: string;
+  netid: string;
 };
+
+type SlotStatus = 'vacant' | 'occupied' | 'possessed';
 
 interface InterviewScheduler {
   readonly name: string;
@@ -302,6 +305,7 @@ interface InterviewSchedulerEdit {
 
 interface InterviewSlotEdit {
   readonly uuid: string;
+  readonly interviewSchedulerUuid: string;
   lead?: IdolMember | null;
   members?: (IdolMember | null)[];
   applicant?: Applicant | null;

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -299,3 +299,10 @@ interface InterviewSchedulerEdit {
   startDate?: number;
   endDate?: number;
 }
+
+interface InterviewSlotEdit {
+  readonly uuid: string;
+  lead?: IdolMember | null;
+  members?: (IdolMember | null)[];
+  applicant?: Applicant | null;
+}

--- a/frontend/public/sample_interview_scheduler_input.csv
+++ b/frontend/public/sample_interview_scheduler_input.csv
@@ -1,0 +1,4 @@
+Email,First Name,Last Name
+aaa111@cornell.edu,Alder,Alderson
+ddd222@cornell.edu,Donald,Donaldson
+cc2785@cornell.edu,Chris,Chen

--- a/frontend/public/sample_interview_scheduler_input.csv
+++ b/frontend/public/sample_interview_scheduler_input.csv
@@ -1,4 +1,5 @@
-Email,First Name,Last Name
-aaa111@cornell.edu,Alder,Alderson
-ddd222@cornell.edu,Donald,Donaldson
-cc2785@cornell.edu,Chris,Chen
+Email,First Name,Last Name,NetID
+aaa111@cornell.edu,Alder,Alderson,aaa111
+ddd222@cornell.edu,Donald,Donaldson,ddd222
+cc2785@cornell.edu,Chris,Chen,cc2785
+personal@gmail.com,Jane,Doe,abc123

--- a/frontend/src/API/InterviewSchedulerAPI.ts
+++ b/frontend/src/API/InterviewSchedulerAPI.ts
@@ -36,6 +36,12 @@ export default class InterviewSchedulerAPI {
     ).then((val) => val.data.slots);
   }
 
+  static async createSlots(slots: InterviewSlot[]): Promise<InterviewSlot[]> {
+    return APIWrapper.post(`${backendURL}/interview-slots`, { slots }).then(
+      (val) => val.data.slots
+    );
+  }
+
   static async updateSlot(edits: InterviewSlotEdit, isApplicant: boolean): Promise<boolean> {
     return APIWrapper.put(
       `${backendURL}/interview-slots${isApplicant ? '/applicant' : ''}`,

--- a/frontend/src/API/InterviewSchedulerAPI.ts
+++ b/frontend/src/API/InterviewSchedulerAPI.ts
@@ -36,7 +36,7 @@ export default class InterviewSchedulerAPI {
     ).then((val) => val.data.slots);
   }
 
-  static async updateSlot(edits: InterviewSlotEdit, isApplicant: boolean): Promise<InterviewSlot> {
+  static async updateSlot(edits: InterviewSlotEdit, isApplicant: boolean): Promise<boolean> {
     return APIWrapper.put(
       `${backendURL}/interview-slots${isApplicant ? '/applicant' : ''}`,
       edits

--- a/frontend/src/API/InterviewSchedulerAPI.ts
+++ b/frontend/src/API/InterviewSchedulerAPI.ts
@@ -22,7 +22,7 @@ export default class InterviewSchedulerAPI {
   }
 
   static async updateInstance(instance: InterviewSchedulerEdit): Promise<InterviewScheduler> {
-    const response = APIWrapper.put(`${backendURL}/interview-scheduler/${instance.uuid}`, instance);
+    const response = APIWrapper.put(`${backendURL}/interview-scheduler`, instance);
     return response.then((val) => val.data.instance);
   }
 
@@ -32,7 +32,18 @@ export default class InterviewSchedulerAPI {
 
   static async getSlots(uuid: string, isApplicant: boolean): Promise<InterviewSlot[]> {
     return APIWrapper.get(
-      `${backendURL}/interview-scheduler${isApplicant ? '/applicant' : ''}/${uuid}/slots`
+      `${backendURL}/interview-slots${isApplicant ? '/applicant' : ''}/${uuid}`
     ).then((val) => val.data.slots);
+  }
+
+  static async updateSlot(edits: InterviewSlotEdit, isApplicant: boolean): Promise<InterviewSlot> {
+    return APIWrapper.put(
+      `${backendURL}/interview-slots${isApplicant ? '/applicant' : ''}`,
+      edits
+    ).then((val) => val.data.success);
+  }
+
+  static async deleteSlot(uuid: string): Promise<void> {
+    APIWrapper.delete(`${backendURL}/interview-slots/${uuid}`);
   }
 }

--- a/frontend/src/API/InterviewSchedulerAPI.ts
+++ b/frontend/src/API/InterviewSchedulerAPI.ts
@@ -6,4 +6,20 @@ export default class InterviewSchedulerAPI {
     const response = APIWrapper.post(`${backendURL}/interview-scheduler`, instance);
     return response.then((val) => val.data.uuid);
   }
+
+  static async getAllInstances(isApplicant: boolean): Promise<InterviewScheduler[]> {
+    const response = APIWrapper.get(
+      `${backendURL}/interview-scheduler${isApplicant ? '/applicant' : ''}`
+    );
+    return response.then((val) => val.data.instances);
+  }
+
+  static async updateInstance(instance: InterviewSchedulerEdit): Promise<InterviewScheduler> {
+    const response = APIWrapper.put(`${backendURL}/interview-scheduler/${instance.uuid}`, instance);
+    return response.then((val) => val.data.instance);
+  }
+
+  static async deleteInstance(uuid: string): Promise<void> {
+    APIWrapper.delete(`${backendURL}/interview-scheduler/${uuid}`);
+  }
 }

--- a/frontend/src/API/InterviewSchedulerAPI.ts
+++ b/frontend/src/API/InterviewSchedulerAPI.ts
@@ -1,0 +1,9 @@
+import APIWrapper from './APIWrapper';
+import { backendURL } from '../environment';
+
+export default class InterviewSchedulerAPI {
+  static async createNewInstance(instance: InterviewScheduler): Promise<string> {
+    const response = APIWrapper.post(`${backendURL}/interview-scheduler`, instance);
+    return response.then((val) => val.data.uuid);
+  }
+}

--- a/frontend/src/API/InterviewSchedulerAPI.ts
+++ b/frontend/src/API/InterviewSchedulerAPI.ts
@@ -14,6 +14,13 @@ export default class InterviewSchedulerAPI {
     return response.then((val) => val.data.instances);
   }
 
+  static async getInstance(uuid: string, isApplicant: boolean): Promise<InterviewScheduler> {
+    const response = APIWrapper.get(
+      `${backendURL}/interview-scheduler${isApplicant ? '/applicant' : ''}/${uuid}`
+    );
+    return response.then((val) => val.data.instance);
+  }
+
   static async updateInstance(instance: InterviewSchedulerEdit): Promise<InterviewScheduler> {
     const response = APIWrapper.put(`${backendURL}/interview-scheduler/${instance.uuid}`, instance);
     return response.then((val) => val.data.instance);
@@ -21,5 +28,11 @@ export default class InterviewSchedulerAPI {
 
   static async deleteInstance(uuid: string): Promise<void> {
     APIWrapper.delete(`${backendURL}/interview-scheduler/${uuid}`);
+  }
+
+  static async getSlots(uuid: string, isApplicant: boolean): Promise<InterviewSlot[]> {
+    return APIWrapper.get(
+      `${backendURL}/interview-scheduler${isApplicant ? '/applicant' : ''}/${uuid}/slots`
+    ).then((val) => val.data.slots);
   }
 }

--- a/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.module.css
+++ b/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.module.css
@@ -19,8 +19,13 @@
   margin-left: auto;
   margin-right: auto;
   margin-top: 5%;
+  margin-bottom: 5%;
 }
 
 .submitButton {
   margin-top: 1em !important;
+}
+
+.editorContainer {
+  margin-top: 3em;
 }

--- a/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.module.css
+++ b/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.module.css
@@ -1,0 +1,26 @@
+.uploadStatusSuccess {
+  margin-top: 2em;
+  padding: 1em;
+  color: green;
+  border: 1px black solid;
+  background-color: lightgray;
+}
+
+.uploadStatusError {
+  margin-top: 2em;
+  padding: 1em;
+  color: red;
+  border: 1px black solid;
+  background-color: lightgray;
+}
+
+.creatorContainer {
+  width: 60%;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 5%;
+}
+
+.submitButton {
+  margin-top: 1em !important;
+}

--- a/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.tsx
+++ b/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.tsx
@@ -71,7 +71,7 @@ const InterviewSchedulerCreator = () => {
 
     await InterviewSchedulerAPI.createNewInstance({
       name,
-      duration,
+      duration: duration * 60000, // convert to milliseconds
       membersPerSlot,
       startDate: (startDate as Date).getTime(),
       endDate: (endDate as Date).getTime(),

--- a/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.tsx
+++ b/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.tsx
@@ -38,7 +38,7 @@ const InterviewSchedulerCreator = () => {
 
     const columnHeaders = rows[0].split(',').map((header) => header.toLowerCase());
     const responses = rows.splice(1).map((row) => row.split(','));
-    const requiredHeaders = ['first name', 'last name', 'email'];
+    const requiredHeaders = ['first name', 'last name', 'email', 'netid'];
 
     const errs = [];
 
@@ -80,7 +80,8 @@ const InterviewSchedulerCreator = () => {
       applicants: responses.map((response) => ({
         firstName: response[columnHeaders.indexOf('first name')],
         lastName: response[columnHeaders.indexOf('last name')],
-        email: response[columnHeaders.indexOf('email')]
+        email: response[columnHeaders.indexOf('email')],
+        netid: response[columnHeaders.indexOf('netid')]
       }))
     });
 
@@ -105,7 +106,8 @@ const InterviewSchedulerCreator = () => {
         />
         <label>
           {' '}
-          Format: .csv with at least a "Email", "First Name", and "Last Name" column.{' '}
+          Format: .csv with at least a "Email", "NetID", "First Name", and "Last Name" column (case
+          insensitive).{' '}
           <a href="/sample_interview_scheduler_input.csv">Download sample file here.</a>
         </label>
         <Header as="h4">Start and end date</Header>

--- a/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.tsx
+++ b/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.tsx
@@ -14,8 +14,8 @@ type UploadStatus = {
 const InterviewSchedulerCreator = () => {
   const [name, setName] = useState<string>('');
   const [csv, setCsv] = useState<File>();
-  const [startDate, setStartDate] = useState<Date>(new Date());
-  const [endDate, setEndDate] = useState<Date>(new Date());
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
   const [duration, setDuration] = useState<number>(30);
   const [membersPerSlot, setMembersPerSlot] = useState<number>(1);
   const [uploadStatus, setUploadStatus] = useState<UploadStatus>({
@@ -60,6 +60,10 @@ const InterviewSchedulerCreator = () => {
       errs.push('Members per slot must be positive.');
     }
 
+    if (!startDate || !endDate) {
+      errs.push('Start date and end date are undefined.');
+    }
+
     if (errs.length > 0) {
       setUploadStatus({ status: 'error', errs });
       return;
@@ -69,11 +73,11 @@ const InterviewSchedulerCreator = () => {
       name,
       duration,
       membersPerSlot,
-      startDate: startDate.getTime(),
-      endDate: endDate.getTime(),
+      startDate: (startDate as Date).getTime(),
+      endDate: (endDate as Date).getTime(),
       isOpen: false,
       uuid: '',
-      applicants:       responses.map((response) => ({
+      applicants: responses.map((response) => ({
         firstName: response[columnHeaders.indexOf('first name')],
         lastName: response[columnHeaders.indexOf('last name')],
         email: response[columnHeaders.indexOf('email')]
@@ -110,12 +114,15 @@ const InterviewSchedulerCreator = () => {
           startDate={startDate}
           endDate={endDate}
           onChange={(date) => {
-            const [start, end] = date as [Date, Date];
+            const [start, end] = date as [Date | null, Date | null];
+            if (start) {
+              start.setHours(0, 0, 0, 0);
+            }
             setStartDate(start);
             setEndDate(end);
           }}
         />
-        <Header as="h4">Duration</Header>
+        <Header as="h4">Duration (in minutes)</Header>
         <input
           type="number"
           defaultValue={30}

--- a/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.tsx
+++ b/frontend/src/components/Admin/AdminInterviewScheduler/AdminInterviewScheduler.tsx
@@ -1,0 +1,175 @@
+import React, { useState } from 'react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import { Button, Form, Header } from 'semantic-ui-react';
+import styles from './AdminInterviewScheduler.module.css';
+import InterviewSchedulerAPI from '../../../API/InterviewSchedulerAPI';
+
+type UploadStatus = {
+  readonly status?: 'success' | 'error';
+  readonly errs: string[];
+};
+
+const InterviewSchedulerCreator = () => {
+  const [name, setName] = useState<string>('');
+  const [csv, setCsv] = useState<File>();
+  const [applicants, setApplicants] = useState<Applicant[]>([]);
+  const [startDate, setStartDate] = useState<Date>(new Date());
+  const [endDate, setEndDate] = useState<Date>(new Date());
+  const [deadline, setDeadline] = useState<Date>(new Date());
+  const [duration, setDuration] = useState<number>(30);
+  const [membersPerSlot, setMembersPerSlot] = useState<number>(1);
+  const [uploadStatus, setUploadStatus] = useState<UploadStatus>({
+    errs: []
+  });
+
+  const onSubmit = async () => {
+    setUploadStatus({ status: undefined, errs: [] });
+
+    if (!csv) {
+      setUploadStatus({
+        status: 'error',
+        errs: ['No csv file has been provided.']
+      });
+      return;
+    }
+
+    const text = await csv.text();
+    const rows = text.split('\n').map((row) => row.trim());
+
+    const columnHeaders = rows[0].split(',').map((header) => header.toLowerCase());
+    const responses = rows.splice(1).map((row) => row.split(','));
+    const requiredHeaders = ['first name', 'last name', 'email'];
+
+    const errs = [];
+
+    requiredHeaders.forEach((header) => {
+      if (!columnHeaders.includes(header)) {
+        errs.push(`The csv file does not contain a column with header: ${header}`);
+      }
+    });
+
+    if (name === '') {
+      errs.push('The name must not be empty.');
+    }
+
+    if (duration < 0) {
+      errs.push('The duration must be positive.');
+    }
+
+    if (membersPerSlot < 0) {
+      errs.push('Members per slot must be positive.');
+    }
+
+    if (errs.length > 0) {
+      setUploadStatus({ status: 'error', errs });
+      return;
+    }
+
+    setApplicants(
+      responses.map((response) => ({
+        firstName: response[columnHeaders.indexOf('first name')],
+        lastName: response[columnHeaders.indexOf('last name')],
+        email: response[columnHeaders.indexOf('email')]
+      }))
+    );
+
+    const uuid = await InterviewSchedulerAPI.createNewInstance({
+      name,
+      duration,
+      membersPerSlot,
+      startDate: startDate.getTime(),
+      endDate: endDate.getTime(),
+      deadline: deadline.getTime(),
+      isOpen: false,
+      applicants
+    });
+
+    setUploadStatus({
+      errs: [uuid],
+      status: 'success'
+    });
+  };
+
+  return (
+    <div className={styles.creatorContainer}>
+      <Header as="h2">Create a new Interview Scheduler instance</Header>
+      <Form>
+        <Form.Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <Header as="h4">Applicants</Header>
+        <input
+          type="file"
+          accept=".csv"
+          onChange={(e) => {
+            if (e.target.files) setCsv(e.target.files[0]);
+          }}
+        />
+        <label>
+          {' '}
+          Format: .csv with at least a "Email", "First Name", and "Last Name" column.{' '}
+          <a href="/sample_interview_scheduler_input.csv">Download sample file here.</a>
+        </label>
+        <Header as="h4">Start and end date</Header>
+        <DatePicker
+          selectsRange
+          startDate={startDate}
+          endDate={endDate}
+          onChange={(date) => {
+            const [start, end] = date as [Date, Date];
+            setStartDate(start);
+            setEndDate(end);
+          }}
+        />
+        <Header as="h4">Deadline</Header>
+        <DatePicker
+          selected={deadline}
+          dateFormat="MMMM do yyyy"
+          onChange={(date: Date) => setDeadline(date)}
+        />
+        <Header as="h4">Duration</Header>
+        <input
+          type="number"
+          defaultValue={30}
+          onChange={(e) => setDuration(Number(e.target.value))}
+        />
+        <Header as="h4">Members Per Slot</Header>
+        <input
+          type="number"
+          defaultValue={1}
+          onChange={(e) => setMembersPerSlot(Number(e.target.value))}
+        />
+        <Button onClick={onSubmit} className={styles.submitButton}>
+          Submit
+        </Button>
+        {uploadStatus.status && (
+          <div
+            className={
+              uploadStatus.status === 'error'
+                ? styles.uploadStatusError
+                : styles.uploadStatusSuccess
+            }
+          >
+            <p>
+              {uploadStatus.status === 'error'
+                ? 'A new interview scheduler could not be created.'
+                : 'A new interview scheduler has been successfully created.'}
+            </p>
+            <ul>
+              {uploadStatus.errs.map((err) => (
+                <li>{err}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </Form>
+    </div>
+  );
+};
+
+const AdminInterviewSchedulerBase = () => (
+  <div>
+    <InterviewSchedulerCreator />
+  </div>
+);
+
+export default AdminInterviewSchedulerBase;

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -153,7 +153,7 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
         /* Always render children under test environment */
         process.env.NODE_ENV === 'test' && children
       }
-      {adminEmails == null || members == null || approvedMembers == null ? (
+      {!hasIDOLAccess || adminEmails == null || members == null || approvedMembers == null ? (
         <div>
           <Loader active size="massive" />
           {!hasIDOLAccess && (

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.module.css
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.module.css
@@ -6,3 +6,23 @@
   display: flex;
   gap: 3%;
 }
+
+.sidebarContainer {
+  width: 40%;
+  padding-top: 4em;
+}
+
+.inviteCardContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 80px);
+}
+
+.inviteCard {
+  width: 40% !important;
+}
+
+.inviteHeader {
+  margin-bottom: 1em;
+}

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.module.css
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.module.css
@@ -26,3 +26,8 @@
 .inviteHeader {
   margin-bottom: 1em;
 }
+
+.headerContainer {
+  display: flex;
+  justify-content: space-between;
+}

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.module.css
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.module.css
@@ -1,12 +1,8 @@
 .schedulerContainer {
   padding: 2%;
+}
+
+.contentContainer {
   display: flex;
-}
-
-.calendarContainer {
-  width: 60%;
-}
-
-.sidebarContainer {
-  width: 40%;
+  gap: 3%;
 }

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.module.css
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.module.css
@@ -1,0 +1,12 @@
+.schedulerContainer {
+  padding: 2%;
+  display: flex;
+}
+
+.calendarContainer {
+  width: 60%;
+}
+
+.sidebarContainer {
+  width: 40%;
+}

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
@@ -1,54 +1,93 @@
 import { useEffect, useState } from 'react';
-import { Header, Loader } from 'semantic-ui-react';
+import { Card, Header } from 'semantic-ui-react';
+import Link from 'next/link';
 import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
 import { useHasMemberPermission } from '../Common/FirestoreDataProvider';
 import styles from './InterviewScheduler.module.css';
 import SchedulingCalendar from './SchedulingCalendar';
-import { getDateString } from '../../utils';
+import { getDateString, getTimeString } from '../../utils';
 import SchedulingSidePanel from './SchedulingSidePanel';
+import { SetSlotsContext } from './SlotHooks';
+import { useUserEmail } from '../Common/UserProvider/UserProvider';
+
+const InviteCard: React.FC<{ scheduler: InterviewScheduler; slot: InterviewSlot }> = ({
+  scheduler,
+  slot
+}) => (
+  <div className={styles.inviteCardContainer}>
+    <Card className={styles.inviteCard}>
+      <Card.Content>
+        <Card.Header className={styles.inviteHeader}>Thank you for signing up!</Card.Header>
+        <div>
+          <p>{scheduler.name}</p>
+          <p>
+            {getTimeString(slot.startTime)} - {getTimeString(slot.startTime + scheduler.duration)}
+          </p>
+          <p>{slot.room}</p>
+        </div>
+      </Card.Content>
+      <Card.Content extra>
+        Need help? Send a message to{' '}
+        <Link href="mailto:hello@cornelldti.org">hello@cornelldti.org</Link>
+      </Card.Content>
+    </Card>
+  </div>
+);
 
 const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
   const [scheduler, setScheduler] = useState<InterviewScheduler>();
   const [slots, setSlots] = useState<InterviewSlot[]>([]);
   const [selectedSlot, setSelectedSlot] = useState<InterviewSlot | undefined>();
   const [hoveredSlot, setHoveredSlot] = useState<InterviewSlot | undefined>();
+  const [possessedSlot, setPossessedSlot] = useState<InterviewSlot | undefined>();
 
-  const hasMemberPermissions = useHasMemberPermission();
+  const isMember = useHasMemberPermission();
+  const userEmail = useUserEmail();
+
+  const refreshSlots = () =>
+    InterviewSchedulerAPI.getSlots(uuid, !isMember).then((res) => {
+      setSlots(res);
+      setPossessedSlot(slots.find((slot) => slot.applicant && slot.applicant.email === userEmail));
+    });
 
   useEffect(() => {
-    InterviewSchedulerAPI.getInstance(uuid, !hasMemberPermissions).then((inst) => {
+    InterviewSchedulerAPI.getInstance(uuid, !isMember).then((inst) => {
       setScheduler(inst);
     });
-    InterviewSchedulerAPI.getSlots(uuid, !hasMemberPermissions).then((res) => {
-      setSlots(res);
-    });
+    refreshSlots();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  if (!isMember && possessedSlot && scheduler)
+    return <InviteCard scheduler={scheduler} slot={possessedSlot} />;
 
   return (
     <div className={styles.schedulerContainer}>
       {!scheduler || !slots ? (
-        <Loader size="massive" />
+        <p>Loading...</p>
       ) : (
-        <>
+        <SetSlotsContext.Provider value={{ setSelectedSlot, setHoveredSlot }}>
           <div>
             <Header as="h2">{scheduler.name}</Header>
             <p>{`${getDateString(scheduler.startDate, false)} - ${getDateString(scheduler.endDate, false)}`}</p>
           </div>
           <div className={styles.contentContainer}>
-            <SchedulingCalendar
-              scheduler={scheduler}
-              slots={slots}
-              setSlots={setSlots}
-              setHoveredSlot={setHoveredSlot}
-              setSelectedSlot={setSelectedSlot}
-            />
-            <SchedulingSidePanel
-              displayedSlot={hoveredSlot || selectedSlot}
-              duration={scheduler.duration}
-            />
+            <SchedulingCalendar scheduler={scheduler} slots={slots} setSlots={setSlots} />
+            <div className={styles.sidebarContainer}>
+              <p>
+                Hover over to review time slots. Click to show more information, sign up, or cancel.
+              </p>
+              {(hoveredSlot || selectedSlot) && (
+                <SchedulingSidePanel
+                  displayedSlot={(hoveredSlot || selectedSlot) as InterviewSlot}
+                  scheduler={scheduler}
+                  setSlots={setSlots}
+                  refresh={refreshSlots}
+                />
+              )}
+            </div>
           </div>
-        </>
+        </SetSlotsContext.Provider>
       )}
     </div>
   );

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
@@ -10,21 +10,34 @@ import SchedulingSidePanel from './SchedulingSidePanel';
 import { EditAvailabilityContext, SetSlotsContext } from './SlotHooks';
 import { useUserEmail } from '../Common/UserProvider/UserProvider';
 
-const InviteCard: React.FC<{ scheduler: InterviewScheduler; slot: InterviewSlot }> = ({
+const InviteCard: React.FC<{ scheduler: InterviewScheduler; slot?: InterviewSlot }> = ({
   scheduler,
   slot
 }) => (
   <div className={styles.inviteCardContainer}>
     <Card className={styles.inviteCard}>
       <Card.Content>
-        <Card.Header className={styles.inviteHeader}>Thank you for signing up!</Card.Header>
-        <div>
-          <p>{scheduler.name}</p>
-          <p>
-            {getTimeString(slot.startTime)} - {getTimeString(slot.startTime + scheduler.duration)}
-          </p>
-          <p>{slot.room}</p>
-        </div>
+        {slot ? (
+          <>
+            <Card.Header className={styles.inviteHeader}>Thank you for signing up!</Card.Header>
+            <div>
+              <p>{scheduler.name}</p>
+              <p>
+                {getTimeString(slot.startTime)} -{' '}
+                {getTimeString(slot.startTime + scheduler.duration)}
+              </p>
+              <p>{slot.room}</p>
+            </div>
+          </>
+        ) : (
+          <>
+            <Card.Header>Could not find time slot.</Card.Header>
+            <p>
+              We could not find a time slot that you signed up for. For assistance, please contact
+              the email below.
+            </p>
+          </>
+        )}
       </Card.Content>
       <Card.Content extra>
         Need help? Send a message to{' '}
@@ -78,7 +91,7 @@ const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
     }
   };
 
-  if (!isMember && possessedSlot && scheduler)
+  if (scheduler && !scheduler.isOpen && !isMember)
     return <InviteCard scheduler={scheduler} slot={possessedSlot} />;
 
   return (

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { Loader } from 'semantic-ui-react';
+import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
+import { useHasMemberPermission } from '../Common/FirestoreDataProvider';
+import styles from './InterviewScheduler.module.css';
+import SchedulingCalendar from './SchedulingCalendar';
+
+const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
+  const [isSchedulerLoading, setIsSchedulerLoading] = useState(true);
+  const [areSlotsLoading, setAreSlotsLoading] = useState(true);
+  const [scheduler, setScheduler] = useState<InterviewScheduler>();
+  const [slots, setSlots] = useState<InterviewSlot[]>([]);
+
+  const hasMemberPermissions = useHasMemberPermission();
+
+  useEffect(() => {
+    InterviewSchedulerAPI.getInstance(uuid, !hasMemberPermissions).then((inst) => {
+      setScheduler(inst);
+      setIsSchedulerLoading(false);
+    });
+    InterviewSchedulerAPI.getSlots(uuid, !hasMemberPermissions).then((res) => {
+      setSlots(res);
+      setAreSlotsLoading(false);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className={styles.schedulerContainer}>
+      {isSchedulerLoading || areSlotsLoading ? (
+        <Loader size="massive" />
+      ) : (
+        <>
+          <div className={styles.calendarContainer}>
+            <SchedulingCalendar scheduler={scheduler as InterviewScheduler} slots={slots} setSlots={setSlots} />
+          </div>
+          <div className={styles.sidebarContainer}></div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default InterviewScheduler;

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
@@ -1,40 +1,53 @@
 import { useEffect, useState } from 'react';
-import { Loader } from 'semantic-ui-react';
+import { Header, Loader } from 'semantic-ui-react';
 import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
 import { useHasMemberPermission } from '../Common/FirestoreDataProvider';
 import styles from './InterviewScheduler.module.css';
 import SchedulingCalendar from './SchedulingCalendar';
+import { getDateString } from '../../utils';
+import SchedulingSidePanel from './SchedulingSidePanel';
 
 const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
-  const [isSchedulerLoading, setIsSchedulerLoading] = useState(true);
-  const [areSlotsLoading, setAreSlotsLoading] = useState(true);
   const [scheduler, setScheduler] = useState<InterviewScheduler>();
   const [slots, setSlots] = useState<InterviewSlot[]>([]);
+  const [selectedSlot, setSelectedSlot] = useState<InterviewSlot | undefined>();
+  const [hoveredSlot, setHoveredSlot] = useState<InterviewSlot | undefined>();
 
   const hasMemberPermissions = useHasMemberPermission();
 
   useEffect(() => {
     InterviewSchedulerAPI.getInstance(uuid, !hasMemberPermissions).then((inst) => {
       setScheduler(inst);
-      setIsSchedulerLoading(false);
     });
     InterviewSchedulerAPI.getSlots(uuid, !hasMemberPermissions).then((res) => {
       setSlots(res);
-      setAreSlotsLoading(false);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
     <div className={styles.schedulerContainer}>
-      {isSchedulerLoading || areSlotsLoading ? (
+      {!scheduler || !slots ? (
         <Loader size="massive" />
       ) : (
         <>
-          <div className={styles.calendarContainer}>
-            <SchedulingCalendar scheduler={scheduler as InterviewScheduler} slots={slots} setSlots={setSlots} />
+          <div>
+            <Header as="h2">{scheduler.name}</Header>
+            <p>{`${getDateString(scheduler.startDate, false)} - ${getDateString(scheduler.endDate, false)}`}</p>
           </div>
-          <div className={styles.sidebarContainer}></div>
+          <div className={styles.contentContainer}>
+            <SchedulingCalendar
+              scheduler={scheduler}
+              slots={slots}
+              setSlots={setSlots}
+              setHoveredSlot={setHoveredSlot}
+              setSelectedSlot={setSelectedSlot}
+            />
+            <SchedulingSidePanel
+              displayedSlot={hoveredSlot || selectedSlot}
+              duration={scheduler.duration}
+            />
+          </div>
         </>
       )}
     </div>

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
@@ -111,7 +111,13 @@ const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
                     </Button>
                   </div>
                 ) : (
-                  <Button basic onClick={() => {setIsEditing(true); setSelectedSlot(undefined)}}>
+                  <Button
+                    basic
+                    onClick={() => {
+                      setIsEditing(true);
+                      setSelectedSlot(undefined);
+                    }}
+                  >
                     Add availabilities
                   </Button>
                 )}

--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
@@ -96,7 +96,7 @@ const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
 
   return (
     <div className={styles.schedulerContainer}>
-      {!scheduler || slots.length === 0 ? (
+      {!scheduler ? (
         <p>Loading...</p>
       ) : (
         <SetSlotsContext.Provider value={{ setSlots, setSelectedSlot, setHoveredSlot }}>

--- a/frontend/src/components/Interview-Scheduler/InterviewSchedulerList.module.css
+++ b/frontend/src/components/Interview-Scheduler/InterviewSchedulerList.module.css
@@ -1,3 +1,3 @@
 .listContainer {
-    padding: 2%
+  padding: 2%;
 }

--- a/frontend/src/components/Interview-Scheduler/InterviewSchedulerList.module.css
+++ b/frontend/src/components/Interview-Scheduler/InterviewSchedulerList.module.css
@@ -1,0 +1,3 @@
+.listContainer {
+    padding: 2%
+}

--- a/frontend/src/components/Interview-Scheduler/InterviewSchedulerList.tsx
+++ b/frontend/src/components/Interview-Scheduler/InterviewSchedulerList.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { Card, Header, Loader } from 'semantic-ui-react';
+import styles from './InterviewSchedulerList.module.css';
+import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
+import { useHasMemberPermission } from '../Common/FirestoreDataProvider';
+
+const InterviewSchedulerList = () => {
+  const [schedulers, setSchedulers] = useState<InterviewScheduler[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const isMember = useHasMemberPermission();
+
+  useEffect(() => {
+    InterviewSchedulerAPI.getAllInstances(!isMember)
+      .then((val) => setSchedulers(val))
+      .then(() => setIsLoading(false));
+  }, [isMember]);
+
+  return isLoading ? (
+    <Loader size="massive" />
+  ) : (
+    <div className={styles.listContainer}>
+      <Header as="h2">Interview Schedulers</Header>
+      {!schedulers || schedulers.length === 0 ? (
+        <p>
+          You currently do not have access to any interview schedulers. If you think this is an
+          error please contact {isMember ? '#idol-support' : 'hello@cornelldti.org'}.
+        </p>
+      ) : (
+        <Card.Group>
+          {schedulers.map((scheduler) => (
+            <Card href={`interview-scheduler/${scheduler.uuid}`} key={scheduler.uuid}>
+              <Card.Content>
+                <Card.Header>{scheduler.name}</Card.Header>
+              </Card.Content>
+            </Card>
+          ))}
+        </Card.Group>
+      )}
+    </div>
+  );
+};
+
+export default InterviewSchedulerList;

--- a/frontend/src/components/Interview-Scheduler/SchedulingCalendar.module.css
+++ b/frontend/src/components/Interview-Scheduler/SchedulingCalendar.module.css
@@ -1,0 +1,41 @@
+.timeslot {
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  border: 1px solid black;
+  height: 15px;
+  width: 150px;
+}
+
+.column {
+  position: relative;
+}
+
+.columnContainer {
+  display: flex;
+  margin-top: 2rem;
+  --hour-block-width: 150px;
+  --hour-block-height: 60px;
+}
+
+.timeLabelColumn {
+  text-align: right;
+  width: 100px;
+  padding-right: 10px;
+  margin-top: 30px
+}
+
+.timeLabel {
+  height: var(--hour-block-height);
+  margin: 0
+}
+
+.slotButton {
+  position: absolute;
+  width: var(--hour-block-width);
+}
+
+.roomName {
+  text-align: center;
+  margin-bottom: 5px;
+}

--- a/frontend/src/components/Interview-Scheduler/SchedulingCalendar.module.css
+++ b/frontend/src/components/Interview-Scheduler/SchedulingCalendar.module.css
@@ -14,6 +14,13 @@
 .calendarContainer {
   width: 60%;
   margin-top: 2em;
+  overflow-x: auto;
+}
+
+.calendarContainerFull {
+  width: 100%;
+  margin-top: 2em;
+  overflow-x: auto;
 }
 
 .columnContainer {
@@ -27,7 +34,6 @@
   text-align: right;
   width: 100px;
   padding-right: 10px;
-  margin-top: 30px;
 }
 
 .timeLabel {
@@ -45,4 +51,10 @@
 .roomName {
   text-align: center;
   margin-bottom: 5px;
+}
+
+.roomForm {
+  display: flex;
+  gap: 1em;
+  margin-top: 1em;
 }

--- a/frontend/src/components/Interview-Scheduler/SchedulingCalendar.module.css
+++ b/frontend/src/components/Interview-Scheduler/SchedulingCalendar.module.css
@@ -13,6 +13,7 @@
 
 .calendarContainer {
   width: 60%;
+  margin-top: 2em;
 }
 
 .columnContainer {

--- a/frontend/src/components/Interview-Scheduler/SchedulingCalendar.module.css
+++ b/frontend/src/components/Interview-Scheduler/SchedulingCalendar.module.css
@@ -11,6 +11,10 @@
   position: relative;
 }
 
+.calendarContainer {
+  width: 60%;
+}
+
 .columnContainer {
   display: flex;
   margin-top: 2rem;
@@ -22,17 +26,19 @@
   text-align: right;
   width: 100px;
   padding-right: 10px;
-  margin-top: 30px
+  margin-top: 30px;
 }
 
 .timeLabel {
   height: var(--hour-block-height);
-  margin: 0
+  margin: 0;
 }
 
 .slotButton {
   position: absolute;
   width: var(--hour-block-width);
+  padding: 0 !important;
+  border-radius: 0 !important;
 }
 
 .roomName {

--- a/frontend/src/components/Interview-Scheduler/SchedulingCalendar.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingCalendar.tsx
@@ -1,0 +1,152 @@
+import { Dispatch, SetStateAction, useRef, useState } from 'react';
+import { Button, Dropdown, Header } from 'semantic-ui-react';
+import styles from './SchedulingCalendar.module.css';
+import { getDayNameFromDate, hourIndexToString } from '../../utils';
+
+const PIXEL_PER_MINUTE = 1;
+
+const TimeBlock = () => (
+  <>
+    <div className={styles.timeslot} style={{ borderBottomStyle: 'hidden' }} />
+    <div
+      className={styles.timeslot}
+      style={{
+        borderTopStyle: 'hidden',
+        borderBottomStyle: 'dashed'
+      }}
+    />
+    <div
+      className={styles.timeslot}
+      style={{
+        borderTopStyle: 'dashed',
+        borderBottomStyle: 'hidden'
+      }}
+    />
+    <div
+      className={styles.timeslot}
+      style={{
+        borderTopStyle: 'hidden'
+      }}
+    />
+  </>
+);
+
+const SchedulerColumn: React.FC<{
+  hours: number[];
+  room: string;
+  slots: InterviewSlot[];
+  duration: number;
+  userView?: boolean;
+}> = ({ hours, duration, room, slots, userView = false }) => {
+  const timeBlockRef = useRef<HTMLDivElement>(null);
+
+  const getMinutesFromStartOfDay = (unixTime: number) => {
+    const date = new Date(unixTime);
+    return date.getHours() * 60 + date.getMinutes();
+  };
+
+  return (
+    <div>
+      <p className={styles.roomName}>{room}</p>
+      <div ref={timeBlockRef} className={styles.column}>
+        <div>
+          {hours.map((_) => (
+            <TimeBlock />
+          ))}
+        </div>
+        <div>
+          {slots.map((slot) => (
+            <Button
+              className={styles.slotButton}
+              style={{
+                top: PIXEL_PER_MINUTE * (getMinutesFromStartOfDay(slot.startTime) - hours[0] * 60),
+                height: duration
+              }}
+            >
+              {hourIndexToString(
+                new Date(slot.startTime).getHours(),
+                new Date(slot.startTime).getMinutes()
+              )}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const MILLISECONDS_PER_DAY = 86400000;
+const MILLISECONDS_PER_MINUTE = 60000;
+
+const SchedulingCalendar: React.FC<{
+  scheduler: InterviewScheduler;
+  slots: InterviewSlot[];
+  setSlots: Dispatch<SetStateAction<InterviewSlot[]>>;
+}> = ({ scheduler, slots, setSlots }) => {
+  const getDateString = (unixTime: number, includeDayName: boolean): string => {
+    const date = new Date(unixTime);
+    return `${includeDayName ? `${getDayNameFromDate(date)} ` : ''}${1 + date.getMonth()}/${date.getDate()}`;
+  };
+
+  const [day, setDay] = useState(scheduler.startDate);
+
+  const filteredSlots = slots.filter(
+    (slot) => slot.startTime >= day && slot.startTime <= day + MILLISECONDS_PER_DAY
+  );
+
+  const options = Array.from(
+    {
+      length: 1 + (scheduler.endDate - scheduler.startDate) / MILLISECONDS_PER_DAY
+    },
+    (_, i) => scheduler.startDate + i * MILLISECONDS_PER_DAY
+  ).map((date) => ({
+    text: getDateString(date, true),
+    value: date
+  }));
+
+  const slotsByRoom = filteredSlots.reduce((acc, curr) => {
+    acc.set(curr.room, [...(acc.get(curr.room) || []), curr]);
+    return acc;
+  }, new Map<string, InterviewSlot[]>());
+
+  const minHour = new Date(Math.min(...filteredSlots.map((slot) => slot.startTime))).getHours();
+  const maxHour = new Date(
+    scheduler.duration * MILLISECONDS_PER_MINUTE +
+      Math.max(...filteredSlots.map((slot) => slot.startTime))
+  ).getHours();
+  const hours = Array.from({ length: maxHour - minHour + 1 }, (_, i) => minHour + i);
+  
+  return (
+    <>
+      <div>
+        <Header as="h2">{scheduler.name}</Header>
+        <p>{`${getDateString(scheduler.startDate, false)} - ${getDateString(scheduler.endDate, false)}`}</p>
+        <Dropdown
+          selection
+          value={day}
+          options={options}
+          onChange={(_, data) => {
+            setDay(data.value as number);
+          }}
+        />
+      </div>
+      <div className={styles.columnContainer}>
+        <div className={styles.timeLabelColumn}>
+          {hours.map((hour) => (
+            <p className={styles.timeLabel}>{hourIndexToString(hour)}</p>
+          ))}
+        </div>
+        {Array.from(slotsByRoom.entries()).map(([room, roomSlots]) => (
+          <SchedulerColumn
+            room={room}
+            slots={roomSlots}
+            duration={scheduler.duration}
+            hours={hours}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default SchedulingCalendar;

--- a/frontend/src/components/Interview-Scheduler/SchedulingCalendar.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingCalendar.tsx
@@ -191,9 +191,6 @@ const SchedulerColumn: React.FC<{
 
   return (
     <div>
-      {/* <p>
-        {bar} | {foo}
-      </p> */}
       <p className={styles.roomName}>{room}</p>
       <div className={styles.column} ref={columnRef}>
         <div

--- a/frontend/src/components/Interview-Scheduler/SchedulingCalendar.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingCalendar.tsx
@@ -1,51 +1,87 @@
-import { Dispatch, SetStateAction, useState } from 'react';
-import { Button, Dropdown } from 'semantic-ui-react';
+import { CSSProperties, DragEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { Button, Dropdown, Form, Input } from 'semantic-ui-react';
 import styles from './SchedulingCalendar.module.css';
 import { getDateString, hourIndexToString } from '../../utils';
-import { useHasAdminPermission } from '../Common/FirestoreDataProvider';
-import { useInterviewSlotStatus, useSetSlotsContext } from './SlotHooks';
+import { useHasAdminPermission, useMembers } from '../Common/FirestoreDataProvider';
+import {
+  useEditAvailabilityContext,
+  useInterviewSlotStatus,
+  useSetSlotsContext
+} from './SlotHooks';
+import { useUserEmail } from '../Common/UserProvider/UserProvider';
 
 const PIXEL_PER_MINUTE = 1;
+const MILLISECONDS_PER_DAY = 86400000;
+const MILLISECONDS_PER_MINUTE = 60000;
 
-const TimeBlock = () => (
-  <>
-    <div className={styles.timeslot} style={{ borderBottomStyle: 'hidden' }} />
-    <div
-      className={styles.timeslot}
-      style={{
-        borderTopStyle: 'hidden',
-        borderBottomStyle: 'dashed'
-      }}
-    />
-    <div
-      className={styles.timeslot}
-      style={{
-        borderTopStyle: 'dashed',
-        borderBottomStyle: 'hidden'
-      }}
-    />
-    <div
-      className={styles.timeslot}
-      style={{
-        borderTopStyle: 'hidden'
-      }}
-    />
-  </>
-);
+type DragRange = {
+  start: number;
+  end: number;
+};
 
-const SlotButton: React.FC<{ slot: InterviewSlot; duration: number; startHour: number }> = ({
-  slot,
-  duration,
-  startHour
-}) => {
+const TimeBlock: React.FC<{ startHour: number; range: DragRange }> = ({ startHour, range }) => {
+  const backgroundStyle = (time: number): CSSProperties => {
+    if (time <= range.end && time >= range.start) {
+      return { background: 'green' };
+    }
+    return {};
+  };
+
+  return (
+    <>
+      <div
+        className={styles.timeslot}
+        style={{ ...backgroundStyle(startHour), borderBottomStyle: 'hidden' }}
+      />
+      <div
+        className={styles.timeslot}
+        style={{
+          ...backgroundStyle(startHour + 15),
+          borderTopStyle: 'hidden',
+          borderBottomStyle: 'dashed'
+        }}
+      />
+      <div
+        className={styles.timeslot}
+        style={{
+          ...backgroundStyle(startHour + 30),
+          borderTopStyle: 'dashed',
+          borderBottomStyle: 'hidden'
+        }}
+      />
+      <div
+        className={styles.timeslot}
+        style={{
+          ...backgroundStyle(startHour + 45),
+          borderTopStyle: 'hidden'
+        }}
+      />
+    </>
+  );
+};
+
+const SlotButton: React.FC<{
+  slot: InterviewSlot;
+  duration: number;
+  startHour: number;
+  tentative?: boolean;
+}> = ({ slot, duration, startHour, tentative = false }) => {
   const { setHoveredSlot, setSelectedSlot } = useSetSlotsContext();
   const slotStatus = useInterviewSlotStatus(slot);
   const isAdmin = useHasAdminPermission();
+  const { isEditing, setTentativeSlots } = useEditAvailabilityContext();
 
   const getMinutesFromStartOfDay = (unixTime: number) => {
     const date = new Date(unixTime);
     return date.getHours() * 60 + date.getMinutes();
   };
+
+  const removeTentativeSlot = () =>
+    setTentativeSlots((prev) =>
+      prev.filter(
+        (tentSlot) => tentSlot.room !== slot.room || tentSlot.startTime !== slot.startTime
+      )
+    );
 
   return (
     <div onMouseEnter={() => setHoveredSlot(slot)} onMouseLeave={() => setHoveredSlot(undefined)}>
@@ -53,10 +89,10 @@ const SlotButton: React.FC<{ slot: InterviewSlot; duration: number; startHour: n
         className={styles.slotButton}
         style={{
           top: PIXEL_PER_MINUTE * (getMinutesFromStartOfDay(slot.startTime) - startHour * 60),
-          height: duration / 60000
+          height: (duration / MILLISECONDS_PER_MINUTE) * PIXEL_PER_MINUTE
         }}
-        onClick={() => setSelectedSlot(slot)}
-        disabled={!isAdmin && slotStatus === 'occupied'}
+        onClick={isEditing ? () => removeTentativeSlot() : () => setSelectedSlot(slot)}
+        disabled={(isEditing && !tentative) || (!isAdmin && slotStatus === 'occupied')}
         color={slotStatus === 'possessed' ? 'green' : undefined}
       >
         {hourIndexToString(
@@ -71,39 +107,165 @@ const SlotButton: React.FC<{ slot: InterviewSlot; duration: number; startHour: n
 const SchedulerColumn: React.FC<{
   hours: number[];
   room: string;
+  day: number;
   slots: InterviewSlot[];
-  duration: number;
-}> = ({ hours, duration, room, slots }) => (
-  <div>
-    <p className={styles.roomName}>{room}</p>
-    <div className={styles.column}>
-      <div>
-        {hours.map((_) => (
-          <TimeBlock />
-        ))}
-      </div>
-      <div>
+  scheduler: InterviewScheduler;
+}> = ({ hours, day, scheduler, room, slots }) => {
+  const [dragRange, setDragRange] = useState<DragRange>({ start: -1, end: -1 });
+  const { isEditing, tentativeSlots, setTentativeSlots } = useEditAvailabilityContext();
+  const columnRef = useRef<HTMLDivElement>(null);
+
+  const members = useMembers();
+  const userEmail = useUserEmail();
+
+  const getMinuteFromDrag = (e: DragEvent<HTMLDivElement>) => {
+    if (!columnRef.current) return -1;
+    return (
+      (e.pageY - columnRef.current.getBoundingClientRect().top) / PIXEL_PER_MINUTE + hours[0] * 60
+    );
+  };
+
+  const handleDragStart = (e: DragEvent<HTMLDivElement>) => {
+    setDragRange({
+      start: getMinuteFromDrag(e),
+      end: getMinuteFromDrag(e)
+    });
+    e.dataTransfer.setDragImage(new Image(), 0, 0);
+  };
+
+  const overlap = (slot1: InterviewSlot, slot2: InterviewSlot) => {
+    const end1 = slot1.startTime + scheduler.duration;
+    const end2 = slot2.startTime + scheduler.duration;
+    return end2 > slot1.startTime && end1 > slot2.startTime;
+  };
+
+  const normalizedRange: DragRange =
+    dragRange.start <= dragRange.end
+      ? {
+          ...dragRange,
+          start: dragRange.start - (dragRange.start % 15)
+        }
+      : {
+          start: dragRange.end - (dragRange.end % 15),
+          end: dragRange.start
+        };
+
+  const handleDragEnd = (_: DragEvent<HTMLDivElement>) => {
+    const validSlots: InterviewSlot[] = [];
+    Array.from(
+      { length: Math.floor((normalizedRange.end - normalizedRange.start) / 15) },
+      (_, i) => normalizedRange.start + i * 15
+    ).forEach((startTime) => {
+      const tentativeSlot: InterviewSlot = {
+        interviewSchedulerUuid: scheduler.uuid,
+        startTime: day + startTime * MILLISECONDS_PER_MINUTE,
+        room,
+        lead: members.find((mem) => mem.email === userEmail) ?? null,
+        members: new Array(scheduler.membersPerSlot).map((x) => null),
+        applicant: null,
+        uuid: ''
+      };
+      if (
+        startTime >= hours[0] * 60 &&
+        startTime + scheduler.duration / MILLISECONDS_PER_MINUTE <=
+          (hours[hours.length - 1] + 1) * 60 &&
+        slots.every((slot) => !overlap(slot, tentativeSlot)) &&
+        validSlots.every((slot) => !overlap(slot, tentativeSlot)) &&
+        tentativeSlots.every(
+          (slot) => slot.room !== tentativeSlot.room || !overlap(slot, tentativeSlot)
+        )
+      )
+        validSlots.push(tentativeSlot);
+    });
+    setTentativeSlots((prev) => [...prev, ...validSlots]);
+
+    setDragRange({ start: -1, end: -1 });
+  };
+
+  const filteredTentativeSlots = tentativeSlots.filter(
+    (tentSlot) =>
+      tentSlot.startTime >= day &&
+      tentSlot.startTime < day + MILLISECONDS_PER_DAY &&
+      tentSlot.room === room
+  );
+
+  return (
+    <div>
+      {/* <p>
+        {bar} | {foo}
+      </p> */}
+      <p className={styles.roomName}>{room}</p>
+      <div className={styles.column} ref={columnRef}>
+        <div
+          draggable={isEditing}
+          ref={columnRef}
+          onDragStart={isEditing ? handleDragStart : undefined}
+          onDrag={(e) => {
+            if (e.pageY !== 0 && isEditing)
+              setDragRange({ ...dragRange, end: getMinuteFromDrag(e) });
+          }}
+          onDragEnd={isEditing ? handleDragEnd : undefined}
+        >
+          {hours.map((hour) => (
+            <TimeBlock key={hour} range={normalizedRange} startHour={hour * 60} />
+          ))}
+        </div>
         {slots.map((slot) => (
-          <SlotButton slot={slot} duration={duration} startHour={hours[0]} key={slot.uuid} />
+          <SlotButton
+            slot={slot}
+            duration={scheduler.duration}
+            startHour={hours[0]}
+            key={slot.uuid || `${slot.room}${slot.startTime}`}
+          />
         ))}
+        {isEditing &&
+          filteredTentativeSlots.map((slot) => (
+            <SlotButton
+              tentative
+              slot={slot}
+              duration={scheduler.duration}
+              startHour={hours[0]}
+              key={slot.uuid || `${slot.room}${slot.startTime}`}
+            />
+          ))}
       </div>
     </div>
-  </div>
-);
+  );
+};
 
-const MILLISECONDS_PER_DAY = 86400000;
+const getSlotsByRoom = (filteredSlots: InterviewSlot[]) =>
+  filteredSlots.reduce((acc, curr) => {
+    acc.set(curr.room, [...(acc.get(curr.room) || []), curr]);
+    return acc;
+  }, new Map<string, InterviewSlot[]>());
 
+const getHours = (filteredSlots: InterviewSlot[], duration: number) => {
+  const minHour = new Date(Math.min(...filteredSlots.map((slot) => slot.startTime))).getHours();
+  const maxHour = new Date(
+    duration + Math.max(...filteredSlots.map((slot) => slot.startTime))
+  ).getHours();
+  return Array.from({ length: maxHour - minHour + 1 }, (_, i) => minHour + i);
+};
 const SchedulingCalendar: React.FC<{
   scheduler: InterviewScheduler;
   slots: InterviewSlot[];
-  setSlots: Dispatch<SetStateAction<InterviewSlot[]>>;
-}> = ({ scheduler, slots, setSlots }) => {
-  const { setSelectedSlot } = useSetSlotsContext();
-  const [day, setDay] = useState(scheduler.startDate);
+}> = ({ scheduler, slots }) => {
+  const [day, setDay] = useState<number>(scheduler.startDate);
+  const [columnName, setColumnName] = useState<string>('');
 
-  const filteredSlots = slots.filter(
-    (slot) => slot.startTime >= day && slot.startTime <= day + MILLISECONDS_PER_DAY
+  const filteredSlots = useMemo(
+    () =>
+      slots.filter((slot) => slot.startTime >= day && slot.startTime < day + MILLISECONDS_PER_DAY),
+    [slots, day]
   );
+
+  const [slotsByRoom, setSlotsByRoom] = useState<Map<string, InterviewSlot[]>>(
+    getSlotsByRoom(filteredSlots)
+  );
+  const [hours, setHours] = useState<number[]>(getHours(filteredSlots, scheduler.duration));
+
+  const { setHoveredSlot, setSelectedSlot } = useSetSlotsContext();
+  const { isEditing } = useEditAvailabilityContext();
 
   const options = Array.from(
     {
@@ -115,19 +277,21 @@ const SchedulingCalendar: React.FC<{
     value: date
   }));
 
-  const slotsByRoom = filteredSlots.reduce((acc, curr) => {
-    acc.set(curr.room, [...(acc.get(curr.room) || []), curr]);
-    return acc;
-  }, new Map<string, InterviewSlot[]>());
+  const extendHours = (change: number) => {
+    const extendedHours: number[] = Array.from({ length: Math.abs(change) }, (_, i) =>
+      change < 0 ? hours[0] - i - 1 : hours[hours.length - 1] + i + 1
+    ).filter((x) => x >= 0 && x <= 23);
+    setHours(change < 0 ? [...extendedHours.reverse(), ...hours] : [...hours, ...extendedHours]);
+  };
 
-  const minHour = new Date(Math.min(...filteredSlots.map((slot) => slot.startTime))).getHours();
-  const maxHour = new Date(
-    scheduler.duration + Math.max(...filteredSlots.map((slot) => slot.startTime))
-  ).getHours();
-  const hours = Array.from({ length: maxHour - minHour + 1 }, (_, i) => minHour + i);
+  useEffect(() => {
+    setSlotsByRoom(getSlotsByRoom(filteredSlots));
+    const hours = getHours(filteredSlots, scheduler.duration);
+    setHours(hours.length === 0 ? [12] : hours);
+  }, [isEditing, filteredSlots, scheduler]);
 
   return (
-    <div className={styles.calendarContainer}>
+    <div className={isEditing ? styles.calendarContainerFull : styles.calendarContainer}>
       <Dropdown
         selection
         value={day}
@@ -135,20 +299,62 @@ const SchedulingCalendar: React.FC<{
         onChange={(_, data) => {
           setDay(data.value as number);
           setSelectedSlot(undefined);
+          setHoveredSlot(undefined);
         }}
       />
+      {isEditing && (
+        <div className={styles.roomForm}>
+          <Form>
+            <Form.Group style={{ margin: 0 }}>
+              <Form.Field
+                control={Input}
+                label="Room name"
+                placeholder="HLS110"
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  setColumnName(event.target.value)
+                }
+                value={columnName}
+              />
+            </Form.Group>
+          </Form>
+          <Button
+            basic
+            disabled={columnName === ''}
+            onClick={() => {
+              setSlotsByRoom(slotsByRoom.set(columnName, []));
+              setColumnName('');
+            }}
+          >
+            Add New Room
+          </Button>
+        </div>
+      )}
       <div className={styles.columnContainer}>
-        <div className={styles.timeLabelColumn}>
+        <div className={styles.timeLabelColumn} style={{ marginTop: isEditing ? '-12px' : '24px' }}>
+          {isEditing && (
+            <Button basic disabled={hours[0] === 0} onClick={() => extendHours(-4)}>
+              Extend
+            </Button>
+          )}
           {hours.map((hour) => (
-            <p className={styles.timeLabel}>{hourIndexToString(hour)}</p>
+            <p className={styles.timeLabel} key={hour}>
+              {hourIndexToString(hour)}
+            </p>
           ))}
+          {isEditing && (
+            <Button basic disabled={hours[hours.length - 1] === 23} onClick={() => extendHours(4)}>
+              Extend
+            </Button>
+          )}
         </div>
         {Array.from(slotsByRoom.entries()).map(([room, roomSlots]) => (
           <SchedulerColumn
             room={room}
+            day={day}
             slots={roomSlots}
-            duration={scheduler.duration}
+            scheduler={scheduler}
             hours={hours}
+            key={room}
           />
         ))}
       </div>

--- a/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.module.css
+++ b/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.module.css
@@ -1,0 +1,4 @@
+.sidebarContainer {
+  width: 40%;
+  padding-top: 4em;
+}

--- a/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.module.css
+++ b/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.module.css
@@ -1,4 +1,3 @@
-.sidebarContainer {
-  width: 40%;
-  padding-top: 4em;
+.buttonContainer {
+  margin-top: 1em;
 }

--- a/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
@@ -1,5 +1,5 @@
 import { Button, Dropdown } from 'semantic-ui-react';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { LEAD_ROLES } from 'common-types/constants';
 import { Emitters, getDateString, getTimeString } from '../../utils';
 import {
@@ -17,9 +17,8 @@ import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
 const SchedulingSidePanel: React.FC<{
   displayedSlot: InterviewSlot;
   scheduler: InterviewScheduler;
-  setSlots: Dispatch<SetStateAction<InterviewSlot[]>>;
   refresh: () => Promise<void>;
-}> = ({ displayedSlot, scheduler, setSlots, refresh }) => {
+}> = ({ displayedSlot, scheduler, refresh }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [lead, setLead] = useState(displayedSlot.lead);
   const [slotMembers, setSlotMembers] = useState(displayedSlot.members);
@@ -33,7 +32,7 @@ const SchedulingSidePanel: React.FC<{
   const isLead = self && LEAD_ROLES.includes(self.role);
 
   const slotStatus = useInterviewSlotStatus(displayedSlot);
-  const { setSelectedSlot } = useSetSlotsContext();
+  const { setSlots, setSelectedSlot } = useSetSlotsContext();
 
   useEffect(() => {
     setIsEditing(false);
@@ -201,6 +200,7 @@ const SchedulingSidePanel: React.FC<{
               {displayedSlot.members.map((member, index) =>
                 isEditing ? (
                   <Dropdown
+                    key={member?.netid}
                     selection
                     value={slotMembers[index]?.email}
                     options={memberOptions}
@@ -218,7 +218,7 @@ const SchedulingSidePanel: React.FC<{
                     }
                   />
                 ) : (
-                  <li>{displayNameOrVacant(member)}</li>
+                  <li key={member?.netid}>{displayNameOrVacant(member)}</li>
                 )
               )}
             </ul>
@@ -254,16 +254,13 @@ const SchedulingSidePanel: React.FC<{
       <div className={styles.buttonContainer}>
         {isAdmin && (
           <>
-            <InterviewSlotDeleteModal
-              slot={displayedSlot}
-              setSlots={setSlots}
-            />
+            <InterviewSlotDeleteModal slot={displayedSlot} setSlots={setSlots} />
             <Button basic onClick={handleAdminEditSave}>
               {isEditing ? 'Save' : 'Edit'}
             </Button>
             {isEditing && (
               <Button basic color="red" onClick={() => setIsEditing(false)}>
-                Cancel
+                Cancel Editing
               </Button>
             )}
           </>

--- a/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
@@ -265,7 +265,7 @@ const SchedulingSidePanel: React.FC<{
             )}
           </>
         )}
-        {!isLead && (slotStatus === 'possessed' || slotStatus === 'vacant') && (
+        {scheduler.isOpen && !isLead && (slotStatus === 'possessed' || slotStatus === 'vacant') && (
           <Button
             basic
             color={slotStatus === 'possessed' ? 'red' : undefined}

--- a/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
@@ -1,0 +1,65 @@
+import { getDateString, getTimeString } from '../../utils';
+import { useHasAdminPermission, useHasMemberPermission } from '../Common/FirestoreDataProvider';
+import { useUserEmail } from '../Common/UserProvider/UserProvider';
+import styles from './SchedulingSidePanel.module.css';
+
+const SchedulingSidePanel: React.FC<{
+  displayedSlot?: InterviewSlot;
+  duration: number;
+}> = ({ displayedSlot, duration }) => {
+  const isAdmin = useHasAdminPermission();
+  const isMember = useHasMemberPermission();
+  const userEmail = useUserEmail();
+
+  const displayNameOrVacant = (
+    person: { email: string; firstName: string; lastName: string } | null
+  ): string =>
+    person
+      ? `${person.firstName} ${person.lastName} ${person.email === userEmail ? '(You)' : ''}`
+      : 'Vacant';
+
+  const displayCensoredName = (
+    person: { email: string; firstName: string; lastName: string } | null
+  ): string => {
+    if (!person) return 'Vacant';
+    if (person.email === '') return 'Occupied';
+    return displayNameOrVacant(person);
+  };
+
+  return (
+    <div className={styles.sidebarContainer}>
+      <p>Scroll over to review timeslots. Click to show more information, sign up, or cancel.</p>
+      {displayedSlot && (
+        <div>
+          <p>Date: {getDateString(displayedSlot.startTime, true)}</p>
+          <p>
+            Time: {getTimeString(displayedSlot.startTime)} -{' '}
+            {getTimeString(displayedSlot.startTime + duration)}
+          </p>
+          <p>Room: {displayedSlot.room}</p>
+          {isMember && (
+            <div>
+              <p>Lead: {displayNameOrVacant(displayedSlot.lead)}</p>
+              <p>Members:</p>
+              <ul>
+                {displayedSlot.members.map((member) => (
+                  <li>{displayNameOrVacant(member)}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {(isAdmin || !isMember) && (
+            <p>
+              Applicant:{' '}
+              {isAdmin
+                ? displayNameOrVacant(displayedSlot.applicant)
+                : displayCensoredName(displayedSlot.applicant)}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SchedulingSidePanel;

--- a/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
@@ -1,63 +1,283 @@
-import { getDateString, getTimeString } from '../../utils';
-import { useHasAdminPermission, useHasMemberPermission } from '../Common/FirestoreDataProvider';
+import { Button, Dropdown } from 'semantic-ui-react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { LEAD_ROLES } from 'common-types/constants';
+import { Emitters, getDateString, getTimeString } from '../../utils';
+import {
+  useHasAdminPermission,
+  useHasMemberPermission,
+  useMember,
+  useMembers
+} from '../Common/FirestoreDataProvider';
 import { useUserEmail } from '../Common/UserProvider/UserProvider';
+import InterviewSlotDeleteModal from '../Modals/InterviewSlotDeleteModal';
 import styles from './SchedulingSidePanel.module.css';
+import { useInterviewSlotStatus, useSetSlotsContext } from './SlotHooks';
+import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
 
 const SchedulingSidePanel: React.FC<{
-  displayedSlot?: InterviewSlot;
-  duration: number;
-}> = ({ displayedSlot, duration }) => {
+  displayedSlot: InterviewSlot;
+  scheduler: InterviewScheduler;
+  setSlots: Dispatch<SetStateAction<InterviewSlot[]>>;
+  refresh: () => Promise<void>;
+}> = ({ displayedSlot, scheduler, setSlots, refresh }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [lead, setLead] = useState(displayedSlot.lead);
+  const [slotMembers, setSlotMembers] = useState(displayedSlot.members);
+  const [applicant, setApplicant] = useState(displayedSlot.applicant);
+
   const isAdmin = useHasAdminPermission();
   const isMember = useHasMemberPermission();
   const userEmail = useUserEmail();
+  const members = useMembers();
+  const self = useMember(userEmail);
+  const isLead = self && LEAD_ROLES.includes(self.role);
 
-  const displayNameOrVacant = (
-    person: { email: string; firstName: string; lastName: string } | null
-  ): string =>
-    person
-      ? `${person.firstName} ${person.lastName} ${person.email === userEmail ? '(You)' : ''}`
-      : 'Vacant';
+  const slotStatus = useInterviewSlotStatus(displayedSlot);
+  const { setSelectedSlot } = useSetSlotsContext();
 
-  const displayCensoredName = (
-    person: { email: string; firstName: string; lastName: string } | null
-  ): string => {
-    if (!person) return 'Vacant';
-    if (person.email === '') return 'Occupied';
+  useEffect(() => {
+    setIsEditing(false);
+    setLead(displayedSlot.lead);
+    setSlotMembers(displayedSlot.members);
+    setApplicant(displayedSlot.applicant);
+  }, [displayedSlot]);
+
+  const getMember = (email: string): IdolMember | null =>
+    members.find((mem) => mem.email === email) ?? null;
+
+  const leadOptions = [
+    { text: 'Vacant' },
+    ...members
+      .filter((mem) => LEAD_ROLES.includes(mem.role))
+      .map((mem) => ({
+        text: `${mem.firstName} ${mem.lastName}`,
+        value: mem.email
+      }))
+  ];
+
+  const memberOptions = [
+    { text: 'Vacant' },
+    ...members
+      .filter((mem) => !LEAD_ROLES.includes(mem.role))
+      .map((mem) => ({
+        text: `${mem.firstName} ${mem.lastName}`,
+        value: mem.email
+      }))
+  ];
+
+  const applicantOptions = [
+    { text: 'Vacant' },
+    ...scheduler.applicants.map((app) => ({
+      text: `${app.firstName} ${app.lastName}`,
+      value: app.email
+    }))
+  ];
+
+  const displayNameOrVacant = (person: Applicant | null) =>
+    person ? (
+      <span>
+        {`${person.firstName} ${person.lastName}`} {person.email === userEmail && <em>(You)</em>}
+      </span>
+    ) : (
+      <strong>Vacant</strong>
+    );
+
+  const displayCensoredName = (person: Applicant | null) => {
+    if (!person) return <strong>Vacant</strong>;
+    if (person.email === '') return <strong>Occupied</strong>;
     return displayNameOrVacant(person);
   };
 
+  const handleAdminEditSave = () => {
+    if (!isEditing) {
+      setIsEditing(true);
+      return;
+    }
+
+    const edits: InterviewSlotEdit = {
+      uuid: displayedSlot.uuid,
+      interviewSchedulerUuid: displayedSlot.interviewSchedulerUuid,
+      lead,
+      members: slotMembers,
+      applicant
+    };
+
+    InterviewSchedulerAPI.updateSlot(edits, false).then((val) => {
+      setIsEditing(false);
+      setSelectedSlot(undefined);
+      if (val) {
+        setSlots((prev) =>
+          prev.map((slot) => (slot.uuid === edits.uuid ? { ...slot, ...edits } : slot))
+        );
+        Emitters.generalSuccess.emit({
+          headerMsg: 'Edit Time Slot',
+          contentMsg: `You have successfully edited time slot!`
+        });
+      } else {
+        Emitters.generalError.emit({
+          headerMsg: 'Edit Time Slot',
+          contentMsg: 'Could not edit time slot!'
+        });
+      }
+    });
+  };
+
+  const handleSignUpCancel = (isSigningUp: boolean) => {
+    const leadEdit = isSigningUp ? getMember(userEmail) : null;
+    const applicantEdit = isSigningUp
+      ? scheduler.applicants.find((app) => app.email === userEmail)
+      : null;
+    let membersEdit: (IdolMember | null)[];
+    if (isSigningUp) {
+      const index = slotMembers.findIndex((item) => item === null);
+      membersEdit =
+        index !== -1
+          ? [...slotMembers.slice(0, index), getMember(userEmail), ...slotMembers.slice(index + 1)]
+          : slotMembers;
+    } else {
+      membersEdit = slotMembers.map((mem) => {
+        if (!mem) return null;
+        return mem.email === userEmail ? null : mem;
+      });
+    }
+
+    const edits: InterviewSlotEdit = {
+      uuid: displayedSlot.uuid,
+      interviewSchedulerUuid: displayedSlot.interviewSchedulerUuid,
+      lead: isLead ? leadEdit : undefined,
+      applicant: !isMember ? applicantEdit : undefined,
+      members: isMember && !isLead ? membersEdit : undefined
+    };
+
+    InterviewSchedulerAPI.updateSlot(edits, !isMember).then((val) => {
+      setSelectedSlot(undefined);
+      if (val) {
+        setSlots((prev) =>
+          prev.map((slot) => (slot.uuid === edits.uuid ? { ...slot, ...edits } : slot))
+        );
+        Emitters.generalSuccess.emit({
+          headerMsg: `${isSigningUp ? 'Sign Up' : 'Cancel'} Time Slot`,
+          contentMsg: `You have successfully ${isSigningUp ? 'signed up for this' : 'cancelled'} time slot!`
+        });
+      } else {
+        Emitters.generalError.emit({
+          headerMsg: `${isSigningUp ? 'Sign Up' : 'Cancel'} Time Slot`,
+          contentMsg: `Could not ${isSigningUp ? 'sign up for this' : 'cancel'} time slot. Another user may have edited this time slot already.`
+        });
+        refresh();
+        setSelectedSlot(undefined);
+      }
+    });
+  };
+
   return (
-    <div className={styles.sidebarContainer}>
-      <p>Scroll over to review timeslots. Click to show more information, sign up, or cancel.</p>
-      {displayedSlot && (
-        <div>
-          <p>Date: {getDateString(displayedSlot.startTime, true)}</p>
-          <p>
-            Time: {getTimeString(displayedSlot.startTime)} -{' '}
-            {getTimeString(displayedSlot.startTime + duration)}
-          </p>
-          <p>Room: {displayedSlot.room}</p>
-          {isMember && (
+    <div>
+      <p>Date: {getDateString(displayedSlot.startTime, true)}</p>
+      <p>
+        Time: {getTimeString(displayedSlot.startTime)} -{' '}
+        {getTimeString(displayedSlot.startTime + scheduler.duration)}
+      </p>
+      <p>Room: {displayedSlot.room}</p>
+      <hr />
+      {isMember && (
+        <>
+          <div>
             <div>
-              <p>Lead: {displayNameOrVacant(displayedSlot.lead)}</p>
-              <p>Members:</p>
-              <ul>
-                {displayedSlot.members.map((member) => (
-                  <li>{displayNameOrVacant(member)}</li>
-                ))}
-              </ul>
+              <p>Lead: {!isEditing && displayNameOrVacant(displayedSlot.lead)}</p>
+              {isEditing && (
+                <Dropdown
+                  search
+                  selection
+                  value={lead?.email}
+                  options={leadOptions}
+                  onChange={(_, data) =>
+                    setLead(data.value === undefined ? null : getMember(data.value as string))
+                  }
+                />
+              )}
             </div>
-          )}
-          {(isAdmin || !isMember) && (
-            <p>
-              Applicant:{' '}
-              {isAdmin
-                ? displayNameOrVacant(displayedSlot.applicant)
-                : displayCensoredName(displayedSlot.applicant)}
-            </p>
+            <p>Members:</p>
+            <ul>
+              {displayedSlot.members.map((member, index) =>
+                isEditing ? (
+                  <Dropdown
+                    selection
+                    value={slotMembers[index]?.email}
+                    options={memberOptions}
+                    onChange={(_, data) =>
+                      setSlotMembers(
+                        slotMembers.map((mem, i) => {
+                          if (i === index) {
+                            return data.value === undefined
+                              ? null
+                              : getMember(data.value as string);
+                          }
+                          return mem;
+                        })
+                      )
+                    }
+                  />
+                ) : (
+                  <li>{displayNameOrVacant(member)}</li>
+                )
+              )}
+            </ul>
+          </div>
+          <hr />
+        </>
+      )}
+      {(isAdmin || !isMember) && (
+        <div>
+          <p>
+            Applicant:{' '}
+            {isAdmin && !isEditing
+              ? displayNameOrVacant(displayedSlot.applicant)
+              : displayCensoredName(displayedSlot.applicant)}
+          </p>
+          {isEditing && (
+            <Dropdown
+              selection
+              value={applicant?.email}
+              options={applicantOptions}
+              onChange={(_, data) => {
+                setApplicant(
+                  data.value === undefined
+                    ? null
+                    : scheduler.applicants.find((app) => app.email === (data.value as string)) ??
+                        null
+                );
+              }}
+            />
           )}
         </div>
       )}
+      <div className={styles.buttonContainer}>
+        {isAdmin && (
+          <>
+            <InterviewSlotDeleteModal
+              slot={displayedSlot}
+              setSlots={setSlots}
+            />
+            <Button basic onClick={handleAdminEditSave}>
+              {isEditing ? 'Save' : 'Edit'}
+            </Button>
+            {isEditing && (
+              <Button basic color="red" onClick={() => setIsEditing(false)}>
+                Cancel
+              </Button>
+            )}
+          </>
+        )}
+        {!isLead && (slotStatus === 'possessed' || slotStatus === 'vacant') && (
+          <Button
+            basic
+            color={slotStatus === 'possessed' ? 'red' : undefined}
+            onClick={() => handleSignUpCancel(slotStatus === 'vacant')}
+          >
+            {slotStatus === 'possessed' ? 'Cancel' : 'Sign Up'}
+          </Button>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/Interview-Scheduler/SlotHooks.tsx
+++ b/frontend/src/components/Interview-Scheduler/SlotHooks.tsx
@@ -4,8 +4,16 @@ import { useHasMemberPermission, useMember } from '../Common/FirestoreDataProvid
 import { useUserEmail } from '../Common/UserProvider/UserProvider';
 
 export const SetSlotsContext = createContext<{
+  setSlots: Dispatch<SetStateAction<InterviewSlot[]>>;
   setSelectedSlot: Dispatch<SetStateAction<InterviewSlot | undefined>>;
   setHoveredSlot: Dispatch<SetStateAction<InterviewSlot | undefined>>;
+} | null>(null);
+
+export const EditAvailabilityContext = createContext<{
+  isEditing: boolean;
+  setIsEditing: Dispatch<SetStateAction<boolean>>;
+  tentativeSlots: InterviewSlot[];
+  setTentativeSlots: Dispatch<SetStateAction<InterviewSlot[]>>;
 } | null>(null);
 
 export const useInterviewSlotStatus = (slot: InterviewSlot): SlotStatus => {
@@ -33,4 +41,10 @@ export const useSetSlotsContext = () => {
   const setSlotsContext = useContext(SetSlotsContext);
   if (!setSlotsContext) throw new Error('No SetSlotsContext value provided.');
   return setSlotsContext;
+};
+
+export const useEditAvailabilityContext = () => {
+  const editAvailabilityContext = useContext(EditAvailabilityContext);
+  if (!editAvailabilityContext) throw new Error('No EditAvailabilityContext value provided.');
+  return editAvailabilityContext;
 };

--- a/frontend/src/components/Interview-Scheduler/SlotHooks.tsx
+++ b/frontend/src/components/Interview-Scheduler/SlotHooks.tsx
@@ -1,0 +1,36 @@
+import { LEAD_ROLES } from 'common-types/constants';
+import { createContext, Dispatch, SetStateAction, useContext } from 'react';
+import { useHasMemberPermission, useMember } from '../Common/FirestoreDataProvider';
+import { useUserEmail } from '../Common/UserProvider/UserProvider';
+
+export const SetSlotsContext = createContext<{
+  setSelectedSlot: Dispatch<SetStateAction<InterviewSlot | undefined>>;
+  setHoveredSlot: Dispatch<SetStateAction<InterviewSlot | undefined>>;
+} | null>(null);
+
+export const useInterviewSlotStatus = (slot: InterviewSlot): SlotStatus => {
+  const isMember = useHasMemberPermission();
+  const userEmail = useUserEmail();
+
+  const self = useMember(userEmail);
+  const isLead = self !== undefined && LEAD_ROLES.includes(self.role);
+
+  if (isLead) {
+    if (slot.lead === null) return 'vacant';
+    return slot.lead !== null && slot.lead.email === userEmail ? 'possessed' : 'occupied';
+  }
+  if (isMember) {
+    if (slot.members.some((mem) => mem === null)) return 'vacant';
+    return slot.members.some((mem) => mem !== null && mem.email === userEmail)
+      ? 'possessed'
+      : 'occupied';
+  }
+  if (slot.applicant === null) return 'vacant';
+  return slot.applicant !== null && slot.applicant.email === userEmail ? 'possessed' : 'occupied';
+};
+
+export const useSetSlotsContext = () => {
+  const setSlotsContext = useContext(SetSlotsContext);
+  if (!setSlotsContext) throw new Error('No SetSlotsContext value provided.');
+  return setSlotsContext;
+};

--- a/frontend/src/components/Modals/InterviewSchedulerDeleteModal.tsx
+++ b/frontend/src/components/Modals/InterviewSchedulerDeleteModal.tsx
@@ -1,0 +1,44 @@
+import { Button, Modal } from 'semantic-ui-react';
+import { useState } from 'react';
+import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
+
+const InterviewSchedulerDeleteModal: React.FC<{
+  uuid: string;
+  setInstances: React.Dispatch<React.SetStateAction<InterviewScheduler[]>>;
+}> = ({ uuid, setInstances }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Modal
+      onClose={() => setIsOpen(false)}
+      onOpen={() => setIsOpen(true)}
+      open={isOpen}
+      trigger={<Button negative>Delete</Button>}
+    >
+      <Modal.Header>
+        Are you sure you want to delete this Interview Scheduler instance?
+      </Modal.Header>
+      <Modal.Content>
+        Deleting this instance will delete all time slots associated with this instance.
+      </Modal.Content>
+      <Modal.Actions>
+        <Button negative onClick={() => setIsOpen(false)}>
+          No
+        </Button>
+        <Button
+          positive
+          onClick={() => {
+            InterviewSchedulerAPI.deleteInstance(uuid).then(() => {
+              setInstances((instances) => instances.filter((inst) => inst.uuid !== uuid));
+            });
+            setIsOpen(false);
+          }}
+        >
+          Yes
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default InterviewSchedulerDeleteModal;

--- a/frontend/src/components/Modals/InterviewSlotDeleteModal.tsx
+++ b/frontend/src/components/Modals/InterviewSlotDeleteModal.tsx
@@ -1,0 +1,42 @@
+import { Button, Modal } from 'semantic-ui-react';
+import { Dispatch, SetStateAction, useState } from 'react';
+import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
+import { useSetSlotsContext } from '../Interview-Scheduler/SlotHooks';
+
+const InterviewSlotDeleteModal: React.FC<{
+  slot: InterviewSlot;
+  setSlots: Dispatch<SetStateAction<InterviewSlot[]>>;
+}> = ({ slot, setSlots }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { setSelectedSlot } = useSetSlotsContext();
+
+  return (
+    <Modal
+      onClose={() => setIsOpen(false)}
+      onOpen={() => setIsOpen(true)}
+      open={isOpen}
+      trigger={<Button negative>Delete</Button>}
+    >
+      <Modal.Header>Are you sure you want to delete this time slot?</Modal.Header>
+      <Modal.Actions>
+        <Button negative onClick={() => setIsOpen(false)}>
+          No
+        </Button>
+        <Button
+          positive
+          onClick={() => {
+            InterviewSchedulerAPI.deleteSlot(slot.uuid).then(() => {
+              setSelectedSlot(undefined);
+              setIsOpen(false);
+              setSlots((slots) => slots.filter((sl) => sl.uuid !== slot.uuid));
+            });
+          }}
+        >
+          Yes
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default InterviewSlotDeleteModal;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -136,8 +136,8 @@ const RoutingMiddleware: React.FC<{ children: ReactNode }> = ({ children }) => {
   const router = useRouter();
   const hasMemberPermissions = useHasMemberPermission();
 
-  if (!router.pathname.startsWith('/applicant') && !hasMemberPermissions) {
-    router.push('/applicant');
+  if (!router.pathname.startsWith('/interview-scheduler') && !hasMemberPermissions) {
+    router.push('/interview-scheduler');
   }
 
   return <>{children}</>;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -129,6 +129,12 @@ const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermis
         Candidate Decider
       </Menu.Item>
     </Link>
+    <Link href="/interview-scheduler">
+      <Menu.Item>
+        <Icon name="users" />
+        Interview Scheduler
+      </Menu.Item>
+    </Link>
   </>
 );
 

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -70,6 +70,12 @@ const navCardItems: readonly NavigationCardItem[] = [
     description: 'Review coffee chat submissions!',
     link: '/admin/coffee-chats',
     adminOnly: true
+  },
+  {
+    header: 'Edit Interview Scheduler',
+    description: 'Create or edit interview scheduler instances',
+    link: '/admin/interview-scheduler',
+    adminOnly: true
   }
 ];
 

--- a/frontend/src/pages/admin/interview-scheduler.tsx
+++ b/frontend/src/pages/admin/interview-scheduler.tsx
@@ -1,0 +1,3 @@
+import AdminInterviewSchedulerBase from "../../components/Admin/AdminInterviewScheduler/AdminInterviewScheduler";
+
+export default AdminInterviewSchedulerBase;

--- a/frontend/src/pages/admin/interview-scheduler.tsx
+++ b/frontend/src/pages/admin/interview-scheduler.tsx
@@ -1,3 +1,3 @@
-import AdminInterviewSchedulerBase from "../../components/Admin/AdminInterviewScheduler/AdminInterviewScheduler";
+import AdminInterviewSchedulerBase from '../../components/Admin/AdminInterviewScheduler/AdminInterviewScheduler';
 
 export default AdminInterviewSchedulerBase;

--- a/frontend/src/pages/applicant/index.tsx
+++ b/frontend/src/pages/applicant/index.tsx
@@ -1,3 +1,0 @@
-const Page = () => <div>Applicant Page</div>;
-
-export default Page;

--- a/frontend/src/pages/interview-scheduler/[uuid].tsx
+++ b/frontend/src/pages/interview-scheduler/[uuid].tsx
@@ -1,0 +1,10 @@
+import { useRouter } from 'next/router';
+import InterviewScheduler from '../../components/Interview-Scheduler/InterviewScheduler';
+
+const InterviewSchedulerPage: React.FC = () => {
+  const router = useRouter();
+  const { uuid } = router.query;
+  return <InterviewScheduler uuid={uuid as string} />;
+};
+
+export default InterviewSchedulerPage;

--- a/frontend/src/pages/interview-scheduler/index.tsx
+++ b/frontend/src/pages/interview-scheduler/index.tsx
@@ -1,3 +1,3 @@
-const Page = () => <div>Interview Scheduler Page</div>;
+import InterviewSchedulerList from "../../components/Interview-Scheduler/InterviewSchedulerList";
 
-export default Page;
+export default InterviewSchedulerList;

--- a/frontend/src/pages/interview-scheduler/index.tsx
+++ b/frontend/src/pages/interview-scheduler/index.tsx
@@ -1,3 +1,3 @@
-import InterviewSchedulerList from "../../components/Interview-Scheduler/InterviewSchedulerList";
+import InterviewSchedulerList from '../../components/Interview-Scheduler/InterviewSchedulerList';
 
 export default InterviewSchedulerList;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -182,3 +182,15 @@ export const formatLink = (link: string, linkType?: LinkType): string | undefine
 
   return extractedLink;
 };
+
+export const getDayNameFromDate = (date: Date) => {
+  const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  return dayNames[date.getDay()];
+};
+
+export const hourIndexToString = (hourIndex: number, minute?: number): string => {
+  const hour = hourIndex % 12 || 12;
+  const suffix = hourIndex < 12 ? 'AM' : 'PM';
+
+  return `${hour}:${minute ? String(minute).padStart(2, '0') : '00'} ${suffix}`;
+};

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -183,14 +183,25 @@ export const formatLink = (link: string, linkType?: LinkType): string | undefine
   return extractedLink;
 };
 
-export const getDayNameFromDate = (date: Date) => {
-  const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-  return dayNames[date.getDay()];
-};
-
 export const hourIndexToString = (hourIndex: number, minute?: number): string => {
   const hour = hourIndex % 12 || 12;
   const suffix = hourIndex < 12 ? 'AM' : 'PM';
+
+  return `${hour}:${minute ? String(minute).padStart(2, '0') : '00'} ${suffix}`;
+};
+
+export const getDateString = (unixTime: number, includeDayName: boolean): string => {
+  const date = new Date(unixTime);
+  const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  const dayName = dayNames[date.getDay()];
+  return `${includeDayName ? `${dayName} ` : ''}${1 + date.getMonth()}/${date.getDate()}`;
+};
+
+export const getTimeString = (unixTime: number): string => {
+  const date = new Date(unixTime);
+  const hour = date.getHours() % 12 || 12;
+  const suffix = date.getHours() < 12 ? 'AM' : 'PM';
+  const minute = date.getMinutes();
 
   return `${hour}:${minute ? String(minute).padStart(2, '0') : '00'} ${suffix}`;
 };


### PR DESCRIPTION
### Summary <!-- Required -->
This PR implements an MVP of the interview scheduler. Admins are allowed to create new scheduler instances at `/admin/interview-scheduler`. There is currently no way to modify an existing instance, other than opening/closing the scheduler. The rest of the feature happens at `/interview-scheduler/[uuid]`. 

Applicants are only allowed to access schedulers in which they are applicants of. They can sign themselves up for a time slot, after which they can view the time slot they signed up for. If needed, they can request a time slot change via email, and a lead will change it on the scheduler. They cannot see which lead/member(s) signed up for this slot.

Members can navigate to the same page and sign up for interview slot(s). They cannot see which applicant, if any, signed up for this slot.

Admins can also follow the same process, but can see every parties' identity. Admins can also edit each party via a dropdown menu. They can add availabilities through a button on the top right. Deleting time slots was made intentionally tedious due to its implications. 

The backend should prevent any sensitive information from being sent back to the client, if that client is not a DTI member. 

Bug Fixes:
* There was a bug that allowed anyone to log into IDOL introduced in the last PR.

### Notion/Figma Link <!-- Optional -->
[Figma](https://www.figma.com/design/G5m5N7c1opQFGBVMM1Uvg4/IDOL-Recruitment-Tool-(Copy)?node-id=1-4&p=f&t=fveBttyqguXzKz8b-0)
<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->
Playtesting at 2/1 12 - 1!

### Notes <!-- Optional -->

Sorry for the big PR.