### PR TITLE
Giving day: navbar updates to "Sponsor" and "Apply"

### DIFF
--- a/new-dti-website/components/navbar.tsx
+++ b/new-dti-website/components/navbar.tsx
@@ -8,33 +8,27 @@ import SectionWrapper from './hoc/SectionWrapper';
 const navbarItems = [
   {
     name: 'Team',
-    url: '/team',
-    special: false
+    url: '/team'
   },
   {
     name: 'Products',
-    url: '/products',
-    special: false
+    url: '/products'
   },
   {
     name: 'Course',
-    url: '/course',
-    special: false
+    url: '/course'
   },
   {
     name: 'Initiatives',
-    url: '/initiatives',
-    special: false
+    url: '/initiatives'
   },
   {
     name: 'Sponsor',
-    url: '/sponsor',
-    special: true
+    url: '/sponsor'
   },
   {
     name: 'Apply',
-    url: '/apply',
-    special: false
+    url: '/apply'
   }
 ];
 
@@ -123,14 +117,36 @@ const Navbar: React.FC = () => {
                   />
                 </button>
               </div>
-              <div className="backdrop-blur-sm w-full px-8 py-4 md:px-14 md:py-4 h-full flex flex-col gap-y-6 landscape:gap-y-2 md:landscape:gap-y-6 text-right">
+              <div className="backdrop-blur-sm w-full px-4 py-4 md:px-14 md:py-4 h-full flex flex-col gap-y-6 landscape:gap-y-2 md:landscape:gap-y-6 text-right">
                 {navbarItems.map((item) => (
                   <a
                     key={item.name}
                     href={item.url}
-                    className={`hover:underline cursor-pointer text-base md:text-2xl font-normal underline-offset-8 decoration-2`}
+                    className={`group cursor-pointer p-4 underline-offset-8 decoration-2 h-[40px] flex items-center ${
+                      pathname === item.url ? 'underline' : ''
+                    } ${
+                      item.name === 'Sponsor'
+                        ? 'mr-2 rounded-[128px] [transition:50ms_ease-out] border border-[rgba(227,73,73,0.60)] px-4 py-2 hover:bg-[rgba(229,74,74,0.20)] justify-center h-[52px]'
+                        : ''
+                    }  ${
+                      item.name === 'Apply'
+                        ? 'rounded-[128px] [transition:50ms_ease-out] bg-white justify-center h-[52px]'
+                        : ''
+                    }`}
                   >
-                    {item.name}
+                    <span
+                      className={`
+                    ${
+                      item.name === 'Sponsor'
+                        ? 'bg-gradient-to-r from-[#F25454] to-[#D63D3D] bg-clip-text text-transparent'
+                        : 'text-white'
+                    }
+                    ${item.name === 'Apply' ? 'text-[#000000]' : ''}
+                    ${item.name !== 'Apply' ? 'group-hover:underline' : ''}
+                  `}
+                    >
+                      {item.name}
+                    </span>
                   </a>
                 ))}
               </div>

--- a/new-dti-website/components/navbar.tsx
+++ b/new-dti-website/components/navbar.tsx
@@ -78,7 +78,7 @@ const Navbar: React.FC = () => {
                         ? 'bg-gradient-to-r from-[#F25454] to-[#D63D3D] bg-clip-text text-transparent'
                         : 'text-white'
                     }
-                    ${item.name === 'Apply' ? 'text-[#000000]' : ''}
+                    ${item.name === 'Apply' ? '!text-[#000000]' : ''}
                     ${item.name !== 'Apply' ? 'group-hover:underline' : ''}
                   `}
                 >
@@ -141,7 +141,7 @@ const Navbar: React.FC = () => {
                         ? 'bg-gradient-to-r from-[#F25454] to-[#D63D3D] bg-clip-text text-transparent'
                         : 'text-white'
                     }
-                    ${item.name === 'Apply' ? 'text-[#000000]' : ''}
+                    ${item.name === 'Apply' ? '!text-[#000000]' : ''}
                     ${item.name !== 'Apply' ? 'group-hover:underline' : ''}
                   `}
                     >

