### PR TITLE
Interview Scheduler Backend

### DIFF
--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -1,13 +1,186 @@
 import InterviewSchedulerDao from '../dao/InterviewSchedulerDao';
+import InterviewSlotDao from '../dao/InterviewSlotDao';
+import { NotFoundError, PermissionError } from '../utils/errors';
+import PermissionsManager from '../utils/permissionsManager';
+import { getMember } from './memberAPI';
 
 const interviewSchedulerDao = new InterviewSchedulerDao();
+const interviewSlotDao = new InterviewSlotDao();
 
-// eslint-disable-next-line import/prefer-default-export
+const censoredApplicant: Applicant = {
+  email: '',
+  firstName: '',
+  lastName: '',
+  netid: ''
+};
+
 export const getAllApplicants = async (): Promise<string[]> => {
   const instances = await interviewSchedulerDao.getAllInstances();
   const applicants = new Set<string>();
-  instances
-    .filter((inst) => !inst.isArchived)
-    .forEach((inst) => inst.applicants.forEach((app) => applicants.add(app)));
+  instances.forEach((inst) => inst.applicants.forEach((app) => applicants.add(app.email)));
   return Array.from(applicants);
+};
+
+export const createInterviewScheduler = async (
+  instance: InterviewScheduler,
+  user: IdolMember
+): Promise<string> => {
+  if (!(await PermissionsManager.isAdmin(user)))
+    throw new PermissionError(
+      'User does not have permission to create new Candidate Decider instances.'
+    );
+
+  return interviewSchedulerDao.createInstance(instance);
+};
+
+export const getAllInterviewSchedulerInstances = async (
+  email: string,
+  isApplicant: boolean
+): Promise<InterviewScheduler[]> => {
+  const instances = await interviewSchedulerDao.getAllInstances();
+
+  if (!isApplicant) {
+    return instances;
+  }
+
+  const filteredInstances = instances
+    .filter((instance) => instance.applicants.some((applicant) => applicant.email === email))
+    .map((instance) => ({
+      ...instance,
+      applicants: []
+    }));
+  return filteredInstances;
+};
+
+export const getInterviewSchedulerInstance = async (
+  uuid: string,
+  email: string,
+  isApplicant: boolean
+): Promise<InterviewScheduler> => {
+  const instance = await interviewSchedulerDao.getInstance(uuid);
+
+  if (!instance)
+    throw new NotFoundError(`Interview scheduler instance with uuid ${uuid} does not exist!`);
+
+  if (isApplicant) {
+    if (instance.applicants.some((applicant) => applicant.email === email)) {
+      return { ...instance, applicants: [] };
+    }
+    throw new PermissionError('User does not have permission to get interview scheduler instance');
+  }
+
+  return instance;
+};
+
+export const updateInterviewSchedulerInstance = async (
+  user: IdolMember,
+  updates: InterviewSchedulerEdit
+): Promise<InterviewScheduler> => {
+  if (!PermissionsManager.isLeadOrAdmin(user))
+    throw new PermissionError(
+      'User does not have permission to update interview scheduler instance.'
+    );
+
+  const instance = await interviewSchedulerDao.getInstance(updates.uuid);
+
+  if (!instance)
+    throw new NotFoundError(
+      `Interview scheduler instance with uuid ${updates.uuid} does not exist!`
+    );
+
+  const newInstance: InterviewScheduler = {
+    ...instance,
+    ...updates
+  };
+
+  return interviewSchedulerDao.updateInstance(newInstance);
+};
+
+export const deleteInterviewSchedulerInstance = async (
+  uuid: string,
+  user: IdolMember
+): Promise<void> => {
+  if (!PermissionsManager.isLeadOrAdmin(user))
+    throw new PermissionError(
+      'User does not have permission to update interview scheduler instance.'
+    );
+
+  const slots = await getInterviewSlots(uuid, user.email, false);
+  await Promise.all(slots.map((slot) => interviewSlotDao.deleteSlot(slot.uuid)));
+  return interviewSchedulerDao.deleteInstance(uuid);
+};
+
+export const getInterviewSlots = async (
+  uuid: string,
+  email: string,
+  isApplicant: boolean
+): Promise<InterviewSlot[]> => {
+  const slots = await interviewSlotDao.getSlotsForScheduler(uuid);
+
+  if (isApplicant) {
+    return slots.map((slot) => ({
+      ...slot,
+      lead: null,
+      members: slot.members.map((_) => null),
+      applicant:
+        slot.applicant === null || slot.applicant.email === email
+          ? slot.applicant
+          : censoredApplicant
+    }));
+  }
+
+  return slots;
+};
+
+export const updateInterviewSlot = async (
+  edits: InterviewSlotEdit,
+  email: string,
+  isApplicant: boolean
+): Promise<boolean> => {
+  const slot = await interviewSlotDao.getSlot(edits.uuid);
+
+  if (!slot) throw new NotFoundError(`Interview slot with uuid ${edits.uuid} does not exist!`);
+  const scheduler = await getInterviewSchedulerInstance(
+    edits.interviewSchedulerUuid,
+    email,
+    isApplicant
+  );
+
+  if (
+    isApplicant &&
+    (!scheduler.isOpen ||
+      !scheduler.applicants.some((applicant) => applicant.email === email) || // Applicants should be an applicant of the scheduler instance
+      (slot.applicant && slot.applicant.email !== email) || // Applicants may not edit an occupied slot
+      (edits.applicant && edits.applicant.email !== email)) // Applicants may not sign up or cancel other applicants
+  )
+    throw new PermissionError('User does not have permission to edit this interview slot.');
+
+  const newSlot: InterviewSlot = {
+    ...slot,
+    ...edits
+  };
+
+  const user = await getMember(email);
+
+  return interviewSlotDao.updateSlot(
+    newSlot,
+    user !== undefined && (await PermissionsManager.isLeadOrAdmin(user))
+  );
+};
+
+export const deleteInterviewSlot = async (uuid: string, user: IdolMember): Promise<void> => {
+  if (!PermissionsManager.isLeadOrAdmin(user))
+    throw new PermissionError('User does not have permission to update interview slots.');
+
+  return interviewSlotDao.deleteSlot(uuid);
+};
+
+export const addInterviewSlots = async (
+  slots: InterviewSlot[],
+  user: IdolMember
+): Promise<InterviewSlot[]> => {
+  if (!PermissionsManager.isLeadOrAdmin(user))
+    throw new PermissionError('User does not have permission to create interview slots.');
+
+  return interviewSlotDao.addSlots(slots);
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -94,7 +94,18 @@ import { getWriteSignedURL, getReadSignedURL, deleteImage } from './API/imageAPI
 import DPSubmissionRequestLogDao from './dao/DPSubmissionRequestLogDao';
 import AdminsDao from './dao/AdminsDao';
 import { sendMail } from './API/mailAPI';
-import { getAllApplicants } from './API/interviewSchedulerAPI';
+import {
+  addInterviewSlots,
+  createInterviewScheduler,
+  deleteInterviewSchedulerInstance,
+  deleteInterviewSlot,
+  getAllApplicants,
+  getAllInterviewSchedulerInstances,
+  getInterviewSchedulerInstance,
+  getInterviewSlots,
+  updateInterviewSchedulerInstance,
+  updateInterviewSlot
+} from './API/interviewSchedulerAPI';
 
 // Constants and configurations
 const app = express();
@@ -496,6 +507,71 @@ loginCheckedPut('/dev-portfolio/:uuid/submission/regrade', async (req, user) => 
 loginCheckedPut('/dev-portfolio/:uuid/submission', async (req, user) => ({
   portfolio: await updateSubmissions(req.params.uuid, req.body.updatedSubmissions, user)
 }));
+
+// Interview Scheduler
+router.get(`/interview-scheduler/applicant`, async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    instances: await getAllInterviewSchedulerInstances(userEmail ?? '', true)
+  });
+});
+
+router.get(`/interview-scheduler/applicant/:uuid`, async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    instance: await getInterviewSchedulerInstance(req.params.uuid, userEmail ?? '', true)
+  });
+});
+
+loginCheckedGet('/interview-scheduler', async (req, user) => ({
+  instances: await getAllInterviewSchedulerInstances(user.email, false)
+}));
+
+loginCheckedGet('/interview-scheduler/:uuid', async (req, user) => ({
+  instance: await getInterviewSchedulerInstance(req.params.uuid, user.email, false)
+}));
+
+loginCheckedPost('/interview-scheduler', async (req, user) => ({
+  uuid: await createInterviewScheduler(req.body, user)
+}));
+
+loginCheckedPut('/interview-scheduler', async (req, user) => ({
+  instance: await updateInterviewSchedulerInstance(user, req.body)
+}));
+
+loginCheckedDelete('/interview-scheduler/:uuid', async (req, user) =>
+  deleteInterviewSchedulerInstance(req.params.uuid, user).then(() => ({}))
+);
+
+router.get('/interview-slots/applicant/:uuid', async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    slots: await getInterviewSlots(req.params.uuid, userEmail ?? '', true)
+  });
+});
+
+router.put('/interview-slot/applicant', async (req, res) => {
+  const userEmail = await getUserEmailFromRequest(req);
+  res.status(200).send({
+    success: await updateInterviewSlot(req.body, userEmail ?? '', true)
+  });
+});
+
+loginCheckedGet('/interview-slots/:uuid', async (req, user) => ({
+  slots: await getInterviewSlots(req.params.uuid, user.email, false)
+}));
+
+loginCheckedPost('/interview-slots', async (req, user) => ({
+  slots: await addInterviewSlots(req.body.slots, user)
+}));
+
+loginCheckedPut('/interview-slots', async (req, user) => ({
+  success: await updateInterviewSlot(req.body, user.email, false)
+}));
+
+loginCheckedDelete('/interview-slots/:uuid', async (req, user) =>
+  deleteInterviewSlot(req.params.uuid, user).then(() => ({}))
+);
 
 app.use('/.netlify/functions/api', router);
 

