### PR TITLE
Admin TEC Dashboard by Period

### DIFF
--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.module.css
@@ -1,12 +1,14 @@
 .headerContainer {
   display: flex;
-  justify-content: right;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
-.csvButton {
-  padding-left: 30%;
-  padding-right: 5%;
-  padding-bottom: 0.5em;
+.csvButton,
+.displayPeriod {
+  padding: 0.5em 5%;
+  display: inline-block;
 }
 
 .dashboardContainer {
@@ -25,11 +27,11 @@
 }
 
 .nameCell {
-  position: sticky;
-  left: 0;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   background-color: white;
-  min-width: 250px;
+  gap: 10px;
 }
 
 .nameHeaderCell {
@@ -38,13 +40,12 @@
 }
 
 .remindButton {
-  position: sticky;
-  left: 35%;
+  position: inline-block;
+  margin-left: 15px;
 }
 
 .notify {
-  position: absolute;
-  right: 1%;
+  right: 10px;
 }
 
 .endOfSemesterCheckbox {

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -98,9 +98,7 @@ const TeamEventDashboard: React.FC = () => {
   const membersNeedingNotification = displayPeriod
     ? allMembers.filter((member) => {
         const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
-        const requiredCredits = LEAD_ROLES.includes(member.role)
-          ? REQUIRED_LEAD_TEC_CREDITS
-          : calculateCredits(null, currentPeriodCredits);
+        const requiredCredits = calculateCredits(null, currentPeriodCredits);
 
         return currentPeriodCredits < requiredCredits;
       })

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -8,11 +8,18 @@ import {
   REQUIRED_LEAD_TEC_CREDITS,
   REQUIRED_MEMBER_TEC_CREDITS,
   REQUIRED_INITIATIVE_CREDITS,
-  INITIATIVE_EVENTS
+  INITIATIVE_EVENTS,
+  TEC_DEADLINES
 } from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
 
+interface Period {
+  name: string,
+  start: Date,
+  deadline: Date,
+  events: TeamEvent[]
+}
 const calculateMemberCreditsForEvent = (
   member: IdolMember,
   event: TeamEvent,
@@ -21,15 +28,15 @@ const calculateMemberCreditsForEvent = (
   isInitiativeEvent && !event.isInitiativeEvent
     ? 0
     : event.requests
-        .filter((req) => req.status === 'approved')
-        .reduce((val: number, attendee) => {
-          if (attendee.member.email !== member.email) {
-            return val;
-          }
-          if (event.hasHours && attendee.hoursAttended)
-            return val + Number(event.numCredits) * attendee.hoursAttended;
-          return val + Number(event.numCredits);
-        }, 0);
+      .filter((req) => req.status === 'approved')
+      .reduce((val: number, attendee) => {
+        if (attendee.member.email !== member.email) {
+          return val;
+        }
+        if (event.hasHours && attendee.hoursAttended)
+          return val + Number(event.numCredits) * attendee.hoursAttended;
+        return val + Number(event.numCredits);
+      }, 0);
 
 const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, false);
@@ -45,6 +52,7 @@ const getInitiativeCredits = (member: IdolMember, teamEvents: TeamEvent[]): numb
 const TeamEventDashboard: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [displayPeriod, setDisplayPeriod] = useState<boolean>(false);
   const [endOfSemesterReminder, setEndOfSemesterReminder] = useState(false);
 
   const allMembers = useMembers();
@@ -57,6 +65,83 @@ const TeamEventDashboard: React.FC = () => {
   }, []);
 
   if (isLoading) return <Loader active>Fetching team event data...</Loader>;
+
+  const getFirstPeriodStart = (): Date => {
+    const today = new Date();
+    const year = today.getFullYear();
+
+    return today.getMonth() < 7
+      ? new Date(year, 0, 1)
+      : new Date(year, 7, 1);
+  };
+
+  const getPeriodIndex = (date: Date): number => {
+    for (let i = 0; i < TEC_DEADLINES.length; i += 1) {
+      if (date <= TEC_DEADLINES[i]) {
+        return i;
+      }
+    }
+    return TEC_DEADLINES.length - 1;
+  };
+
+  const getPeriods = () => {
+    const periods: Period[] = [];
+    let i = 0;
+    TEC_DEADLINES.forEach((date) => {
+      i += 1;
+      const periodIndex = getPeriodIndex(new Date(date.getTime() - 24 * 60 * 60 * 1000));
+      const periodStart = periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
+      const periodEnd = TEC_DEADLINES[periodIndex];
+      const events = teamEvents.filter(event => {
+        const eventDate = new Date(event.date);
+        return eventDate > periodStart && eventDate <= periodEnd;
+      });
+      periods.push({ name: `Period ${i}`, start: periodStart, deadline: date, events });
+    });
+    return periods;
+  };
+
+  const periods = getPeriods();
+  const getCreditsPerPeriod = (member: IdolMember) => {
+    const credPerPeriod: number[] = [];
+    periods.forEach((period: Period) => {
+      credPerPeriod.push(getTotalCredits(member, period.events));
+    })
+    return credPerPeriod;
+  }
+
+  const getTECPeriod = (submissionDate: Date) => {
+    const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
+    if (currentPeriodIndex === -1) {
+      return TEC_DEADLINES.length;
+    }
+    return currentPeriodIndex;
+  };
+
+  const calculateCredits = (prevCredits: number | null, currentCredits: number) => {
+    if (prevCredits === null) {
+      return currentCredits < 1 ? 1 - currentCredits : 0;
+    }
+    if (prevCredits < 1) {
+      return currentCredits + prevCredits < 2
+        ? 2 - prevCredits - currentCredits
+        : 0;
+    }
+
+    return currentCredits < 1 ? 1 - currentCredits : 0;
+  };
+
+  const currentPeriodIndex = getTECPeriod(new Date());
+  const membersNeedingNotification = displayPeriod
+    ? allMembers.filter((member) => {
+      const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
+      const requiredCredits = LEAD_ROLES.includes(member.role)
+        ? REQUIRED_LEAD_TEC_CREDITS
+        : calculateCredits(null, currentPeriodCredits);
+
+      return currentPeriodCredits < requiredCredits;
+    })
+    : [];
 
   const handleExportToCsv = () => {
     const csvData = allMembers.map((member) => {
@@ -101,7 +186,14 @@ const TeamEventDashboard: React.FC = () => {
       <div className={styles.headerContainer}>
         <Header as="h1">Team Event Dashboard</Header>
         <div className={styles.csvButton}>
-          <Button onClick={handleExportToCsv}>Export to CSV</Button>
+          <div className={styles.displayPeriod}>
+            <Button onClick={() => setDisplayPeriod((prev) => !prev)}>
+              {!displayPeriod ? "Display TEC by Period" : "Return to Dashboard"}
+            </Button>
+          </div>
+          <div className={styles.csvButton}>
+            <Button onClick={handleExportToCsv}>Export to CSV</Button>
+          </div>
         </div>
       </div>
       <div className={styles.tableContainer}>
@@ -109,29 +201,42 @@ const TeamEventDashboard: React.FC = () => {
           <Table.Header>
             <Table.HeaderCell className={styles.nameCell}>
               Name
-              <NotifyMemberModal
-                all={true}
-                trigger={
-                  <Button className={styles.remindButton} size="small" color="red">
-                    Remind All (Excludes Advisors)
-                  </Button>
-                }
-                members={allMembers.filter((member) => {
-                  if (ADVISOR_ROLES.includes(member.role)) return false;
-                  const totalCredits = teamEvents.reduce(
-                    (val, event) => val + calculateTotalCreditsForEvent(member, event),
-                    0
-                  );
-                  return (
-                    totalCredits <
-                    (LEAD_ROLES.includes(member.role)
-                      ? REQUIRED_LEAD_TEC_CREDITS
-                      : REQUIRED_MEMBER_TEC_CREDITS)
-                  );
-                })}
-                endOfSemesterReminder={endOfSemesterReminder}
-                type={'tec'}
-              />
+              {displayPeriod && membersNeedingNotification.length > 0 ?
+                (<NotifyMemberModal
+                  all={true}
+                  trigger={
+                    <Button className={styles.remindButton} size="small" color="orange">
+                      Notify Members Below Required Period Credits
+                    </Button>
+                  }
+                  members={membersNeedingNotification}
+                  endOfSemesterReminder={endOfSemesterReminder}
+                  type={'tec'}
+                />
+                ) :
+                <NotifyMemberModal
+                  all={true}
+                  trigger={
+                    <Button className={styles.remindButton} size="small" color="red">
+                      Remind All (Excludes Advisors)
+                    </Button>
+                  }
+                  members={allMembers.filter((member) => {
+                    if (ADVISOR_ROLES.includes(member.role)) return false;
+                    const totalCredits = teamEvents.reduce(
+                      (val, event) => val + calculateTotalCreditsForEvent(member, event),
+                      0
+                    );
+                    return (
+                      totalCredits <
+                      (LEAD_ROLES.includes(member.role)
+                        ? REQUIRED_LEAD_TEC_CREDITS
+                        : REQUIRED_MEMBER_TEC_CREDITS)
+                    );
+                  })}
+                  endOfSemesterReminder={endOfSemesterReminder}
+                  type={'tec'}
+                />}
               <Checkbox
                 className={styles.endOfSemesterCheckbox}
                 label={{ children: 'End of Semester Reminder?' }}
@@ -141,56 +246,102 @@ const TeamEventDashboard: React.FC = () => {
                 }
               />
             </Table.HeaderCell>
-            <Table.HeaderCell>Total</Table.HeaderCell>
+            <Table.HeaderCell>{!displayPeriod ? "Total" : "Required Credits"}</Table.HeaderCell>
             {INITIATIVE_EVENTS && <Table.HeaderCell>Total Initiative Credits</Table.HeaderCell>}
-            {teamEvents.map((event) => (
-              <Table.HeaderCell>{event.name}</Table.HeaderCell>
-            ))}
+            {!displayPeriod ?
+              teamEvents.map((event) => (
+                <Table.HeaderCell>{event.name}</Table.HeaderCell>
+              )) : periods.map((period) => (
+                <Table.HeaderCell>{period.name}</Table.HeaderCell>
+              ))}
           </Table.Header>
           <Table.Body>
-            {allMembers.map((member) => {
-              const totalCredits = getTotalCredits(member, teamEvents);
-              const initiativeCredits = getInitiativeCredits(member, teamEvents);
-              const totalCreditsMet =
-                totalCredits >=
-                (LEAD_ROLES.includes(member.role)
-                  ? REQUIRED_LEAD_TEC_CREDITS
-                  : REQUIRED_MEMBER_TEC_CREDITS);
-              const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
+            {!displayPeriod
+              ? allMembers.map((member) => {
+                const totalCredits = getTotalCredits(member, teamEvents);
+                const initiativeCredits = getInitiativeCredits(member, teamEvents);
+                const totalCreditsMet =
+                  totalCredits >=
+                  (LEAD_ROLES.includes(member.role)
+                    ? REQUIRED_LEAD_TEC_CREDITS
+                    : REQUIRED_MEMBER_TEC_CREDITS);
+                const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
 
-              const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-              return (
-                <Table.Row>
-                  <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
-                    {member.firstName} {member.lastName} ({member.netid})
-                    {!totalCreditsMet && (
-                      <NotifyMemberModal
-                        all={false}
-                        trigger={
-                          isAdvisor ? (
-                            <div />
-                          ) : (
-                            <Icon className={styles.notify} name="exclamation" color="red" />
-                          )
-                        }
-                        member={member}
-                        endOfSemesterReminder={endOfSemesterReminder}
-                        type={'tec'}
-                      />
+                return (
+                  <Table.Row>
+                    <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
+                      {member.firstName} {member.lastName} ({member.netid})
+                      {!totalCreditsMet && (
+                        <NotifyMemberModal
+                          all={false}
+                          trigger={
+                            isAdvisor ? (
+                              <div />
+                            ) : (
+                              <Icon className={styles.notify} name="exclamation" color="red" />
+                            )
+                          }
+                          member={member}
+                          endOfSemesterReminder={endOfSemesterReminder}
+                          type={'tec'}
+                        />
+                      )}
+                    </Table.Cell>
+                    <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
+                    {INITIATIVE_EVENTS && (
+                      <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
                     )}
-                  </Table.Cell>
-                  <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
-                  {INITIATIVE_EVENTS && (
-                    <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
-                  )}
-                  {teamEvents.map((event) => {
-                    const numCredits = calculateTotalCreditsForEvent(member, event);
-                    return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                  })}
-                </Table.Row>
-              );
-            })}
+                    {teamEvents.map((event) => {
+                      const numCredits = calculateTotalCreditsForEvent(member, event);
+                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                    })}
+                  </Table.Row>
+                );
+              }) : allMembers.map((member) => {
+                const currentPeriodIndex = getTECPeriod(new Date());
+                const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
+                const creditsPerPeriod = getCreditsPerPeriod(member);
+
+                const previousPeriodIndex = currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
+                const previousPeriodCredits = previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
+                const requiredCredits = calculateCredits(previousPeriodCredits, currentPeriodCredits);
+
+                const isAdvisor = ADVISOR_ROLES.includes(member.role);
+
+                return (
+                  <Table.Row>
+                    <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
+                      {member.firstName} {member.lastName} ({member.netid})
+                      {requiredCredits > 0 && (
+                        <NotifyMemberModal
+                          all={false}
+                          trigger={
+                            isAdvisor ? (
+                              <div />
+                            ) : (
+                              <Icon className={styles.notify} name="exclamation" color="red" />
+                            )
+                          }
+                          member={member}
+                          endOfSemesterReminder={endOfSemesterReminder}
+                          type={'tec'}
+                        />
+                      )}
+                    </Table.Cell>
+                    <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
+                    {periods.map((period) => {
+                      const numCredits = period.events
+                        .map((event) => calculateTotalCreditsForEvent(member, event))
+                        .filter((credits) => credits != null)
+                        .reduce((sum, credits) => sum + credits, 0);
+
+                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                    })}
+                  </Table.Row>
+                );
+              })}
           </Table.Body>
         </Table>
       </div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -15,10 +15,10 @@ import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
 
 interface Period {
-  name: string,
-  start: Date,
-  deadline: Date,
-  events: TeamEvent[]
+  name: string;
+  start: Date;
+  deadline: Date;
+  events: TeamEvent[];
 }
 const calculateMemberCreditsForEvent = (
   member: IdolMember,
@@ -28,15 +28,15 @@ const calculateMemberCreditsForEvent = (
   isInitiativeEvent && !event.isInitiativeEvent
     ? 0
     : event.requests
-      .filter((req) => req.status === 'approved')
-      .reduce((val: number, attendee) => {
-        if (attendee.member.email !== member.email) {
-          return val;
-        }
-        if (event.hasHours && attendee.hoursAttended)
-          return val + Number(event.numCredits) * attendee.hoursAttended;
-        return val + Number(event.numCredits);
-      }, 0);
+        .filter((req) => req.status === 'approved')
+        .reduce((val: number, attendee) => {
+          if (attendee.member.email !== member.email) {
+            return val;
+          }
+          if (event.hasHours && attendee.hoursAttended)
+            return val + Number(event.numCredits) * attendee.hoursAttended;
+          return val + Number(event.numCredits);
+        }, 0);
 
 const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, false);
@@ -70,9 +70,7 @@ const TeamEventDashboard: React.FC = () => {
     const today = new Date();
     const year = today.getFullYear();
 
-    return today.getMonth() < 7
-      ? new Date(year, 0, 1)
-      : new Date(year, 7, 1);
+    return today.getMonth() < 7 ? new Date(year, 0, 1) : new Date(year, 7, 1);
   };
 
   const getPeriodIndex = (date: Date): number => {
@@ -90,9 +88,10 @@ const TeamEventDashboard: React.FC = () => {
     TEC_DEADLINES.forEach((date) => {
       i += 1;
       const periodIndex = getPeriodIndex(new Date(date.getTime() - 24 * 60 * 60 * 1000));
-      const periodStart = periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
+      const periodStart =
+        periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
       const periodEnd = TEC_DEADLINES[periodIndex];
-      const events = teamEvents.filter(event => {
+      const events = teamEvents.filter((event) => {
         const eventDate = new Date(event.date);
         return eventDate > periodStart && eventDate <= periodEnd;
       });
@@ -106,9 +105,9 @@ const TeamEventDashboard: React.FC = () => {
     const credPerPeriod: number[] = [];
     periods.forEach((period: Period) => {
       credPerPeriod.push(getTotalCredits(member, period.events));
-    })
+    });
     return credPerPeriod;
-  }
+  };
 
   const getTECPeriod = (submissionDate: Date) => {
     const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
@@ -123,9 +122,7 @@ const TeamEventDashboard: React.FC = () => {
       return currentCredits < 1 ? 1 - currentCredits : 0;
     }
     if (prevCredits < 1) {
-      return currentCredits + prevCredits < 2
-        ? 2 - prevCredits - currentCredits
-        : 0;
+      return currentCredits + prevCredits < 2 ? 2 - prevCredits - currentCredits : 0;
     }
 
     return currentCredits < 1 ? 1 - currentCredits : 0;
@@ -134,13 +131,13 @@ const TeamEventDashboard: React.FC = () => {
   const currentPeriodIndex = getTECPeriod(new Date());
   const membersNeedingNotification = displayPeriod
     ? allMembers.filter((member) => {
-      const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
-      const requiredCredits = LEAD_ROLES.includes(member.role)
-        ? REQUIRED_LEAD_TEC_CREDITS
-        : calculateCredits(null, currentPeriodCredits);
+        const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
+        const requiredCredits = LEAD_ROLES.includes(member.role)
+          ? REQUIRED_LEAD_TEC_CREDITS
+          : calculateCredits(null, currentPeriodCredits);
 
-      return currentPeriodCredits < requiredCredits;
-    })
+        return currentPeriodCredits < requiredCredits;
+      })
     : [];
 
   const handleExportToCsv = () => {
@@ -188,7 +185,7 @@ const TeamEventDashboard: React.FC = () => {
         <div className={styles.csvButton}>
           <div className={styles.displayPeriod}>
             <Button onClick={() => setDisplayPeriod((prev) => !prev)}>
-              {!displayPeriod ? "Display TEC by Period" : "Return to Dashboard"}
+              {!displayPeriod ? 'Display TEC by Period' : 'Return to Dashboard'}
             </Button>
           </div>
           <div className={styles.csvButton}>
@@ -201,8 +198,8 @@ const TeamEventDashboard: React.FC = () => {
           <Table.Header>
             <Table.HeaderCell className={styles.nameCell}>
               Name
-              {displayPeriod && membersNeedingNotification.length > 0 ?
-                (<NotifyMemberModal
+              {displayPeriod && membersNeedingNotification.length > 0 ? (
+                <NotifyMemberModal
                   all={true}
                   trigger={
                     <Button className={styles.remindButton} size="small" color="orange">
@@ -213,7 +210,7 @@ const TeamEventDashboard: React.FC = () => {
                   endOfSemesterReminder={endOfSemesterReminder}
                   type={'tec'}
                 />
-                ) :
+              ) : (
                 <NotifyMemberModal
                   all={true}
                   trigger={
@@ -236,7 +233,8 @@ const TeamEventDashboard: React.FC = () => {
                   })}
                   endOfSemesterReminder={endOfSemesterReminder}
                   type={'tec'}
-                />}
+                />
+              )}
               <Checkbox
                 className={styles.endOfSemesterCheckbox}
                 label={{ children: 'End of Semester Reminder?' }}
@@ -246,102 +244,108 @@ const TeamEventDashboard: React.FC = () => {
                 }
               />
             </Table.HeaderCell>
-            <Table.HeaderCell>{!displayPeriod ? "Total" : "Required Credits"}</Table.HeaderCell>
+            <Table.HeaderCell>{!displayPeriod ? 'Total' : 'Required Credits'}</Table.HeaderCell>
             {INITIATIVE_EVENTS && <Table.HeaderCell>Total Initiative Credits</Table.HeaderCell>}
-            {!displayPeriod ?
-              teamEvents.map((event) => (
-                <Table.HeaderCell>{event.name}</Table.HeaderCell>
-              )) : periods.map((period) => (
-                <Table.HeaderCell>{period.name}</Table.HeaderCell>
-              ))}
+            {!displayPeriod
+              ? teamEvents.map((event) => <Table.HeaderCell>{event.name}</Table.HeaderCell>)
+              : periods.map((period) => <Table.HeaderCell>{period.name}</Table.HeaderCell>)}
           </Table.Header>
           <Table.Body>
             {!displayPeriod
               ? allMembers.map((member) => {
-                const totalCredits = getTotalCredits(member, teamEvents);
-                const initiativeCredits = getInitiativeCredits(member, teamEvents);
-                const totalCreditsMet =
-                  totalCredits >=
-                  (LEAD_ROLES.includes(member.role)
-                    ? REQUIRED_LEAD_TEC_CREDITS
-                    : REQUIRED_MEMBER_TEC_CREDITS);
-                const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
+                  const totalCredits = getTotalCredits(member, teamEvents);
+                  const initiativeCredits = getInitiativeCredits(member, teamEvents);
+                  const totalCreditsMet =
+                    totalCredits >=
+                    (LEAD_ROLES.includes(member.role)
+                      ? REQUIRED_LEAD_TEC_CREDITS
+                      : REQUIRED_MEMBER_TEC_CREDITS);
+                  const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
 
-                const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                  const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-                return (
-                  <Table.Row>
-                    <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
-                      {member.firstName} {member.lastName} ({member.netid})
-                      {!totalCreditsMet && (
-                        <NotifyMemberModal
-                          all={false}
-                          trigger={
-                            isAdvisor ? (
-                              <div />
-                            ) : (
-                              <Icon className={styles.notify} name="exclamation" color="red" />
-                            )
-                          }
-                          member={member}
-                          endOfSemesterReminder={endOfSemesterReminder}
-                          type={'tec'}
-                        />
+                  return (
+                    <Table.Row>
+                      <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
+                        {member.firstName} {member.lastName} ({member.netid})
+                        {!totalCreditsMet && (
+                          <NotifyMemberModal
+                            all={false}
+                            trigger={
+                              isAdvisor ? (
+                                <div />
+                              ) : (
+                                <Icon className={styles.notify} name="exclamation" color="red" />
+                              )
+                            }
+                            member={member}
+                            endOfSemesterReminder={endOfSemesterReminder}
+                            type={'tec'}
+                          />
+                        )}
+                      </Table.Cell>
+                      <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
+                      {INITIATIVE_EVENTS && (
+                        <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
                       )}
-                    </Table.Cell>
-                    <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
-                    {INITIATIVE_EVENTS && (
-                      <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
-                    )}
-                    {teamEvents.map((event) => {
-                      const numCredits = calculateTotalCreditsForEvent(member, event);
-                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                    })}
-                  </Table.Row>
-                );
-              }) : allMembers.map((member) => {
-                const currentPeriodIndex = getTECPeriod(new Date());
-                const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
-                const creditsPerPeriod = getCreditsPerPeriod(member);
+                      {teamEvents.map((event) => {
+                        const numCredits = calculateTotalCreditsForEvent(member, event);
+                        return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                      })}
+                    </Table.Row>
+                  );
+                })
+              : allMembers.map((member) => {
+                  const currentPeriodIndex = getTECPeriod(new Date());
+                  const currentPeriodCredits = getTotalCredits(
+                    member,
+                    periods[currentPeriodIndex].events
+                  );
+                  const creditsPerPeriod = getCreditsPerPeriod(member);
 
-                const previousPeriodIndex = currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
-                const previousPeriodCredits = previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
-                const requiredCredits = calculateCredits(previousPeriodCredits, currentPeriodCredits);
+                  const previousPeriodIndex =
+                    currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
+                  const previousPeriodCredits =
+                    previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
+                  const requiredCredits = calculateCredits(
+                    previousPeriodCredits,
+                    currentPeriodCredits
+                  );
 
-                const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                  const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-                return (
-                  <Table.Row>
-                    <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
-                      {member.firstName} {member.lastName} ({member.netid})
-                      {requiredCredits > 0 && (
-                        <NotifyMemberModal
-                          all={false}
-                          trigger={
-                            isAdvisor ? (
-                              <div />
-                            ) : (
-                              <Icon className={styles.notify} name="exclamation" color="red" />
-                            )
-                          }
-                          member={member}
-                          endOfSemesterReminder={endOfSemesterReminder}
-                          type={'tec'}
-                        />
-                      )}
-                    </Table.Cell>
-                    <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
-                    {periods.map((period) => {
-                      const numCredits = period.events
-                        .map((event) => calculateTotalCreditsForEvent(member, event))
-                        .filter((credits) => credits != null)
-                        .reduce((sum, credits) => sum + credits, 0);
+                  return (
+                    <Table.Row>
+                      <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
+                        {member.firstName} {member.lastName} ({member.netid})
+                        {requiredCredits > 0 && (
+                          <NotifyMemberModal
+                            all={false}
+                            trigger={
+                              isAdvisor ? (
+                                <div />
+                              ) : (
+                                <Icon className={styles.notify} name="exclamation" color="red" />
+                              )
+                            }
+                            member={member}
+                            endOfSemesterReminder={endOfSemesterReminder}
+                            type={'tec'}
+                          />
+                        )}
+                      </Table.Cell>
+                      <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
+                      {periods.map((period) => {
+                        const numCredits = period.events
+                          .map((event) => calculateTotalCreditsForEvent(member, event))
+                          .filter((credits) => credits != null)
+                          .reduce((sum, credits) => sum + credits, 0);
 
-                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                    })}
-                  </Table.Row>
-                );
-              })}
+                        return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                      })}
+                    </Table.Row>
+                  );
+                })}
           </Table.Body>
         </Table>
       </div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -28,15 +28,15 @@ const calculateMemberCreditsForEvent = (
   isInitiativeEvent && !event.isInitiativeEvent
     ? 0
     : event.requests
-      .filter((req) => req.status === 'approved')
-      .reduce((val: number, attendee) => {
-        if (attendee.member.email !== member.email) {
-          return val;
-        }
-        if (event.hasHours && attendee.hoursAttended)
-          return val + Number(event.numCredits) * attendee.hoursAttended;
-        return val + Number(event.numCredits);
-      }, 0);
+        .filter((req) => req.status === 'approved')
+        .reduce((val: number, attendee) => {
+          if (attendee.member.email !== member.email) {
+            return val;
+          }
+          if (event.hasHours && attendee.hoursAttended)
+            return val + Number(event.numCredits) * attendee.hoursAttended;
+          return val + Number(event.numCredits);
+        }, 0);
 
 const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, false);
@@ -131,13 +131,13 @@ const TeamEventDashboard: React.FC = () => {
   const currentPeriodIndex = getTECPeriod(new Date());
   const membersNeedingNotification = displayPeriod
     ? allMembers.filter((member) => {
-      const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
-      const requiredCredits = LEAD_ROLES.includes(member.role)
-        ? REQUIRED_LEAD_TEC_CREDITS
-        : calculateCredits(null, currentPeriodCredits);
+        const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
+        const requiredCredits = LEAD_ROLES.includes(member.role)
+          ? REQUIRED_LEAD_TEC_CREDITS
+          : calculateCredits(null, currentPeriodCredits);
 
-      return currentPeriodCredits < requiredCredits;
-    })
+        return currentPeriodCredits < requiredCredits;
+      })
     : [];
 
   const handleExportToCsv = () => {
@@ -255,99 +255,99 @@ const TeamEventDashboard: React.FC = () => {
           <Table.Body>
             {!displayPeriod
               ? allMembers.map((member) => {
-                const totalCredits = getTotalCredits(member, teamEvents);
-                const initiativeCredits = getInitiativeCredits(member, teamEvents);
-                const totalCreditsMet =
-                  totalCredits >=
-                  (LEAD_ROLES.includes(member.role)
-                    ? REQUIRED_LEAD_TEC_CREDITS
-                    : REQUIRED_MEMBER_TEC_CREDITS);
-                const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
+                  const totalCredits = getTotalCredits(member, teamEvents);
+                  const initiativeCredits = getInitiativeCredits(member, teamEvents);
+                  const totalCreditsMet =
+                    totalCredits >=
+                    (LEAD_ROLES.includes(member.role)
+                      ? REQUIRED_LEAD_TEC_CREDITS
+                      : REQUIRED_MEMBER_TEC_CREDITS);
+                  const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
 
-                const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                  const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-                return (
-                  <Table.Row>
-                    <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
-                      {member.firstName} {member.lastName} ({member.netid})
-                      {!totalCreditsMet && (
-                        <NotifyMemberModal
-                          all={false}
-                          trigger={
-                            isAdvisor ? (
-                              <div />
-                            ) : (
-                              <Icon className={styles.notify} name="exclamation" color="red" />
-                            )
-                          }
-                          member={member}
-                          endOfSemesterReminder={endOfSemesterReminder}
-                          type={'tec'}
-                        />
+                  return (
+                    <Table.Row>
+                      <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
+                        {member.firstName} {member.lastName} ({member.netid})
+                        {!totalCreditsMet && (
+                          <NotifyMemberModal
+                            all={false}
+                            trigger={
+                              isAdvisor ? (
+                                <div />
+                              ) : (
+                                <Icon className={styles.notify} name="exclamation" color="red" />
+                              )
+                            }
+                            member={member}
+                            endOfSemesterReminder={endOfSemesterReminder}
+                            type={'tec'}
+                          />
+                        )}
+                      </Table.Cell>
+                      <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
+                      {INITIATIVE_EVENTS && (
+                        <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
                       )}
-                    </Table.Cell>
-                    <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
-                    {INITIATIVE_EVENTS && (
-                      <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
-                    )}
-                    {teamEvents.map((event) => {
-                      const numCredits = calculateTotalCreditsForEvent(member, event);
-                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                    })}
-                  </Table.Row>
-                );
-              })
+                      {teamEvents.map((event) => {
+                        const numCredits = calculateTotalCreditsForEvent(member, event);
+                        return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                      })}
+                    </Table.Row>
+                  );
+                })
               : allMembers.map((member) => {
-                const currentPeriodIndex = getTECPeriod(new Date());
-                const currentPeriodCredits = getTotalCredits(
-                  member,
-                  periods[currentPeriodIndex].events
-                );
-                const creditsPerPeriod = getCreditsPerPeriod(member);
+                  const currentPeriodIndex = getTECPeriod(new Date());
+                  const currentPeriodCredits = getTotalCredits(
+                    member,
+                    periods[currentPeriodIndex].events
+                  );
+                  const creditsPerPeriod = getCreditsPerPeriod(member);
 
-                const previousPeriodIndex =
-                  currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
-                const previousPeriodCredits =
-                  previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
-                const requiredCredits = calculateCredits(
-                  previousPeriodCredits,
-                  currentPeriodCredits
-                );
+                  const previousPeriodIndex =
+                    currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
+                  const previousPeriodCredits =
+                    previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
+                  const requiredCredits = calculateCredits(
+                    previousPeriodCredits,
+                    currentPeriodCredits
+                  );
 
-                const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                  const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-                return (
-                  <Table.Row>
-                    <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
-                      {member.firstName} {member.lastName} ({member.netid})
-                      {requiredCredits > 0 && (
-                        <NotifyMemberModal
-                          all={false}
-                          trigger={
-                            isAdvisor ? (
-                              <div />
-                            ) : (
-                              <Icon className={styles.notify} name="exclamation" color="red" />
-                            )
-                          }
-                          member={member}
-                          endOfSemesterReminder={endOfSemesterReminder}
-                          type={'tec'}
-                        />
-                      )}
-                    </Table.Cell>
-                    <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
-                    {periods.map((period) => {
-                      const numCredits = period.events
-                        .map((event) => calculateTotalCreditsForEvent(member, event))
-                        .filter((credits) => credits != null)
-                        .reduce((sum, credits) => sum + credits, 0);
+                  return (
+                    <Table.Row>
+                      <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
+                        {member.firstName} {member.lastName} ({member.netid})
+                        {requiredCredits > 0 && (
+                          <NotifyMemberModal
+                            all={false}
+                            trigger={
+                              isAdvisor ? (
+                                <div />
+                              ) : (
+                                <Icon className={styles.notify} name="exclamation" color="red" />
+                              )
+                            }
+                            member={member}
+                            endOfSemesterReminder={endOfSemesterReminder}
+                            type={'tec'}
+                          />
+                        )}
+                      </Table.Cell>
+                      <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
+                      {periods.map((period) => {
+                        const numCredits = period.events
+                          .map((event) => calculateTotalCreditsForEvent(member, event))
+                          .filter((credits) => credits != null)
+                          .reduce((sum, credits) => sum + credits, 0);
 
-                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                    })}
-                  </Table.Row>
-                );
-              })}
+                        return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                      })}
+                    </Table.Row>
+                  );
+                })}
           </Table.Body>
         </Table>
       </div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -15,10 +15,10 @@ import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
 
 interface Period {
-  name: string;
-  start: Date;
-  deadline: Date;
-  events: TeamEvent[];
+  name: string,
+  start: Date,
+  deadline: Date,
+  events: TeamEvent[]
 }
 const calculateMemberCreditsForEvent = (
   member: IdolMember,
@@ -28,15 +28,15 @@ const calculateMemberCreditsForEvent = (
   isInitiativeEvent && !event.isInitiativeEvent
     ? 0
     : event.requests
-        .filter((req) => req.status === 'approved')
-        .reduce((val: number, attendee) => {
-          if (attendee.member.email !== member.email) {
-            return val;
-          }
-          if (event.hasHours && attendee.hoursAttended)
-            return val + Number(event.numCredits) * attendee.hoursAttended;
-          return val + Number(event.numCredits);
-        }, 0);
+      .filter((req) => req.status === 'approved')
+      .reduce((val: number, attendee) => {
+        if (attendee.member.email !== member.email) {
+          return val;
+        }
+        if (event.hasHours && attendee.hoursAttended)
+          return val + Number(event.numCredits) * attendee.hoursAttended;
+        return val + Number(event.numCredits);
+      }, 0);
 
 const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, false);
@@ -70,7 +70,9 @@ const TeamEventDashboard: React.FC = () => {
     const today = new Date();
     const year = today.getFullYear();
 
-    return today.getMonth() < 7 ? new Date(year, 0, 1) : new Date(year, 7, 1);
+    return today.getMonth() < 7
+      ? new Date(year, 0, 1)
+      : new Date(year, 7, 1);
   };
 
   const getPeriodIndex = (date: Date): number => {
@@ -88,10 +90,9 @@ const TeamEventDashboard: React.FC = () => {
     TEC_DEADLINES.forEach((date) => {
       i += 1;
       const periodIndex = getPeriodIndex(new Date(date.getTime() - 24 * 60 * 60 * 1000));
-      const periodStart =
-        periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
+      const periodStart = periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
       const periodEnd = TEC_DEADLINES[periodIndex];
-      const events = teamEvents.filter((event) => {
+      const events = teamEvents.filter(event => {
         const eventDate = new Date(event.date);
         return eventDate > periodStart && eventDate <= periodEnd;
       });
@@ -105,9 +106,9 @@ const TeamEventDashboard: React.FC = () => {
     const credPerPeriod: number[] = [];
     periods.forEach((period: Period) => {
       credPerPeriod.push(getTotalCredits(member, period.events));
-    });
+    })
     return credPerPeriod;
-  };
+  }
 
   const getTECPeriod = (submissionDate: Date) => {
     const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
@@ -122,7 +123,9 @@ const TeamEventDashboard: React.FC = () => {
       return currentCredits < 1 ? 1 - currentCredits : 0;
     }
     if (prevCredits < 1) {
-      return currentCredits + prevCredits < 2 ? 2 - prevCredits - currentCredits : 0;
+      return currentCredits + prevCredits < 2
+        ? 2 - prevCredits - currentCredits
+        : 0;
     }
 
     return currentCredits < 1 ? 1 - currentCredits : 0;
@@ -131,13 +134,13 @@ const TeamEventDashboard: React.FC = () => {
   const currentPeriodIndex = getTECPeriod(new Date());
   const membersNeedingNotification = displayPeriod
     ? allMembers.filter((member) => {
-        const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
-        const requiredCredits = LEAD_ROLES.includes(member.role)
-          ? REQUIRED_LEAD_TEC_CREDITS
-          : calculateCredits(null, currentPeriodCredits);
+      const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
+      const requiredCredits = LEAD_ROLES.includes(member.role)
+        ? REQUIRED_LEAD_TEC_CREDITS
+        : calculateCredits(null, currentPeriodCredits);
 
-        return currentPeriodCredits < requiredCredits;
-      })
+      return currentPeriodCredits < requiredCredits;
+    })
     : [];
 
   const handleExportToCsv = () => {
@@ -185,7 +188,7 @@ const TeamEventDashboard: React.FC = () => {
         <div className={styles.csvButton}>
           <div className={styles.displayPeriod}>
             <Button onClick={() => setDisplayPeriod((prev) => !prev)}>
-              {!displayPeriod ? 'Display TEC by Period' : 'Return to Dashboard'}
+              {!displayPeriod ? "Display TEC by Period" : "Return to Dashboard"}
             </Button>
           </div>
           <div className={styles.csvButton}>
@@ -198,8 +201,8 @@ const TeamEventDashboard: React.FC = () => {
           <Table.Header>
             <Table.HeaderCell className={styles.nameCell}>
               Name
-              {displayPeriod && membersNeedingNotification.length > 0 ? (
-                <NotifyMemberModal
+              {displayPeriod && membersNeedingNotification.length > 0 ?
+                (<NotifyMemberModal
                   all={true}
                   trigger={
                     <Button className={styles.remindButton} size="small" color="orange">
@@ -210,7 +213,7 @@ const TeamEventDashboard: React.FC = () => {
                   endOfSemesterReminder={endOfSemesterReminder}
                   type={'tec'}
                 />
-              ) : (
+                ) :
                 <NotifyMemberModal
                   all={true}
                   trigger={
@@ -233,8 +236,7 @@ const TeamEventDashboard: React.FC = () => {
                   })}
                   endOfSemesterReminder={endOfSemesterReminder}
                   type={'tec'}
-                />
-              )}
+                />}
               <Checkbox
                 className={styles.endOfSemesterCheckbox}
                 label={{ children: 'End of Semester Reminder?' }}
@@ -244,108 +246,102 @@ const TeamEventDashboard: React.FC = () => {
                 }
               />
             </Table.HeaderCell>
-            <Table.HeaderCell>{!displayPeriod ? 'Total' : 'Required Credits'}</Table.HeaderCell>
+            <Table.HeaderCell>{!displayPeriod ? "Total" : "Required Credits"}</Table.HeaderCell>
             {INITIATIVE_EVENTS && <Table.HeaderCell>Total Initiative Credits</Table.HeaderCell>}
-            {!displayPeriod
-              ? teamEvents.map((event) => <Table.HeaderCell>{event.name}</Table.HeaderCell>)
-              : periods.map((period) => <Table.HeaderCell>{period.name}</Table.HeaderCell>)}
+            {!displayPeriod ?
+              teamEvents.map((event) => (
+                <Table.HeaderCell>{event.name}</Table.HeaderCell>
+              )) : periods.map((period) => (
+                <Table.HeaderCell>{period.name}</Table.HeaderCell>
+              ))}
           </Table.Header>
           <Table.Body>
             {!displayPeriod
               ? allMembers.map((member) => {
-                  const totalCredits = getTotalCredits(member, teamEvents);
-                  const initiativeCredits = getInitiativeCredits(member, teamEvents);
-                  const totalCreditsMet =
-                    totalCredits >=
-                    (LEAD_ROLES.includes(member.role)
-                      ? REQUIRED_LEAD_TEC_CREDITS
-                      : REQUIRED_MEMBER_TEC_CREDITS);
-                  const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
+                const totalCredits = getTotalCredits(member, teamEvents);
+                const initiativeCredits = getInitiativeCredits(member, teamEvents);
+                const totalCreditsMet =
+                  totalCredits >=
+                  (LEAD_ROLES.includes(member.role)
+                    ? REQUIRED_LEAD_TEC_CREDITS
+                    : REQUIRED_MEMBER_TEC_CREDITS);
+                const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
 
-                  const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-                  return (
-                    <Table.Row>
-                      <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
-                        {member.firstName} {member.lastName} ({member.netid})
-                        {!totalCreditsMet && (
-                          <NotifyMemberModal
-                            all={false}
-                            trigger={
-                              isAdvisor ? (
-                                <div />
-                              ) : (
-                                <Icon className={styles.notify} name="exclamation" color="red" />
-                              )
-                            }
-                            member={member}
-                            endOfSemesterReminder={endOfSemesterReminder}
-                            type={'tec'}
-                          />
-                        )}
-                      </Table.Cell>
-                      <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
-                      {INITIATIVE_EVENTS && (
-                        <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
+                return (
+                  <Table.Row>
+                    <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
+                      {member.firstName} {member.lastName} ({member.netid})
+                      {!totalCreditsMet && (
+                        <NotifyMemberModal
+                          all={false}
+                          trigger={
+                            isAdvisor ? (
+                              <div />
+                            ) : (
+                              <Icon className={styles.notify} name="exclamation" color="red" />
+                            )
+                          }
+                          member={member}
+                          endOfSemesterReminder={endOfSemesterReminder}
+                          type={'tec'}
+                        />
                       )}
-                      {teamEvents.map((event) => {
-                        const numCredits = calculateTotalCreditsForEvent(member, event);
-                        return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                      })}
-                    </Table.Row>
-                  );
-                })
-              : allMembers.map((member) => {
-                  const currentPeriodIndex = getTECPeriod(new Date());
-                  const currentPeriodCredits = getTotalCredits(
-                    member,
-                    periods[currentPeriodIndex].events
-                  );
-                  const creditsPerPeriod = getCreditsPerPeriod(member);
+                    </Table.Cell>
+                    <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
+                    {INITIATIVE_EVENTS && (
+                      <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
+                    )}
+                    {teamEvents.map((event) => {
+                      const numCredits = calculateTotalCreditsForEvent(member, event);
+                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                    })}
+                  </Table.Row>
+                );
+              }) : allMembers.map((member) => {
+                const currentPeriodIndex = getTECPeriod(new Date());
+                const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
+                const creditsPerPeriod = getCreditsPerPeriod(member);
 
-                  const previousPeriodIndex =
-                    currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
-                  const previousPeriodCredits =
-                    previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
-                  const requiredCredits = calculateCredits(
-                    previousPeriodCredits,
-                    currentPeriodCredits
-                  );
+                const previousPeriodIndex = currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
+                const previousPeriodCredits = previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
+                const requiredCredits = calculateCredits(previousPeriodCredits, currentPeriodCredits);
 
-                  const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-                  return (
-                    <Table.Row>
-                      <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
-                        {member.firstName} {member.lastName} ({member.netid})
-                        {requiredCredits > 0 && (
-                          <NotifyMemberModal
-                            all={false}
-                            trigger={
-                              isAdvisor ? (
-                                <div />
-                              ) : (
-                                <Icon className={styles.notify} name="exclamation" color="red" />
-                              )
-                            }
-                            member={member}
-                            endOfSemesterReminder={endOfSemesterReminder}
-                            type={'tec'}
-                          />
-                        )}
-                      </Table.Cell>
-                      <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
-                      {periods.map((period) => {
-                        const numCredits = period.events
-                          .map((event) => calculateTotalCreditsForEvent(member, event))
-                          .filter((credits) => credits != null)
-                          .reduce((sum, credits) => sum + credits, 0);
+                return (
+                  <Table.Row>
+                    <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
+                      {member.firstName} {member.lastName} ({member.netid})
+                      {requiredCredits > 0 && (
+                        <NotifyMemberModal
+                          all={false}
+                          trigger={
+                            isAdvisor ? (
+                              <div />
+                            ) : (
+                              <Icon className={styles.notify} name="exclamation" color="red" />
+                            )
+                          }
+                          member={member}
+                          endOfSemesterReminder={endOfSemesterReminder}
+                          type={'tec'}
+                        />
+                      )}
+                    </Table.Cell>
+                    <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
+                    {periods.map((period) => {
+                      const numCredits = period.events
+                        .map((event) => calculateTotalCreditsForEvent(member, event))
+                        .filter((credits) => credits != null)
+                        .reduce((sum, credits) => sum + credits, 0);
 
-                        return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                      })}
-                    </Table.Row>
-                  );
-                })}
+                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                    })}
+                  </Table.Row>
+                );
+              })}
           </Table.Body>
         </Table>
       </div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
-import { getTECPeriod } from '../../../utils';
+import { calculateCredits, getTECPeriod } from '../../../utils';
 
 interface Period {
   name: string;
@@ -29,15 +29,15 @@ const calculateMemberCreditsForEvent = (
   isInitiativeEvent && !event.isInitiativeEvent
     ? 0
     : event.requests
-      .filter((req) => req.status === 'approved')
-      .reduce((val: number, attendee) => {
-        if (attendee.member.email !== member.email) {
-          return val;
-        }
-        if (event.hasHours && attendee.hoursAttended)
-          return val + Number(event.numCredits) * attendee.hoursAttended;
-        return val + Number(event.numCredits);
-      }, 0);
+        .filter((req) => req.status === 'approved')
+        .reduce((val: number, attendee) => {
+          if (attendee.member.email !== member.email) {
+            return val;
+          }
+          if (event.hasHours && attendee.hoursAttended)
+            return val + Number(event.numCredits) * attendee.hoursAttended;
+          return val + Number(event.numCredits);
+        }, 0);
 
 const calculateTotalCreditsForEvent = (member: IdolMember, event: TeamEvent): number =>
   calculateMemberCreditsForEvent(member, event, false);
@@ -76,10 +76,8 @@ const TeamEventDashboard: React.FC = () => {
 
   const getPeriods = () =>
     TEC_DEADLINES.map((date, i) => {
-      const periodIndex = getTECPeriod(new Date(date.getTime() - 24 * 60 * 60 * 1000));
-      const periodStart =
-        periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
-      const periodEnd = TEC_DEADLINES[periodIndex];
+      const periodStart = i === 0 ? getFirstPeriodStart() : TEC_DEADLINES[i - 1];
+      const periodEnd = TEC_DEADLINES[i];
       const events = teamEvents.filter((event) => {
         const eventDate = new Date(event.date);
         return eventDate > periodStart && eventDate <= periodEnd;
@@ -96,27 +94,16 @@ const TeamEventDashboard: React.FC = () => {
     return credPerPeriod;
   };
 
-  const calculateCredits = (prevCredits: number | null, currentCredits: number) => {
-    if (prevCredits === null) {
-      return currentCredits < 1 ? 1 - currentCredits : 0;
-    }
-    if (prevCredits < 1) {
-      return currentCredits + prevCredits < 2 ? 2 - prevCredits - currentCredits : 0;
-    }
-
-    return currentCredits < 1 ? 1 - currentCredits : 0;
-  };
-
   const currentPeriodIndex = getTECPeriod(new Date());
   const membersNeedingNotification = displayPeriod
     ? allMembers.filter((member) => {
-      const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
-      const requiredCredits = LEAD_ROLES.includes(member.role)
-        ? REQUIRED_LEAD_TEC_CREDITS
-        : calculateCredits(null, currentPeriodCredits);
+        const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
+        const requiredCredits = LEAD_ROLES.includes(member.role)
+          ? REQUIRED_LEAD_TEC_CREDITS
+          : calculateCredits(null, currentPeriodCredits);
 
-      return currentPeriodCredits < requiredCredits;
-    })
+        return currentPeriodCredits < requiredCredits;
+      })
     : [];
 
   const handleExportToCsv = () => {
@@ -234,99 +221,99 @@ const TeamEventDashboard: React.FC = () => {
           <Table.Body>
             {!displayPeriod
               ? allMembers.map((member) => {
-                const totalCredits = getTotalCredits(member, teamEvents);
-                const initiativeCredits = getInitiativeCredits(member, teamEvents);
-                const totalCreditsMet =
-                  totalCredits >=
-                  (LEAD_ROLES.includes(member.role)
-                    ? REQUIRED_LEAD_TEC_CREDITS
-                    : REQUIRED_MEMBER_TEC_CREDITS);
-                const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
+                  const totalCredits = getTotalCredits(member, teamEvents);
+                  const initiativeCredits = getInitiativeCredits(member, teamEvents);
+                  const totalCreditsMet =
+                    totalCredits >=
+                    (LEAD_ROLES.includes(member.role)
+                      ? REQUIRED_LEAD_TEC_CREDITS
+                      : REQUIRED_MEMBER_TEC_CREDITS);
+                  const initiativeCreditsMet = initiativeCredits >= REQUIRED_INITIATIVE_CREDITS;
 
-                const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                  const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-                return (
-                  <Table.Row>
-                    <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
-                      {member.firstName} {member.lastName} ({member.netid})
-                      {!totalCreditsMet && (
-                        <NotifyMemberModal
-                          all={false}
-                          trigger={
-                            isAdvisor ? (
-                              <div />
-                            ) : (
-                              <Icon className={styles.notify} name="exclamation" color="red" />
-                            )
-                          }
-                          member={member}
-                          endOfSemesterReminder={endOfSemesterReminder}
-                          type={'tec'}
-                        />
+                  return (
+                    <Table.Row>
+                      <Table.Cell positive={totalCreditsMet} className={styles.nameCell}>
+                        {member.firstName} {member.lastName} ({member.netid})
+                        {!totalCreditsMet && (
+                          <NotifyMemberModal
+                            all={false}
+                            trigger={
+                              isAdvisor ? (
+                                <div />
+                              ) : (
+                                <Icon className={styles.notify} name="exclamation" color="red" />
+                              )
+                            }
+                            member={member}
+                            endOfSemesterReminder={endOfSemesterReminder}
+                            type={'tec'}
+                          />
+                        )}
+                      </Table.Cell>
+                      <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
+                      {INITIATIVE_EVENTS && (
+                        <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
                       )}
-                    </Table.Cell>
-                    <Table.Cell positive={totalCreditsMet}>{totalCredits}</Table.Cell>
-                    {INITIATIVE_EVENTS && (
-                      <Table.Cell positive={initiativeCreditsMet}>{initiativeCredits}</Table.Cell>
-                    )}
-                    {teamEvents.map((event) => {
-                      const numCredits = calculateTotalCreditsForEvent(member, event);
-                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                    })}
-                  </Table.Row>
-                );
-              })
+                      {teamEvents.map((event) => {
+                        const numCredits = calculateTotalCreditsForEvent(member, event);
+                        return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                      })}
+                    </Table.Row>
+                  );
+                })
               : allMembers.map((member) => {
-                const currentPeriodIndex = getTECPeriod(new Date());
-                const currentPeriodCredits = getTotalCredits(
-                  member,
-                  periods[currentPeriodIndex].events
-                );
-                const creditsPerPeriod = getCreditsPerPeriod(member);
+                  const currentPeriodIndex = getTECPeriod(new Date());
+                  const currentPeriodCredits = getTotalCredits(
+                    member,
+                    periods[currentPeriodIndex].events
+                  );
+                  const creditsPerPeriod = getCreditsPerPeriod(member);
 
-                const previousPeriodIndex =
-                  currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
-                const previousPeriodCredits =
-                  previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
-                const requiredCredits = calculateCredits(
-                  previousPeriodCredits,
-                  currentPeriodCredits
-                );
+                  const previousPeriodIndex =
+                    currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
+                  const previousPeriodCredits =
+                    previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
+                  const requiredCredits = calculateCredits(
+                    previousPeriodCredits,
+                    currentPeriodCredits
+                  );
 
-                const isAdvisor = ADVISOR_ROLES.includes(member.role);
+                  const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
-                return (
-                  <Table.Row>
-                    <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
-                      {member.firstName} {member.lastName} ({member.netid})
-                      {requiredCredits > 0 && (
-                        <NotifyMemberModal
-                          all={false}
-                          trigger={
-                            isAdvisor ? (
-                              <div />
-                            ) : (
-                              <Icon className={styles.notify} name="exclamation" color="red" />
-                            )
-                          }
-                          member={member}
-                          endOfSemesterReminder={endOfSemesterReminder}
-                          type={'tec'}
-                        />
-                      )}
-                    </Table.Cell>
-                    <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
-                    {periods.map((period) => {
-                      const numCredits = period.events
-                        .map((event) => calculateTotalCreditsForEvent(member, event))
-                        .filter((credits) => credits != null)
-                        .reduce((sum, credits) => sum + credits, 0);
+                  return (
+                    <Table.Row>
+                      <Table.Cell positive={requiredCredits <= 0} className={styles.nameCell}>
+                        {member.firstName} {member.lastName} ({member.netid})
+                        {requiredCredits > 0 && (
+                          <NotifyMemberModal
+                            all={false}
+                            trigger={
+                              isAdvisor ? (
+                                <div />
+                              ) : (
+                                <Icon className={styles.notify} name="exclamation" color="red" />
+                              )
+                            }
+                            member={member}
+                            endOfSemesterReminder={endOfSemesterReminder}
+                            type={'tec'}
+                          />
+                        )}
+                      </Table.Cell>
+                      <Table.Cell positive={requiredCredits <= 0}>{requiredCredits}</Table.Cell>
+                      {periods.map((period) => {
+                        const numCredits = period.events
+                          .map((event) => calculateTotalCreditsForEvent(member, event))
+                          .filter((credits) => credits != null)
+                          .reduce((sum, credits) => sum + credits, 0);
 
-                      return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
-                    })}
-                  </Table.Row>
-                );
-              })}
+                        return <Table.Cell className={styles.eventCell}>{numCredits}</Table.Cell>;
+                      })}
+                    </Table.Row>
+                  );
+                })}
           </Table.Body>
         </Table>
       </div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -86,13 +86,8 @@ const TeamEventDashboard: React.FC = () => {
     });
 
   const periods = getPeriods();
-  const getCreditsPerPeriod = (member: IdolMember) => {
-    const credPerPeriod: number[] = [];
-    periods.forEach((period: Period) => {
-      credPerPeriod.push(getTotalCredits(member, period.events));
-    });
-    return credPerPeriod;
-  };
+  const getCreditsPerPeriod = (member: IdolMember) =>
+    periods.map((period: Period) => getTotalCredits(member, period.events));
 
   const currentPeriodIndex = getTECPeriod(new Date());
   const membersNeedingNotification = displayPeriod

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -15,10 +15,10 @@ import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
 
 interface Period {
-  name: string,
-  start: Date,
-  deadline: Date,
-  events: TeamEvent[]
+  name: string;
+  start: Date;
+  deadline: Date;
+  events: TeamEvent[];
 }
 const calculateMemberCreditsForEvent = (
   member: IdolMember,
@@ -70,9 +70,7 @@ const TeamEventDashboard: React.FC = () => {
     const today = new Date();
     const year = today.getFullYear();
 
-    return today.getMonth() < 7
-      ? new Date(year, 0, 1)
-      : new Date(year, 7, 1);
+    return today.getMonth() < 7 ? new Date(year, 0, 1) : new Date(year, 7, 1);
   };
 
   const getPeriodIndex = (date: Date): number => {
@@ -90,9 +88,10 @@ const TeamEventDashboard: React.FC = () => {
     TEC_DEADLINES.forEach((date) => {
       i += 1;
       const periodIndex = getPeriodIndex(new Date(date.getTime() - 24 * 60 * 60 * 1000));
-      const periodStart = periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
+      const periodStart =
+        periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
       const periodEnd = TEC_DEADLINES[periodIndex];
-      const events = teamEvents.filter(event => {
+      const events = teamEvents.filter((event) => {
         const eventDate = new Date(event.date);
         return eventDate > periodStart && eventDate <= periodEnd;
       });
@@ -106,9 +105,9 @@ const TeamEventDashboard: React.FC = () => {
     const credPerPeriod: number[] = [];
     periods.forEach((period: Period) => {
       credPerPeriod.push(getTotalCredits(member, period.events));
-    })
+    });
     return credPerPeriod;
-  }
+  };
 
   const getTECPeriod = (submissionDate: Date) => {
     const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
@@ -123,9 +122,7 @@ const TeamEventDashboard: React.FC = () => {
       return currentCredits < 1 ? 1 - currentCredits : 0;
     }
     if (prevCredits < 1) {
-      return currentCredits + prevCredits < 2
-        ? 2 - prevCredits - currentCredits
-        : 0;
+      return currentCredits + prevCredits < 2 ? 2 - prevCredits - currentCredits : 0;
     }
 
     return currentCredits < 1 ? 1 - currentCredits : 0;
@@ -188,7 +185,7 @@ const TeamEventDashboard: React.FC = () => {
         <div className={styles.csvButton}>
           <div className={styles.displayPeriod}>
             <Button onClick={() => setDisplayPeriod((prev) => !prev)}>
-              {!displayPeriod ? "Display TEC by Period" : "Return to Dashboard"}
+              {!displayPeriod ? 'Display TEC by Period' : 'Return to Dashboard'}
             </Button>
           </div>
           <div className={styles.csvButton}>
@@ -201,8 +198,8 @@ const TeamEventDashboard: React.FC = () => {
           <Table.Header>
             <Table.HeaderCell className={styles.nameCell}>
               Name
-              {displayPeriod && membersNeedingNotification.length > 0 ?
-                (<NotifyMemberModal
+              {displayPeriod && membersNeedingNotification.length > 0 ? (
+                <NotifyMemberModal
                   all={true}
                   trigger={
                     <Button className={styles.remindButton} size="small" color="orange">
@@ -213,7 +210,7 @@ const TeamEventDashboard: React.FC = () => {
                   endOfSemesterReminder={endOfSemesterReminder}
                   type={'tec'}
                 />
-                ) :
+              ) : (
                 <NotifyMemberModal
                   all={true}
                   trigger={
@@ -236,24 +233,24 @@ const TeamEventDashboard: React.FC = () => {
                   })}
                   endOfSemesterReminder={endOfSemesterReminder}
                   type={'tec'}
-                />}
-              <Checkbox
-                className={styles.endOfSemesterCheckbox}
-                label={{ children: 'End of Semester Reminder?' }}
-                checked={endOfSemesterReminder}
-                onChange={() =>
-                  setEndOfSemesterReminder((endOfSemesterReminder) => !endOfSemesterReminder)
-                }
-              />
+                />
+              )}
+              {!displayPeriod && (
+                <Checkbox
+                  className={styles.endOfSemesterCheckbox}
+                  label={{ children: 'End of Semester Reminder?' }}
+                  checked={endOfSemesterReminder}
+                  onChange={() =>
+                    setEndOfSemesterReminder((endOfSemesterReminder) => !endOfSemesterReminder)
+                  }
+                />
+              )}
             </Table.HeaderCell>
-            <Table.HeaderCell>{!displayPeriod ? "Total" : "Required Credits"}</Table.HeaderCell>
+            <Table.HeaderCell>{!displayPeriod ? 'Total' : 'Required Credits'}</Table.HeaderCell>
             {INITIATIVE_EVENTS && <Table.HeaderCell>Total Initiative Credits</Table.HeaderCell>}
-            {!displayPeriod ?
-              teamEvents.map((event) => (
-                <Table.HeaderCell>{event.name}</Table.HeaderCell>
-              )) : periods.map((period) => (
-                <Table.HeaderCell>{period.name}</Table.HeaderCell>
-              ))}
+            {!displayPeriod
+              ? teamEvents.map((event) => <Table.HeaderCell>{event.name}</Table.HeaderCell>)
+              : periods.map((period) => <Table.HeaderCell>{period.name}</Table.HeaderCell>)}
           </Table.Header>
           <Table.Body>
             {!displayPeriod
@@ -299,14 +296,23 @@ const TeamEventDashboard: React.FC = () => {
                     })}
                   </Table.Row>
                 );
-              }) : allMembers.map((member) => {
+              })
+              : allMembers.map((member) => {
                 const currentPeriodIndex = getTECPeriod(new Date());
-                const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
+                const currentPeriodCredits = getTotalCredits(
+                  member,
+                  periods[currentPeriodIndex].events
+                );
                 const creditsPerPeriod = getCreditsPerPeriod(member);
 
-                const previousPeriodIndex = currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
-                const previousPeriodCredits = previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
-                const requiredCredits = calculateCredits(previousPeriodCredits, currentPeriodCredits);
+                const previousPeriodIndex =
+                  currentPeriodIndex > 0 ? currentPeriodIndex - 1 : null;
+                const previousPeriodCredits =
+                  previousPeriodIndex !== null ? creditsPerPeriod[previousPeriodIndex] : null;
+                const requiredCredits = calculateCredits(
+                  previousPeriodCredits,
+                  currentPeriodCredits
+                );
 
                 const isAdvisor = ADVISOR_ROLES.includes(member.role);
 

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
+import { getTECPeriod } from '../../../utils';
 
 interface Period {
   name: string;
@@ -73,18 +74,9 @@ const TeamEventDashboard: React.FC = () => {
     return today.getMonth() < 7 ? new Date(year, 0, 1) : new Date(year, 7, 1);
   };
 
-  const getPeriodIndex = (date: Date): number => {
-    for (let i = 0; i < TEC_DEADLINES.length; i += 1) {
-      if (date <= TEC_DEADLINES[i]) {
-        return i;
-      }
-    }
-    return TEC_DEADLINES.length - 1;
-  };
-
   const getPeriods = () =>
     TEC_DEADLINES.map((date, i) => {
-      const periodIndex = getPeriodIndex(new Date(date.getTime() - 24 * 60 * 60 * 1000));
+      const periodIndex = getTECPeriod(new Date(date.getTime() - 24 * 60 * 60 * 1000));
       const periodStart =
         periodIndex === 0 ? getFirstPeriodStart() : TEC_DEADLINES[periodIndex - 1];
       const periodEnd = TEC_DEADLINES[periodIndex];
@@ -102,14 +94,6 @@ const TeamEventDashboard: React.FC = () => {
       credPerPeriod.push(getTotalCredits(member, period.events));
     });
     return credPerPeriod;
-  };
-
-  const getTECPeriod = (submissionDate: Date) => {
-    const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
-    if (currentPeriodIndex === -1) {
-      return TEC_DEADLINES.length;
-    }
-    return currentPeriodIndex;
   };
 
   const calculateCredits = (prevCredits: number | null, currentCredits: number) => {

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,5 +1,7 @@
 /* eslint-disable max-classes-per-file */
 
+import { TEC_DEADLINES } from "./consts";
+
 export const getNetIDFromEmail = (email: string): string => email.split('@')[0];
 
 export const getRoleDescriptionFromRoleID = (role: Role): RoleDescription => {
@@ -208,4 +210,18 @@ export const fpo = async (csv: File): Promise<[string[], string[][]]> => {
   const headers = rows[0].split(',').map((header) => header.toLowerCase());
   const responses = rows.splice(1).map((row) => row.split(','));
   return [headers, responses];
+};
+
+/**
+ * Determines the TEC period index for a given submission date.
+ * @param submissionDate The date for which the TEC period is being determined.
+ * @returns The index of the current TEC period in the `TEC_DEADLINES` array.
+ *          If the submission date is after all deadlines, returns the last period index.
+ */
+export const getTECPeriod = (submissionDate: Date) => {
+  const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
+  if (currentPeriodIndex === -1) {
+    return TEC_DEADLINES.length;
+  }
+  return currentPeriodIndex;
 };

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
-import { TEC_DEADLINES } from "./consts";
+import { TEC_DEADLINES } from './consts';
 
 export const getNetIDFromEmail = (email: string): string => email.split('@')[0];
 
@@ -224,4 +224,15 @@ export const getTECPeriod = (submissionDate: Date) => {
     return TEC_DEADLINES.length - 1;
   }
   return currentPeriodIndex;
+};
+
+export const calculateCredits = (prevCredits: number | null, currentCredits: number) => {
+  if (prevCredits === null) {
+    return currentCredits < 1 ? 1 - currentCredits : 0;
+  }
+  if (prevCredits < 1) {
+    return currentCredits + prevCredits < 2 ? 2 - prevCredits - currentCredits : 0;
+  }
+
+  return currentCredits < 1 ? 1 - currentCredits : 0;
 };

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -226,6 +226,13 @@ export const getTECPeriod = (submissionDate: Date) => {
   return currentPeriodIndex;
 };
 
+/**
+ * Calculates the number of credits needed based on previous and current period credits.
+ * @param prevCredits The number of credits from the previous period. Null if it's the first period.
+ * @param currentCredits The number of credits in the current period.
+ * @returns The number of additional credits needed to meet the requirement.
+ *          Returns 0 if the requirement is already met.
+ */
 export const calculateCredits = (prevCredits: number | null, currentCredits: number) => {
   if (prevCredits === null) {
     return currentCredits < 1 ? 1 - currentCredits : 0;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -221,7 +221,7 @@ export const fpo = async (csv: File): Promise<[string[], string[][]]> => {
 export const getTECPeriod = (submissionDate: Date) => {
   const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
   if (currentPeriodIndex === -1) {
-    return TEC_DEADLINES.length;
+    return TEC_DEADLINES.length - 1;
   }
   return currentPeriodIndex;
 };


### PR DESCRIPTION
### Summary <!-- Required -->

 I added a toggleable view that allows admins to track TEC credits across different periods.

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

Verified that toggling the new setting correctly switches between total TEC view and period-based TEC view.
Ensured that period-based TEC calculations display accurate credit requirements for each member.
Checked that the notify button correctly reflects members who have not met their TEC requirements per period.

https://github.com/user-attachments/assets/a37ec563-131a-4112-9d32-49c5b6cdbd3c

### Notes <!-- Optional -->

I still need to update the email message that goes out to members who haven't completed their TEC for the current period as currently the message is the same as the one that tells them they haven't competed enough TEC for the semester. 

Also I'm not sure how the policy should affect leads? Are they required to do more than 1 tec per period?
