### PR TITLE
[Giving Day] Polished "Sponsor Impact" section

### DIFF
--- a/new-dti-website/src/app/sponsor/page.tsx
+++ b/new-dti-website/src/app/sponsor/page.tsx
@@ -53,18 +53,18 @@ const SponsorImpact = () => (
     md:flex-row"
   >
     {impacts.map((impact) => (
-      <div className="flex flex-col gap-3 md:w-1/3">
-        <div className="flex items-center gap-1">
-          <Image
-            src={impact.image}
-            alt={impact.key}
-            height={impact.height}
-            width={impact.width}
-            className="h-24 h-auto md:w-[30%]"
-          />
-          <h3 className="font-semibold lg:text-xl xs:text-lg text-center">{impact.title}</h3>
+      <div className="flex flex-col gap-4 md:w-1/3">
+        <Image
+          src={impact.image}
+          alt={impact.key}
+          height={impact.height}
+          width={impact.width}
+          className="h-24 h-auto md:w-[30%] w-[20%]"
+        />
+        <div className="flex flex-col gap-2">
+          <h3 className="font-semibold lg:text-xl xs:text-lg">{impact.title}</h3>
+          <p className="lg:text-lg xs:text-sm">{impact.description}</p>
         </div>
-        <p className="lg:text-lg xs:text-sm">{impact.description}</p>
       </div>
     ))}
   </div>


### PR DESCRIPTION
based on [figma mocks](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1320-7047&t=gKiKdxScEyb2YX6E-11)

Made icon go above text so the cards look more aligned
reduced width of icon on mobile


|X|Before|After|
|-|-|-|
|Desktop|<img width="1284" alt="Screenshot 2025-02-28 at 1 11 31 PM" src="https://github.com/user-attachments/assets/603e166a-1893-4656-8fab-ebb680f2f6e3" />|<img width="1284" alt="Screenshot 2025-02-28 at 1 11 18 PM" src="https://github.com/user-attachments/assets/79933fc6-fcd1-4cac-9dd1-f1351d3660db" />|
|Mobile|<img width="408" alt="Screenshot 2025-02-28 at 1 11 41 PM" src="https://github.com/user-attachments/assets/8075391b-107a-4d4d-a0bf-378e124827e3" />|<img width="408" alt="Screenshot 2025-02-28 at 1 12 44 PM" src="https://github.com/user-attachments/assets/a5dc2cda-c33a-43dd-83e6-dca0af62ae6b" />|