--- a/backend/src/dao/InterviewSchedulerDao.ts
+++ b/backend/src/dao/InterviewSchedulerDao.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import { interviewSchedulerCollection } from '../firebase';
 import BaseDao from './BaseDao';
 
@@ -12,5 +13,23 @@ export default class InterviewSchedulerDao extends BaseDao<InterviewScheduler, I
 
   async getAllInstances(): Promise<InterviewScheduler[]> {
     return this.getDocuments();
+  }
+
+  async getInstance(uuid: string): Promise<InterviewScheduler | null> {
+    return this.getDocument(uuid);
+  }
+
+  async createInstance(instance: InterviewScheduler): Promise<string> {
+    const uuid = uuidv4();
+    this.createDocument(uuid, { ...instance, uuid });
+    return uuid;
+  }
+
+  async updateInstance(instance: InterviewScheduler): Promise<InterviewScheduler> {
+    return this.updateDocument(instance.uuid, instance);
+  }
+
+  async deleteInstance(uuid: string): Promise<void> {
+    this.deleteDocument(uuid);
   }
 }

--- a/backend/src/dao/InterviewSchedulerDao.ts
+++ b/backend/src/dao/InterviewSchedulerDao.ts
@@ -20,9 +20,12 @@ export default class InterviewSchedulerDao extends BaseDao<InterviewScheduler, I
   }
 
   async createInstance(instance: InterviewScheduler): Promise<string> {
-    const uuid = uuidv4();
-    this.createDocument(uuid, { ...instance, uuid });
-    return uuid;
+    const instanceWithUUID = {
+      ...instance,
+      uuid: instance.uuid ? instance.uuid : uuidv4()
+    };
+    const doc = await this.createDocument(instanceWithUUID.uuid, instanceWithUUID);
+    return doc.uuid;
   }
 
   async updateInstance(instance: InterviewScheduler): Promise<InterviewScheduler> {

--- a/backend/src/dao/InterviewSlotDao.ts
+++ b/backend/src/dao/InterviewSlotDao.ts
@@ -1,0 +1,81 @@
+import { v4 as uuidv4 } from 'uuid';
+import { db, interviewSlotCollection, memberCollection } from '../firebase';
+import { DBInterviewSlot } from '../types/DataTypes';
+import { getMemberFromDocumentReference } from '../utils/memberUtil';
+import BaseDao from './BaseDao';
+
+async function serializeInterviewSlot(instance: InterviewSlot): Promise<DBInterviewSlot> {
+  return {
+    ...instance,
+    lead: instance.lead ? memberCollection.doc(instance.lead.email) : null,
+    members: instance.members.map((member) => (member ? memberCollection.doc(member.email) : null))
+  };
+}
+
+async function materializeInterviewSlot(dbInstance: DBInterviewSlot): Promise<InterviewSlot> {
+  return {
+    ...dbInstance,
+    lead: dbInstance.lead ? await getMemberFromDocumentReference(dbInstance.lead) : null,
+    members: await Promise.all(
+      dbInstance.members.map((member) => (member ? getMemberFromDocumentReference(member) : null))
+    )
+  };
+}
+
+export default class InterviewSlotDao extends BaseDao<InterviewSlot, DBInterviewSlot> {
+  constructor() {
+    super(interviewSlotCollection, materializeInterviewSlot, serializeInterviewSlot);
+  }
+
+  async getSlotsForScheduler(uuid: string): Promise<InterviewSlot[]> {
+    return this.getDocuments([
+      { field: 'interviewSchedulerUuid', comparisonOperator: '==', value: uuid }
+    ]);
+  }
+
+  async getSlot(uuid: string): Promise<InterviewSlot | null> {
+    return this.getDocument(uuid);
+  }
+
+  async addSlots(slots: InterviewSlot[]): Promise<InterviewSlot[]> {
+    return Promise.all(
+      slots.map((slot) => {
+        const uuid = uuidv4();
+        return this.createDocument(uuid, {
+          ...slot,
+          uuid
+        });
+      })
+    );
+  }
+
+  async updateSlot(updatedSlot: InterviewSlot, adminBypass: boolean): Promise<boolean> {
+    const wasUpdated: boolean = await db.runTransaction(async (t) => {
+      const query = this.collection.where('uuid', '==', updatedSlot.uuid);
+      const snapshot = await t.get(query);
+      const oldSlot = await materializeInterviewSlot(snapshot.docs[0].data());
+
+      if (
+        !adminBypass &&
+        oldSlot.applicant &&
+        updatedSlot.applicant &&
+        oldSlot.applicant.email !== updatedSlot.applicant.email
+      ) {
+        return false;
+      }
+
+      const dbSlot = await serializeInterviewSlot({
+        ...oldSlot,
+        ...updatedSlot
+      });
+      t.update(this.collection.doc(dbSlot.uuid), dbSlot);
+      return true;
+    });
+
+    return wasUpdated;
+  }
+
+  async deleteSlot(uuid: string): Promise<void> {
+    return this.deleteDocument(uuid);
+  }
+}

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -7,7 +7,8 @@ import {
   DevPortfolioSubmissionRequestLog,
   DBTeamEventAttendance,
   DBCandidateDeciderReview,
-  DBCoffeeChat
+  DBCoffeeChat,
+  DBInterviewSlot
 } from './types/DataTypes';
 import { configureAccount } from './utils/firebase-utils';
 
@@ -190,5 +191,16 @@ export const interviewSchedulerCollection: admin.firestore.CollectionReference<I
     },
     toFirestore(interviewSchedulerData: InterviewScheduler) {
       return interviewSchedulerData;
+    }
+  });
+
+export const interviewSlotCollection: admin.firestore.CollectionReference<DBInterviewSlot> = db
+  .collection('interview-slots')
+  .withConverter({
+    fromFirestore(snapshot): DBInterviewSlot {
+      return snapshot.data() as DBInterviewSlot;
+    },
+    toFirestore(interviewSlotData: DBInterviewSlot) {
+      return interviewSlotData;
     }
   });

