### PR TITLE
Bump actions/cache to v4

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           node-version-file: .node-version
       - name: Use Yarn Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}

--- a/.github/workflows/pull-from-idol-images.yml
+++ b/.github/workflows/pull-from-idol-images.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version-file: .node-version
       - name: Use Yarn Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}

--- a/.github/workflows/pull-from-idol.yml
+++ b/.github/workflows/pull-from-idol.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version-file: .node-version
       - name: Use Yarn Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}

--- a/.github/workflows/tec-request-notification.yml
+++ b/.github/workflows/tec-request-notification.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version-file: .node-version
       - name: Use Yarn Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/yarn
           key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}


### PR DESCRIPTION
### Summary <!-- Required -->
This PR bumps the deprecated v1 of `actions/cache` to v4 as prescribed in this [GitHub blog post](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down), which has prevented previous PRs from building.

### Testing
If this PR builds lol