### PR TITLE
IDOL: Update coffee chat bingo board for SP25

### DIFF
--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -65,15 +65,12 @@ export const createCoffeeChat = async (
     'approved',
     coffeeChat.otherMember
   );
-  const prevChats = [
-    ...pendingChats.filter((chat) => !chat.isArchived),
-    ...approvedChats.filter((chat) => !chat.isArchived)
-  ];
+  const prevChats = [...pendingChats, ...approvedChats];
   const chatExists = prevChats.length > 0;
 
   if (chatExists) {
     throw new Error(
-      'Cannot create coffee chat with member. Previous coffee chats from previous semesters exist.'
+      'Cannot create coffee chat with member. Coffee chats from current or previous semesters exist.'
     );
   }
 

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -2,9 +2,8 @@ import { Request } from 'express';
 import CoffeeChatDao from '../dao/CoffeeChatDao';
 import PermissionsManager from '../utils/permissionsManager';
 import { BadRequestError, PermissionError } from '../utils/errors';
-import { getMember, allMembers } from './memberAPI';
-import { LEAD_ROLES } from '../consts';
-import { getGeneralRoleFromLeadType } from '../utils/memberUtil';
+import { getMember } from './memberAPI';
+import { ADVISOR_ROLES } from '../consts';
 import { sendCoffeeChatReminder } from './mailAPI';
 
 const coffeeChatDao = new CoffeeChatDao();