--- a/backend/src/types/DataTypes.d.ts
+++ b/backend/src/types/DataTypes.d.ts
@@ -125,7 +125,8 @@ export type DBInterviewSlot = {
   readonly interviewSchedulerUuid: string;
   readonly startTime: number;
   readonly room: string;
-  lead: firestore.DocumentReference;
-  members: string[];
-  applicant: string;
+  readonly uuid: string;
+  lead: firestore.DocumentReference | null;
+  members: (firestore.DocumentReference | null)[];
+  applicant: Applicant | null;
 };

--- a/backend/tests/InterviewSchedulerDao.test.ts
+++ b/backend/tests/InterviewSchedulerDao.test.ts
@@ -1,0 +1,32 @@
+import InterviewScheulderDao from '../src/dao/InterviewSchedulerDao';
+import { candidateDeciderCollection } from '../src/firebase';
+import { fakeInterviewScheduler } from './data/createData';
+
+const interviewSchedulerDao = new InterviewScheulderDao();
+
+const mockIS = { ...fakeInterviewScheduler(), uuid: 'testUuid' };
+
+beforeAll(async () => {
+  await interviewSchedulerDao.createInstance(mockIS);
+});
+
+afterAll(async () => {
+  await candidateDeciderCollection.doc(mockIS.uuid).delete();
+});
+
+test('Get all instances', () =>
+  interviewSchedulerDao.getAllInstances().then((allInstances) => {
+    expect(allInstances.some((instance) => instance === mockIS));
+  }));
+
+test('Get instance by uuid', () =>
+  interviewSchedulerDao.getInstance('testUUid').then((attendance) => {
+    expect(attendance === mockIS);
+  }));
+
+test('Delete instance', () => {
+  interviewSchedulerDao.deleteInstance(mockIS.uuid);
+  interviewSchedulerDao.getAllInstances().then((allInstances) => {
+    expect(allInstances.every((instance) => instance !== mockIS));
+  });
+});

