### PR TITLE
[Giving Day] Changed secondary text color

### DIFF
--- a/new-dti-website/components/bottom.tsx
+++ b/new-dti-website/components/bottom.tsx
@@ -21,13 +21,13 @@ const Bottom: React.FC = () => (
       </div>
       <div className="text-left w-full md:self-center max-w-[520px] relative z-10">
         <div className="flex flex-col gap-[16px]">
-          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium">Courses</p>
+          <p className="uppercase text-[16px] tracking-[1px] text-[#A3A3A3] font-medium">Courses</p>
           <div className="flex flex-col gap-[8px]">
             <h2 className="text-[32px] font-semibold lg:leading-10">
               Teaching the Cornell community
             </h2>
 
-            <p className="text-[#909090] text-[18px]">
+            <p className="text-[#A3A3A3] text-[18px]">
               Learn about modern industry-leading technologies with DTI courses, and explore your
               ideas through our incubator program.
             </p>
@@ -55,7 +55,7 @@ const Bottom: React.FC = () => (
       </div>
       <div className="text-left w-full md:self-center max-w-[520px] relative z-10">
         <div className="flex flex-col gap-[16px]">
-          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium">
+          <p className="uppercase text-[16px] tracking-[1px] text-[#A3A3A3] font-medium">
             Outreach
           </p>
           <div className="flex flex-col gap-[8px]">
@@ -63,7 +63,7 @@ const Bottom: React.FC = () => (
               Expanding reach to our community
             </h2>
 
-            <p className="text-[#909090] text-[18px]">
+            <p className="text-[#A3A3A3] text-[18px]">
               We strive to build initiatives not only at Cornell, but also in the Ithaca community
               and beyond.
             </p>
@@ -91,11 +91,11 @@ const Bottom: React.FC = () => (
       </div>
       <div className="text-left w-full md:self-center max-w-[520px] relative z-10">
         <div className="flex flex-col gap-[16px]">
-          <p className="uppercase text-[16px] tracking-[1px] text-[#909090] font-medium">Team</p>
+          <p className="uppercase text-[16px] tracking-[1px] text-[#A3A3A3] font-medium">Team</p>
           <div className="flex flex-col gap-[8px]">
             <h2 className="text-[32px] font-semibold lg:leading-10">We're a family</h2>
 
-            <p className="text-[#909090] text-[18px]">
+            <p className="text-[#A3A3A3] text-[18px]">
               We solve real-world problems to improve our community while growing personally and
               sharing our experiences to help others learn.
             </p>

--- a/new-dti-website/components/bottom.tsx
+++ b/new-dti-website/components/bottom.tsx
@@ -21,13 +21,15 @@ const Bottom: React.FC = () => (
       </div>
       <div className="text-left w-full md:self-center max-w-[520px] relative z-10">
         <div className="flex flex-col gap-[16px]">
-          <p className="uppercase text-[16px] tracking-[1px] text-[#A3A3A3] font-medium">Courses</p>
+          <p className="uppercase text-[16px] tracking-[1px] text-hero-secondary font-medium">
+            Courses
+          </p>
           <div className="flex flex-col gap-[8px]">
             <h2 className="text-[32px] font-semibold lg:leading-10">
               Teaching the Cornell community
             </h2>
 
-            <p className="text-[#A3A3A3] text-[18px]">
+            <p className="text-hero-secondary text-[18px]">
               Learn about modern industry-leading technologies with DTI courses, and explore your
               ideas through our incubator program.
             </p>
@@ -55,7 +57,7 @@ const Bottom: React.FC = () => (
       </div>
       <div className="text-left w-full md:self-center max-w-[520px] relative z-10">
         <div className="flex flex-col gap-[16px]">
-          <p className="uppercase text-[16px] tracking-[1px] text-[#A3A3A3] font-medium">
+          <p className="uppercase text-[16px] tracking-[1px] text-hero-secondary font-medium">
             Outreach
           </p>
           <div className="flex flex-col gap-[8px]">
@@ -63,7 +65,7 @@ const Bottom: React.FC = () => (
               Expanding reach to our community
             </h2>
 
-            <p className="text-[#A3A3A3] text-[18px]">
+            <p className="text-hero-secondary text-[18px]">
               We strive to build initiatives not only at Cornell, but also in the Ithaca community
               and beyond.
             </p>
@@ -91,11 +93,13 @@ const Bottom: React.FC = () => (
       </div>
       <div className="text-left w-full md:self-center max-w-[520px] relative z-10">
         <div className="flex flex-col gap-[16px]">
-          <p className="uppercase text-[16px] tracking-[1px] text-[#A3A3A3] font-medium">Team</p>
+          <p className="uppercase text-[16px] tracking-[1px] text-hero-secondary font-medium">
+            Team
+          </p>
           <div className="flex flex-col gap-[8px]">
             <h2 className="text-[32px] font-semibold lg:leading-10">We're a family</h2>
 
-            <p className="text-[#A3A3A3] text-[18px]">
+            <p className="text-hero-secondary text-[18px]">
               We solve real-world problems to improve our community while growing personally and
               sharing our experiences to help others learn.
             </p>

--- a/new-dti-website/src/app/globals.css
+++ b/new-dti-website/src/app/globals.css
@@ -39,7 +39,7 @@
     --radius: 0.5rem;
 
     --hero-primary: 255, 255, 255;
-    --hero-secondary: 255, 255, 255, 0.7;
+    --hero-secondary: 163, 163, 163;
 
     --hero-leading-header-xs: 63px;
     --hero-leading-header: 120px;


### PR DESCRIPTION
james spokes requested this lmao
<img width="678" alt="Screenshot 2025-02-28 at 9 54 37 PM" src="https://github.com/user-attachments/assets/6f6f5b56-013f-413b-987a-fca62f6227a3" />

also for code cleanliness replaced the hardcoded values in `bottom.tsx` with the CSS color variables



|X|Before|After|
|-|-|-|
|Contrast levels|<img width="490" alt="Screenshot 2025-02-28 at 9 55 25 PM" src="https://github.com/user-attachments/assets/8805b2da-13ef-4be8-bb56-00475f2103d7" />|<img width="490" alt="Screenshot 2025-02-28 at 9 55 39 PM" src="https://github.com/user-attachments/assets/0671e9e5-d523-4689-83bb-32e37eb4e70c" />|
|Home page feature sections|<img width="1288" alt="Screenshot 2025-02-28 at 9 53 39 PM" src="https://github.com/user-attachments/assets/e8d744a3-02e4-47fb-9f40-8fdd9dbbee2d" />|<img width="1288" alt="Screenshot 2025-02-28 at 9 53 31 PM" src="https://github.com/user-attachments/assets/7932c6fb-26c7-44d3-ae45-d3c42592efa2" />|
|Hero sections|<img width="1288" alt="Screenshot 2025-02-28 at 9 53 48 PM" src="https://github.com/user-attachments/assets/6dc0684d-0999-4abf-b4eb-2b27e827b15d" />|<img width="1288" alt="Screenshot 2025-02-28 at 9 53 56 PM" src="https://github.com/user-attachments/assets/3971155e-62e1-4283-a560-92b8244a5b93" />|