--- a/new-dti-website/components/navbar.tsx
+++ b/new-dti-website/components/navbar.tsx
@@ -8,27 +8,33 @@ import SectionWrapper from './hoc/SectionWrapper';
 const navbarItems = [
   {
     name: 'Team',
-    url: '/team'
+    url: '/team',
+    special: false
   },
   {
     name: 'Products',
-    url: '/products'
+    url: '/products',
+    special: false
   },
   {
     name: 'Course',
-    url: '/course'
+    url: '/course',
+    special: false
   },
   {
     name: 'Initiatives',
-    url: '/initiatives'
+    url: '/initiatives',
+    special: false
   },
   {
     name: 'Sponsor',
-    url: '/sponsor'
+    url: '/sponsor',
+    special: true
   },
   {
     name: 'Apply',
-    url: '/apply'
+    url: '/apply',
+    special: false
   }
 ];
 
@@ -59,13 +65,31 @@ const Navbar: React.FC = () => {
           <div className="hidden !justify-self-end w-fit lg:inline-flex flex-row">
             {navbarItems.map((item) => (
               <a
-                className={`hover:underline cursor-pointer text-white p-4 underline-offset-8 decoration-2 decoration-white h-[48px] flex items-center ${
-                  pathname === item.url ? 'underline' : ''
-                }`}
-                href={item.url}
                 key={item.name}
+                href={item.url}
+                className={`group cursor-pointer p-4 underline-offset-8 decoration-2 h-[40px] flex items-center ${
+                  pathname === item.url ? 'underline' : ''
+                } ${
+                  item.name === 'Sponsor'
+                    ? 'mr-2 rounded-[128px] [transition:50ms_ease-out] border border-[rgba(227,73,73,0.60)] px-4 py-2 hover:bg-[rgba(229,74,74,0.20)]'
+                    : ''
+                }  ${
+                  item.name === 'Apply' ? 'rounded-[128px] [transition:50ms_ease-out] bg-white' : ''
+                }`}
               >
-                {item.name}
+                <span
+                  className={`
+                    ${
+                      item.name === 'Sponsor'
+                        ? 'bg-gradient-to-r from-[#F25454] to-[#D63D3D] bg-clip-text text-transparent'
+                        : 'text-white'
+                    }
+                    ${item.name === 'Apply' ? 'text-[#000000]' : ''}
+                    ${item.name !== 'Apply' ? 'group-hover:underline' : ''}
+                  `}
+                >
+                  {item.name}
+                </span>
               </a>
             ))}
           </div>
@@ -103,8 +127,8 @@ const Navbar: React.FC = () => {
                 {navbarItems.map((item) => (
                   <a
                     key={item.name}
-                    className="hover:underline cursor-pointer text-white text-base md:text-2xl font-normal underline-offset-8 decoration-2 decoration-white"
                     href={item.url}
+                    className={`hover:underline cursor-pointer text-base md:text-2xl font-normal underline-offset-8 decoration-2`}
                   >
                     {item.name}
                   </a>


### PR DESCRIPTION
[figma](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1294-1572&p=f&t=51d4oYxL0O06amCX-11)

IDOL site giving day changes

made "Sponsor" link red to bedazzle it
made "Apply" a white button so that it doesn't look weird being a link next to "Sponsor"

made same changes for mobile too (and i left-aligned links for readability)


|X|Before|After|
|-|-|-|
|Desktop|<img width="1557" alt="Screenshot 2025-02-22 at 3 54 46 PM" src="https://github.com/user-attachments/assets/c6354576-1fda-45a6-aafb-de33d37c847a" />|<img width="1557" alt="Screenshot 2025-02-22 at 3 54 56 PM" src="https://github.com/user-attachments/assets/00310947-c09f-4458-bfdb-427b8d136ac1" />|
|Mobile|<img width="415" alt="Screenshot 2025-02-22 at 3 55 24 PM" src="https://github.com/user-attachments/assets/5748d7fa-7b67-4919-b935-14af3e749af5" />|<img width="415" alt="Screenshot 2025-02-22 at 3 55 14 PM" src="https://github.com/user-attachments/assets/0e8bdcf0-9a72-4ff5-9245-ab9869326f1d" />|