--- a/backend/tests/data/createData.ts
+++ b/backend/tests/data/createData.ts
@@ -228,3 +228,27 @@ export const fakeCoffeeChat = (): CoffeeChat => {
   };
   return CC;
 };
+
+export const fakeApplicant = (): Applicant => {
+  const applicant = {
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    netid: 'applicant123', // to easily be able to find fake members if needed
+    email: faker.internet.email()
+  };
+  return applicant;
+};
+
+export const fakeInterviewScheduler = (): InterviewScheduler => {
+  const interviewScheduler = {
+    name: '',
+    duration: 30,
+    membersPerSlot: 1,
+    isOpen: false,
+    startDate: 1738386000000, // 2025-02-01T05:00:00.000Z
+    endDate: 1738817999000, // 2025-02-06T04:59:59.000Z,
+    applicants: [fakeApplicant()],
+    uuid: faker.datatype.uuid()
+  };
+  return interviewScheduler;
+};

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -267,21 +267,47 @@ interface MemberDetails {
 
 type CoffeeChatSuggestions = { [k: string]: MemberDetails[] };
 
+type Applicant = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  netid: string;
+};
+
+type SlotStatus = 'vacant' | 'occupied' | 'possessed';
+
 interface InterviewScheduler {
   readonly name: string;
   readonly duration: number;
   readonly membersPerSlot: number;
   readonly isOpen: boolean;
-  readonly isArchived: boolean;
-  readonly deadline: number;
-  readonly applicants: string[];
+  readonly startDate: number;
+  readonly endDate: number;
+  readonly applicants: Applicant[];
+  readonly uuid: string;
 }
 
 interface InterviewSlot {
   readonly interviewSchedulerUuid: string;
   readonly startTime: number;
   readonly room: string;
-  readonly lead: IdolMember;
-  readonly members: string[];
-  readonly applicant: string;
+  readonly lead: IdolMember | null;
+  readonly members: (IdolMember | null)[];
+  readonly applicant: Applicant | null;
+  readonly uuid: string;
+}
+
+interface InterviewSchedulerEdit {
+  readonly uuid: string;
+  isOpen?: boolean;
+  startDate?: number;
+  endDate?: number;
+}
+
+interface InterviewSlotEdit {
+  readonly uuid: string;
+  readonly interviewSchedulerUuid: string;
+  lead?: IdolMember | null;
+  members?: (IdolMember | null)[];
+  applicant?: Applicant | null;
 }

--- a/frontend/src/components/Common/FirestoreDataProvider.tsx
+++ b/frontend/src/components/Common/FirestoreDataProvider.tsx
@@ -153,7 +153,7 @@ export default function FirestoreDataProvider({ children }: Props): JSX.Element 
         /* Always render children under test environment */
         process.env.NODE_ENV === 'test' && children
       }
-      {adminEmails == null || members == null || approvedMembers == null ? (
+      {!hasIDOLAccess || adminEmails == null || members == null || approvedMembers == null ? (
         <div>
           <Loader active size="massive" />
           {!hasIDOLAccess && (


### PR DESCRIPTION
### Summary <!-- Required -->
This PR adds the interview scheduler backend, adding CRUD operations for interview slots and interview schedulers. Some endpoints are duplicated for applicants and IDOL members for permission. Data sent back to applicants should be censored. Updating interview slots should be done transactionally to prevent overwritten data.

### Test Plan <!-- Required -->
Unit tests in `InterviewSchedulerDao.test.ts`.

### Breaking Changes <!-- Optional -->
See the two new Firebase collections