@@ -203,138 +202,22 @@ export const checkMemberMeetsCategory = async (
   submitterEmail: string,
   category: string
 ): Promise<{ status: MemberMeetsCategoryStatus; message: string }> => {
-  const otherMemberProperties = await CoffeeChatDao.getMemberProperties(otherMemberEmail);
-  const submitterProperties = await CoffeeChatDao.getMemberProperties(submitterEmail);
   const otherMember = await getMember(otherMemberEmail);
   const submitter = await getMember(submitterEmail);
-  const haveNoCommonSubteams = (member1: IdolMember, member2: IdolMember): boolean =>
-    member2.subteams.every((team) => !member1.subteams.includes(team)) &&
-    member1.subteams.every((team) => !member2.subteams.includes(team));
   let status: MemberMeetsCategoryStatus = 'no data';
   let message: string = '';
 
-  // If otherMember doesn't exist in the DB, assume they are an alumni
-  if (!otherMember && category === 'an alumni') {
-    return { status: 'pass', message };
-  }
-
   // If otherMember and submitter don't exist, status should stay undefined
   if (otherMember && submitter) {
-    if (category === 'an alumni') {
-      status = (await allMembers()).every((member) => member.email !== otherMember.email)
-        ? 'pass'
-        : 'fail';
+    if (category === 'a newbie') {
+      status = otherMember.semesterJoined === 'Spring 2025' ? 'pass' : 'fail';
       if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember.lastName} is not an alumni`;
+        message = `${otherMember.firstName} ${otherMember.lastName} is not a newbie`;
       }
-    } else if (category === 'courseplan member') {
-      status = otherMember.subteams.includes('courseplan') ? 'pass' : 'fail';
+    } else if (category === 'is an advisor') {
+      status = ADVISOR_ROLES.includes(otherMember.role) ? 'pass' : 'fail';
       if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember?.lastName} is not a CoursePlan member`;
-      }
-    } else if (category === 'business member') {
-      status = otherMember.role === 'business' ? 'pass' : 'fail';
-      if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember.lastName} is not a business member`;
-      }
-    } else if (category === 'idol member') {
-      status = otherMember.subteams.includes('idol') ? 'pass' : 'fail';
-      if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember.lastName} is not an IDOL member`;
-      }
-    } else if (category === 'curaise member') {
-      status = otherMember.subteams.includes('curaise') ? 'pass' : 'fail';
-      if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember.lastName} is not a CURaise member`;
-      }
-    } else if (category === 'cornellgo member') {
-      status = otherMember.subteams.includes('cornellgo') ? 'pass' : 'fail';
-      if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember.lastName} is not a CornellGo member`;
-      }
-    } else if (category === 'carriage member') {
-      status = otherMember.subteams.includes('carriage') ? 'pass' : 'fail';
-      if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember.lastName} is not a Carriage member`;
-      }
-    } else if (category === 'qmi member') {
-      status = otherMember.subteams.includes('queuemein') ? 'pass' : 'fail';
-      if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember.lastName} is not a QMI member`;
-      }
-    } else if (category === 'cuapts member') {
-      status = otherMember.subteams.includes('cuapts') ? 'pass' : 'fail';
-      if (status === 'fail') {
-        message = `${otherMember.firstName} ${otherMember.lastName} is not a CUApts member`;
-      }
-    } else if (category === 'a pm (not your team)') {
-      const isPm = otherMember.role === 'pm';
-      const notSameTeam = haveNoCommonSubteams(submitter, otherMember);
-      status = isPm && notSameTeam ? 'pass' : 'fail';
-      if (status === 'fail') {
-        if (!isPm) {
-          message = `${otherMember.firstName} ${otherMember.lastName} is not a PM`;
-        } else {
-          message = `${otherMember.firstName} ${otherMember.lastName} is a PM, but is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
-        }
-      }
-    } else if (category === 'a tpm (not your team)') {
-      const isTpm = otherMember.role === 'tpm';
-      const notSameTeam = haveNoCommonSubteams(submitter, otherMember);
-      status = isTpm && notSameTeam ? 'pass' : 'fail';
-      if (status === 'fail') {
-        if (!isTpm) {
-          message = `${otherMember.firstName} ${otherMember.lastName} is not a TPM`;
-        } else {
-          message = `${otherMember.firstName} ${otherMember.lastName} is a TPM, but is on the same team as ${submitter?.firstName} ${submitter?.lastName}`;
-        }
-      }
-    }
-
-    // If otherMemberProperties doesn't exist, status should stay undefined
-    if (otherMemberProperties) {
-      if (category === 'a newbie') {
-        status = otherMemberProperties.newbie ? 'pass' : 'fail';
-        if (status === 'fail') {
-          message = `${otherMember.firstName} ${otherMember.lastName} is not a newbie`;
-        }
-      } else if (category === 'is/was a TA') {
-        status = otherMemberProperties.ta ? 'pass' : 'fail';
-        if (status === 'fail') {
-          message = `${otherMember.firstName} ${otherMember.lastName} was never a TA`;
-        }
-      } else if (category === 'major/minor that is not cs/infosci') {
-        status = otherMemberProperties.notCsOrInfosci ? 'pass' : 'fail';
-        if (status === 'fail') {
-          message = `${otherMember.firstName} ${otherMember.lastName} is a CS or Infosci major`;
-        }
-      }
-
-      // If submitterProperties doesn't exist, status should stay undefined
-      if (submitterProperties) {
-        if (category === 'from a different college') {
-          status = otherMemberProperties.college !== submitterProperties.college ? 'pass' : 'fail';
-          if (status === 'fail') {
-            message = `${otherMember.firstName} ${otherMember.lastName} is from the same college as ${submitter.firstName} ${submitter.lastName} (${otherMemberProperties.college})`;
-          }
-        }
-      }
-    }
-
-    if (category === 'a lead (not your role)') {
-      const isLead = LEAD_ROLES.includes(otherMember.role);
-      if (!isLead) {
-        status = 'fail';
-        message = `${otherMember.firstName} ${otherMember.lastName} is not a lead`;
-      } else {
-        const diffRole = !LEAD_ROLES.includes(submitter.role)
-          ? getGeneralRoleFromLeadType(otherMember.role) !== submitter.role
-          : getGeneralRoleFromLeadType(otherMember.role) !==
-            getGeneralRoleFromLeadType(submitter.role);
-        status = diffRole ? 'pass' : 'fail';
-        if (!diffRole) {
-          message = `${otherMember.firstName} ${otherMember.lastName} is a lead, but from the same role (${submitter.role}) as ${submitter.firstName} ${submitter.lastName}`;
-        }
+        message = `${otherMember.firstName} ${otherMember.lastName} is not an advisor`;
       }
     }
   }

--- a/backend/src/API/coffeeChatAPI.ts
+++ b/backend/src/API/coffeeChatAPI.ts
@@ -65,7 +65,10 @@ export const createCoffeeChat = async (
     'approved',
     coffeeChat.otherMember
   );
-  const prevChats = [...pendingChats, ...approvedChats];
+  const prevChats = [
+    ...pendingChats.filter((chat) => !chat.isArchived),
+    ...approvedChats.filter((chat) => !chat.isArchived)
+  ];
   const chatExists = prevChats.length > 0;
 
   if (chatExists) {

--- a/backend/src/consts.ts
+++ b/backend/src/consts.ts
@@ -1,8 +1,8 @@
 const COFFEE_CHAT_BINGO_BOARD = [
-  ['an alumni', 'courseplan member', 'a pm (not your team)', 'business member'],
-  ['is/was a TA', 'major/minor that is not cs/infosci', 'idol member', 'a newbie'],
-  ['from a different college', 'curaise member', 'cornellgo member', 'a tpm (not your team)'],
-  ['carriage member', 'qmi member', 'a lead (not your role)', 'cuapts member']
+  ['has studied abroad', 'a newbie', 'plays DTI on roblox', 'sleeps before 12am'],
+  ['double major', 'uses windows', 'is an advisor', 'loves to cook'],
+  ['attended a hackathon', 'collects blindboxes', 'lives in ctown', 'plays a sport'],
+  ['lives on west', 'is left handed', 'has a digital camera', 'loves to eat']
 ];
 
 export default COFFEE_CHAT_BINGO_BOARD;

--- a/backend/src/consts.ts
+++ b/backend/src/consts.ts
@@ -2,7 +2,7 @@ const COFFEE_CHAT_BINGO_BOARD = [
   ['has studied abroad', 'a newbie', 'plays DTI on roblox', 'sleeps before 12am'],
   ['double major', 'uses windows', 'is an advisor', 'loves to cook'],
   ['attended a hackathon', 'collects blindboxes', 'lives in ctown', 'plays a sport'],
-  ['lives on west', 'is left handed', 'has a digital camera', 'loves to eat']
+  ['lives on west', 'is left handed', 'has a digital camera', 'loves pineapple on pizza']
 ];
 
 export default COFFEE_CHAT_BINGO_BOARD;

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -115,6 +115,7 @@ export type DBCoffeeChat = {
   category: string;
   status: Status;
   date: number;
+  isArchived: false;
   memberMeetsCategory: MemberMeetsCategoryStatus;
   reason?: string;
   errorMessage?: string;

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -115,7 +115,7 @@ export type DBCoffeeChat = {
   category: string;
   status: Status;
   date: number;
-  isArchived: false;
+  isArchived: boolean;
   memberMeetsCategory: MemberMeetsCategoryStatus;
   reason?: string;
   errorMessage?: string;

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -206,26 +206,26 @@ describe('More complicated member meets category checks', () => {
   });
 
   test('is an advisor', async () => {
-    const result = await checkMemberMeetsCategory(user1.email, user2.email, 'is an advisor');
+    const result = await checkMemberMeetsCategory(user2.email, user1.email, 'is an advisor');
     expect(result.status).toBe('pass');
     expect(result.message).toBe('');
   });
 
   test('is not an advisor', async () => {
-    const result = await checkMemberMeetsCategory(user1.email, user3.email, 'is an advisor');
+    const result = await checkMemberMeetsCategory(user3.email, user1.email, 'is an advisor');
     expect(result.status).toBe('fail');
     expect(result.message).toBe(`${user3.firstName} ${user3.lastName} is not an advisor`);
   });
 
   test('is newbie', async () => {
-    const result = await checkMemberMeetsCategory(user1.email, user3.email, 'a newbie');
+    const result = await checkMemberMeetsCategory(user4.email, user1.email, 'a newbie');
     expect(result.status).toBe('pass');
     expect(result.message).toBe('');
   });
-  
+
   test('is newbie', async () => {
-    const result = await checkMemberMeetsCategory(user1.email, user2.email, 'a newbie');
+    const result = await checkMemberMeetsCategory(user2.email, user1.email, 'a newbie');
     expect(result.status).toBe('fail');
-    expect(result.message).toBe(`${user2.firstName} ${user2.lastName} is not an advisor`);
+    expect(result.message).toBe(`${user2.firstName} ${user2.lastName} is not a newbie`);
   });
 });

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -49,7 +49,7 @@ describe('User is not lead or admin', () => {
   test('createCoffeeChat should throw error if previous chats exist', async () => {
     await expect(createCoffeeChat(coffeeChat, user)).rejects.toThrow(
       new Error(
-        'Cannot create coffee chat with member. Previous coffee chats from previous semesters exist.'
+        'Cannot create coffee chat with member. Coffee chats from current or previous semesters exist.'
       )
     );
   });

--- a/backend/tests/CoffeeChatAPI.test.ts
+++ b/backend/tests/CoffeeChatAPI.test.ts
@@ -12,7 +12,6 @@ import {
 } from '../src/API/coffeeChatAPI';
 import { setMember, deleteMember } from '../src/API/memberAPI';
 import { PermissionError } from '../src/utils/errors';
-import { getGeneralRoleFromLeadType } from '../src/utils/memberUtil';
 
 const user = fakeIdolMember();
 const user2 = fakeIdolMember();
@@ -191,110 +190,42 @@ describe('User is lead or admin', () => {
 
 describe('More complicated member meets category checks', () => {
   const admin = { ...fakeIdolLead() };
-  const user1 = { ...fakeIdolMember(), subteams: ['team1'], role: 'developer' as Role };
-  const user2 = { ...fakeIdolMember(), role: 'pm' as Role, subteams: ['team2'] };
-  const user3 = { ...fakeIdolMember(), role: 'pm' as Role, subteams: ['team1'] };
-  const user4 = { ...fakeIdolMember(), role: 'business' as Role };
-  const user5 = { ...fakeIdolMember(), role: 'tpm' as Role, subteams: ['team3'] };
-  const user6 = { ...fakeIdolMember(), role: 'tpm' as Role, subteams: ['team1'] };
-  const user7 = { ...fakeIdolMember(), role: 'product-lead' as Role };
-  const user8 = { ...fakeIdolMember(), role: 'dev-lead' as Role };
-  const user9 = { ...fakeIdolMember(), role: 'ops-lead' as Role };
-  const user10 = { ...fakeIdolMember(), role: 'ops-lead' as Role };
+  const user1 = fakeIdolMember();
+  const user2 = { ...fakeIdolMember(), role: 'dev-advisor' as Role };
+  const user3 = { ...fakeIdolMember(), role: 'tpm' as Role };
+  const user4 = { ...fakeIdolMember(), semesterJoined: 'Spring 2025' };
 
   beforeAll(async () => {
-    const users = [user1, user2, user3, user4, user5, user6, user7, user8, user9, user10];
+    const users = [user1, user2, user3, user4];
     await Promise.all(users.map((user) => setMember(user, admin)));
   });
 
   afterAll(async () => {
-    const users = [user1, user2, user3, user4, user5, user6, user7, user8, user9, user10];
+    const users = [user1, user2, user3, user4];
     await Promise.all(users.map((user) => deleteMember(user.email, admin)));
-    await CoffeeChatDao.deleteMemberProperties(user7.email);
-    await CoffeeChatDao.deleteMemberProperties(user8.email);
   });
 
-  test('pm that is not on same team', async () => {
-    const result = await checkMemberMeetsCategory(user2.email, user1.email, 'a pm (not your team)');
+  test('is an advisor', async () => {
+    const result = await checkMemberMeetsCategory(user1.email, user2.email, 'is an advisor');
     expect(result.status).toBe('pass');
     expect(result.message).toBe('');
   });
 
-  test('pm that is on same team', async () => {
-    const result = await checkMemberMeetsCategory(user3.email, user1.email, 'a pm (not your team)');
+  test('is not an advisor', async () => {
+    const result = await checkMemberMeetsCategory(user1.email, user3.email, 'is an advisor');
     expect(result.status).toBe('fail');
-    expect(result.message).toBe(
-      `${user3.firstName} ${user3.lastName} is a PM, but is on the same team as ${user1.firstName} ${user1.lastName}`
-    );
+    expect(result.message).toBe(`${user3.firstName} ${user3.lastName} is not an advisor`);
   });
 
-  test('not a pm', async () => {
-    const result = await checkMemberMeetsCategory(user4.email, user1.email, 'a pm (not your team)');
-    expect(result.status).toBe('fail');
-    expect(result.message).toBe(`${user4.firstName} ${user4.lastName} is not a PM`);
-  });
-
-  test('tpm that is not on same team', async () => {
-    const result = await checkMemberMeetsCategory(
-      user5.email,
-      user1.email,
-      'a tpm (not your team)'
-    );
+  test('is newbie', async () => {
+    const result = await checkMemberMeetsCategory(user1.email, user3.email, 'a newbie');
     expect(result.status).toBe('pass');
     expect(result.message).toBe('');
   });
-
-  test('tpm that is on same team', async () => {
-    const result = await checkMemberMeetsCategory(
-      user6.email,
-      user1.email,
-      'a tpm (not your team)'
-    );
+  
+  test('is newbie', async () => {
+    const result = await checkMemberMeetsCategory(user1.email, user2.email, 'a newbie');
     expect(result.status).toBe('fail');
-    expect(result.message).toBe(
-      `${user6.firstName} ${user6.lastName} is a TPM, but is on the same team as ${user1.firstName} ${user1.lastName}`
-    );
-  });
-
-  test('not a tpm', async () => {
-    const result = await checkMemberMeetsCategory(
-      user4.email,
-      user1.email,
-      'a tpm (not your team)'
-    );
-    expect(result.status).toBe('fail');
-    expect(result.message).toBe(`${user4.firstName} ${user4.lastName} is not a TPM`);
-  });
-
-  test('a lead that is not same role', async () => {
-    const result = await checkMemberMeetsCategory(
-      user7.email,
-      user1.email,
-      'a lead (not your role)'
-    );
-    expect(result.status).toBe('pass');
-    expect(result.message).toBe('');
-  });
-
-  test('a lead that is the same role', async () => {
-    const result = await checkMemberMeetsCategory(
-      user8.email,
-      user1.email,
-      'a lead (not your role)'
-    );
-    expect(result.status).toBe('fail');
-    expect(result.message).toBe(
-      `${user8.firstName} ${user8.lastName} is a lead, but from the same role (${getGeneralRoleFromLeadType(user8.role)}) as ${user1.firstName} ${user1.lastName}`
-    );
-  });
-
-  test('not a lead', async () => {
-    const result = await checkMemberMeetsCategory(
-      user4.email,
-      user1.email,
-      'a lead (not your role)'
-    );
-    expect(result.status).toBe('fail');
-    expect(result.message).toBe(`${user4.firstName} ${user4.lastName} is not a lead`);
+    expect(result.message).toBe(`${user2.firstName} ${user2.lastName} is not an advisor`);
   });
 });

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -223,6 +223,7 @@ export const fakeCoffeeChat = (): CoffeeChat => {
     category: 'test',
     status: 'pending' as Status,
     date: Date.now(),
+    isArchived: false,
     memberMeetsCategory: 'no data' as MemberMeetsCategoryStatus
   };
   return CC;

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -245,6 +245,7 @@ interface CoffeeChat {
   readonly category: string;
   readonly status: Status;
   readonly date: number;
+  readonly isArchived: boolean;
   readonly memberMeetsCategory: MemberMeetsCategoryStatus;
   readonly reason?: string;
   readonly errorMessage?: string;

--- a/frontend/src/components/Admin/CoffeeChats/CoffeeChats.tsx
+++ b/frontend/src/components/Admin/CoffeeChats/CoffeeChats.tsx
@@ -46,9 +46,10 @@ const CoffeeChats: React.FC = () => {
     setSelectedMember(member);
 
     CoffeeChatAPI.getCoffeeChatsByUser(member).then((coffeeChats) => {
-      setSpecificApprovedChats(coffeeChats.filter((chat) => chat.status === 'approved'));
-      setSpecificPendingChats(coffeeChats.filter((chat) => chat.status === 'pending'));
-      setSpecificRejectedChats(coffeeChats.filter((chat) => chat.status === 'rejected'));
+      const filteredChats = coffeeChats.filter((chat) => !chat.isArchived);
+      setSpecificApprovedChats(filteredChats.filter((chat) => chat.status === 'approved'));
+      setSpecificPendingChats(filteredChats.filter((chat) => chat.status === 'pending'));
+      setSpecificRejectedChats(filteredChats.filter((chat) => chat.status === 'rejected'));
       setIsChatLoading(false);
     });
 

--- a/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
+++ b/frontend/src/components/Forms/CoffeeChatsForm/CoffeeChatsForm.tsx
@@ -27,9 +27,10 @@ const CoffeeChatsForm: React.FC = () => {
   useEffect(() => {
     MembersAPI.getAllMembers().then((members) => setMembersList(members));
     CoffeeChatAPI.getCoffeeChatsByUser(userInfo).then((coffeeChats) => {
-      setApprovedChats(coffeeChats.filter((chat) => chat.status === 'approved'));
-      setPendingChats(coffeeChats.filter((chat) => chat.status === 'pending'));
-      setRejectedChats(coffeeChats.filter((chat) => chat.status === 'rejected'));
+      const filteredChats = coffeeChats.filter((chat) => !chat.isArchived);
+      setApprovedChats(filteredChats.filter((chat) => chat.status === 'approved'));
+      setPendingChats(filteredChats.filter((chat) => chat.status === 'pending'));
+      setRejectedChats(filteredChats.filter((chat) => chat.status === 'rejected'));
       setIsChatLoading(false);
     });
     CoffeeChatAPI.getCoffeeChatBingoBoard().then((board) => setBingoBoard(board));
@@ -118,6 +119,7 @@ const CoffeeChatsForm: React.FC = () => {
         category,
         status: 'pending' as Status,
         date: new Date().getTime(),
+        isArchived: false,
         memberMeetsCategory,
         errorMessage
       };


### PR DESCRIPTION
### Summary <!-- Required -->
This PR updates the bingo board for spring 2025. 
* Updated the bingo board. The board is still saved as a constant, but it will change with an upcoming PR.
* Updated autochecker to check "is an advisor" and "is a newbie". Everything else must be manually checked by the C&I lead until we obtain the data from the category form.
* Added an isArchived field for all past coffee chats. New coffee chats should have it set to false.

### Notion/Figma Link <!-- Optional -->
[Notion](https://www.notion.so/Idol-SP25-1890ad723ce180a19f3ff99268d34e53?p=1900ad723ce1809da802c767149da395&pm=s)

### Test Plan <!-- Required -->
Tested the new bingo board such that it only displays unarchived chats, members could submit, and autocheck works.

https://github.com/user-attachments/assets/436c75da-dab1-49f5-9e14-c910de43ce02



### Notes <!-- Optional -->
`CoffeeChat` and `DBCoffeeChat` types have been updated and have been reflected in both databases.
