### PR TITLE
Clement candidate decider layout change

### DIFF
--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.module.css
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.module.css
@@ -3,9 +3,6 @@
   flex-direction: column;
   align-items: left;
   justify-content: left;
-  padding: 20px !important;
-  margin-top: 20px;
-  margin-bottom: 20px;
 }
 
 .iconsContainer {

--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -1,4 +1,3 @@
-import { Card } from 'semantic-ui-react';
 import styles from './ApplicantCredentials.module.css';
 import { formatLink } from '../../utils';
 

--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -27,7 +27,7 @@ const ApplicantCredentials: React.FC<Props> = ({
   preferredName,
   candidate
 }) => (
-  <Card className={styles.credentialContainer}>
+  <div className={styles.credentialContainer}>
     {seeApplicantName ? (
       <>
         <h1>
@@ -83,7 +83,7 @@ const ApplicantCredentials: React.FC<Props> = ({
         )}
       </div>
     )}
-  </Card>
+  </div>
 );
 
 const FileIcon = () => (

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
@@ -3,21 +3,22 @@
 }
 
 .candidateDeciderContainer {
-  padding: 2%;
   display: flex;
+  height: 100%;
+  gap: 32px;
+  padding: 32px;
 }
 
-.applicationContainer {
-  width: 150em;
-  border-right: solid;
-  border-color: lightgrey;
-  padding: 1%;
-  overflow-wrap: break-word;
-  overflow: hidden;
+.leftColumn {
+  width: 500px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  border: 1px solid #666;
 }
 
 .progressContainer {
-  padding: 1%;
   display: flex;
   width: 100%;
 }
@@ -29,6 +30,8 @@
 }
 
 .searchBar {
+  display: flex;
+  gap: 8px;
   margin-bottom: 1%;
 }
 
@@ -49,4 +52,56 @@
 
 .previousNextButtonContainer {
   margin-right: 0.5% !important;
+}
+
+.responsesContainer {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  flex: 1;
+  border: 1px solid #666;
+  padding: 24px;
+}
+
+.top {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.bottom {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.saveButtonWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  border-top: 1px solid #666;
+}
+
+.saveButtonWrapper button {
+  flex: 1;
+}
+
+.ratingSelectorWrapper {
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  border-top: 1px solid #666;
+}
+
+.commentEditorWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  border-top: 1px solid #666;
+}
+
+.navigation {
+  padding: 24px;
 }

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -48,6 +48,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [nextCandidate, setNextCandidate] = useState<number | null>(null);
   const [currentCandidate, setCurrentCandidate] = useState<number>(0);
+  const [showOtherVotes, setShowOtherVotes] = useState<boolean>(false);
   const [seeApplicantName, setSeeApplicantName] = useState<boolean>(false);
 
   const userInfo = useSelf();

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -226,8 +226,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
                 </Button>
               </Button.Group>
             </div>
-
-            <div className={styles.controlsContainer}></div>
           </div>
           <div className={styles.commentEditorWrapper}>
             <CommentEditor currentComment={currentComment} setCurrentComment={setCurrentComment} />

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
-import { Button, Dropdown, Checkbox, Modal } from 'semantic-ui-react';
+import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+import { Button, Checkbox, Modal, Form, Radio } from 'semantic-ui-react';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import ResponsesPanel from './ResponsesPanel';
 import LocalProgressPanel from './LocalProgressPanel';
-import GlobalProgressPanel from './GlobalProgressPanel';
 import { useHasAdminPermission, useSelf } from '../Common/FirestoreDataProvider';
 import styles from './CandidateDecider.module.css';
 import SearchBar from './SearchBar';
@@ -11,9 +10,6 @@ import {
   useCandidateDeciderInstance,
   useCandidateDeciderReviews
 } from './useCandidateDeciderInstance';
-import { Dispatch, SetStateAction } from 'react';
-import { Form, Radio } from 'semantic-ui-react';
-import ApplicantCredentials from './ApplicantCredentials';
 
 type CandidateDeciderProps = {
   uuid: string;
@@ -52,7 +48,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [nextCandidate, setNextCandidate] = useState<number | null>(null);
   const [currentCandidate, setCurrentCandidate] = useState<number>(0);
-  const [showOtherVotes, setShowOtherVotes] = useState<boolean>(false);
   const [seeApplicantName, setSeeApplicantName] = useState<boolean>(false);
 
   const userInfo = useSelf();
@@ -196,11 +191,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
                 currentCandidate={currentCandidate}
                 reviews={completedReviews}
               />
-              {/* <GlobalProgressPanel
-            showOtherVotes={showOtherVotes}
-            candidates={instance.candidates}
-            reviews={completedReviews}
-          /> */}
             </div>
 
             <div className={styles.searchBar}>
@@ -236,33 +226,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
               </Button.Group>
             </div>
 
-            <div className={styles.controlsContainer}>
-              {/* <h4 className={styles.candidateIDTitle}>Candidate ID:</h4>
-          <Dropdown
-            compact
-            value={currentCandidate}
-            selection
-            options={instance.candidates.map((candidate) => ({
-              value: candidate.id,
-              key: candidate.id,
-              text: candidate.id + 1 // offset by 1 to account for 0-indexed array
-            }))}
-            onChange={(_, data) => {
-              handleCandidateChange(data.value as number);
-            }}
-          />
-          <span className={styles.ofNum}>of {instance.candidates.length}</span> */}
-
-              {/* {hasAdminPermission && (
-            <Checkbox
-              className={styles.showOtherVotes}
-              toggle
-              checked={showOtherVotes}
-              onChange={() => setShowOtherVotes((prev) => !prev)}
-              label="Show other people's votes"
-            />
-          )} */}
-            </div>
+            <div className={styles.controlsContainer}></div>
           </div>
           <div className={styles.commentEditorWrapper}>
             <CommentEditor currentComment={currentComment} setCurrentComment={setCurrentComment} />

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -11,10 +11,42 @@ import {
   useCandidateDeciderInstance,
   useCandidateDeciderReviews
 } from './useCandidateDeciderInstance';
+import { Dispatch, SetStateAction } from 'react';
+import { Form, Radio } from 'semantic-ui-react';
+import ApplicantCredentials from './ApplicantCredentials';
 
 type CandidateDeciderProps = {
   uuid: string;
 };
+
+const ratings = [
+  { value: 1, text: 'Strong No', color: 'red' },
+  { value: 2, text: 'No', color: 'orange' },
+  { value: 3, text: 'Maybe', color: 'yellow' },
+  { value: 4, text: 'Yes', color: 'green' },
+  { value: 5, text: 'Strong Yes', color: 'green ' },
+  { value: 0, text: 'Undecided', color: 'grey' }
+];
+
+type CommentEditorProps = {
+  currentComment: string | undefined;
+  setCurrentComment: Dispatch<SetStateAction<string | undefined>>;
+};
+
+const CommentEditor: React.FC<CommentEditorProps> = ({ currentComment, setCurrentComment }) => (
+  <div style={{ width: '100%' }}>
+    <h4>Comments</h4>
+    <Form.Group inline>
+      <Form.Input
+        style={{ height: 256, width: '100%' }}
+        className="fifteen wide field"
+        placeholder={'Comment...'}
+        onChange={(_, data) => setCurrentComment(data.value)}
+        value={currentComment}
+      />
+    </Form.Group>
+  </div>
+);
 
 const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -154,19 +186,58 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           </Button>
         </Modal.Actions>
       </Modal>
-      <div className={styles.applicationContainer}>
-        <div className={styles.searchBar}>
-          <SearchBar
-            instance={instance}
-            setCurrentCandidate={(candidate) => {
-              handleCandidateChange(candidate);
-            }}
-            currentCandidate={currentCandidate}
-            seeApplicantName={seeApplicantName}
-          />
-        </div>
-        <div className={styles.controlsContainer}>
-          <h4 className={styles.candidateIDTitle}>Candidate ID:</h4>
+      <div className={styles.leftColumn}>
+        <div className={styles.top}>
+          <div className={styles.navigation}>
+            <div className={styles.progressContainer}>
+              <LocalProgressPanel
+                showOtherVotes={showOtherVotes}
+                candidates={instance.candidates}
+                currentCandidate={currentCandidate}
+                reviews={completedReviews}
+              />
+              {/* <GlobalProgressPanel
+            showOtherVotes={showOtherVotes}
+            candidates={instance.candidates}
+            reviews={completedReviews}
+          /> */}
+            </div>
+
+            <div className={styles.searchBar}>
+              <Button
+                basic
+                color="blue"
+                disabled={currentCandidate === 0}
+                onClick={() => {
+                  handleCandidateChange(currentCandidate - 1);
+                }}
+              >
+                PREVIOUS
+              </Button>
+              <SearchBar
+                instance={instance}
+                setCurrentCandidate={(candidate) => {
+                  handleCandidateChange(candidate);
+                }}
+                currentCandidate={currentCandidate}
+                seeApplicantName={seeApplicantName}
+              />
+              <Button.Group className={styles.previousNextButtonContainer}>
+                <Button
+                  basic
+                  color="blue"
+                  disabled={currentCandidate === instance.candidates.length - 1}
+                  onClick={() => {
+                    handleCandidateChange(currentCandidate + 1);
+                  }}
+                >
+                  NEXT
+                </Button>
+              </Button.Group>
+            </div>
+
+            <div className={styles.controlsContainer}>
+              {/* <h4 className={styles.candidateIDTitle}>Candidate ID:</h4>
           <Dropdown
             compact
             value={currentCandidate}
@@ -180,43 +251,9 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
               handleCandidateChange(data.value as number);
             }}
           />
-          <span className={styles.ofNum}>of {instance.candidates.length}</span>
-          <Button.Group className={styles.previousNextButtonContainer}>
-            <Button
-              basic
-              color="blue"
-              disabled={currentCandidate === 0}
-              onClick={() => {
-                handleCandidateChange(currentCandidate - 1);
-              }}
-            >
-              PREVIOUS
-            </Button>
-            <Button
-              basic
-              color="blue"
-              disabled={currentCandidate === instance.candidates.length - 1}
-              onClick={() => {
-                handleCandidateChange(currentCandidate + 1);
-              }}
-            >
-              NEXT
-            </Button>
-          </Button.Group>
-          <Button
-            className="ui blue button"
-            disabled={isSaved}
-            onClick={() => {
-              handleRatingAndCommentChange(
-                currentCandidate,
-                currentRating ?? 0,
-                currentComment ?? ''
-              );
-            }}
-          >
-            Save
-          </Button>
-          {hasAdminPermission && (
+          <span className={styles.ofNum}>of {instance.candidates.length}</span> */}
+
+              {/* {hasAdminPermission && (
             <Checkbox
               className={styles.showOtherVotes}
               toggle
@@ -224,17 +261,61 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
               onChange={() => setShowOtherVotes((prev) => !prev)}
               label="Show other people's votes"
             />
-          )}
-          {hasAdminPermission && (
-            <Checkbox
-              className={styles.seeApplicantName}
-              toggle
-              checked={seeApplicantName}
-              onChange={() => setSeeApplicantName((prev) => !prev)}
-              label="See applicant name"
-            />
-          )}
+          )} */}
+            </div>
+          </div>
+          <div className={styles.commentEditorWrapper}>
+            <CommentEditor currentComment={currentComment} setCurrentComment={setCurrentComment} />
+          </div>
         </div>
+        <div className={styles.bottom}>
+          <div className={styles.ratingSelectorWrapper}>
+            <h4>Final selection</h4>
+
+            <Form>
+              <Form.Group inline>
+                {ratings.map((rt) => (
+                  <Form.Field key={rt.value}>
+                    <Radio
+                      label={rt.text}
+                      name="rating-group"
+                      value={rt.value}
+                      color={rt.color}
+                      checked={rt.value === currentRating}
+                      onClick={() => setCurrentRating(rt.value as Rating)}
+                    />
+                  </Form.Field>
+                ))}
+              </Form.Group>
+            </Form>
+          </div>
+          <div className={styles.saveButtonWrapper}>
+            <Button
+              className="ui blue button"
+              disabled={isSaved}
+              onClick={() => {
+                handleRatingAndCommentChange(
+                  currentCandidate,
+                  currentRating ?? 0,
+                  currentComment ?? ''
+                );
+              }}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </div>
+      <div className={styles.responsesContainer}>
+        {hasAdminPermission && (
+          <Checkbox
+            className={styles.seeApplicantName}
+            toggle
+            checked={seeApplicantName}
+            onChange={() => setSeeApplicantName((prev) => !prev)}
+            label="See applicant name"
+          />
+        )}
         <ResponsesPanel
           headers={instance.headers}
           responses={instance.candidates[currentCandidate].responses}
@@ -244,19 +325,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           setCurrentRating={setCurrentRating}
           seeApplicantName={seeApplicantName}
           candidate={instance.candidates[currentCandidate].id}
-        />
-      </div>
-      <div className={styles.progressContainer}>
-        <LocalProgressPanel
-          showOtherVotes={showOtherVotes}
-          candidates={instance.candidates}
-          currentCandidate={currentCandidate}
-          reviews={completedReviews}
-        />
-        <GlobalProgressPanel
-          showOtherVotes={showOtherVotes}
-          candidates={instance.candidates}
-          reviews={completedReviews}
         />
       </div>
     </div>

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -48,7 +48,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [nextCandidate, setNextCandidate] = useState<number | null>(null);
   const [currentCandidate, setCurrentCandidate] = useState<number>(0);
-  const [showOtherVotes, setShowOtherVotes] = useState<boolean>(false);
   const [seeApplicantName, setSeeApplicantName] = useState<boolean>(false);
 
   const userInfo = useSelf();
@@ -187,7 +186,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           <div className={styles.navigation}>
             <div className={styles.progressContainer}>
               <LocalProgressPanel
-                showOtherVotes={showOtherVotes}
                 candidates={instance.candidates}
                 currentCandidate={currentCandidate}
                 reviews={completedReviews}

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -37,7 +37,7 @@ const CommentEditor: React.FC<CommentEditorProps> = ({ currentComment, setCurren
         style={{ height: 256, width: '100%' }}
         className="fifteen wide field"
         placeholder={'Comment...'}
-        onChange={(_, data) => setCurrentComment(data.value)}
+        onChange={(event) => setCurrentComment(event.target.value)}
         value={currentComment}
       />
     </Form.Group>
@@ -59,8 +59,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
     const rating = reviews.find(
       (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
     );
-    if (rating) return rating.rating;
-    return undefined;
+    return rating ? rating.rating : undefined;
   };
 
   const getComment = (candidate: number) => {
@@ -80,8 +79,8 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
     currentComment === defaultCurrentComment && currentRating === defaultCurrentRating;
 
   const populateReviewForCandidate = (candidate: number) => {
-    const rating = getRating(candidate);
-    const comment = getComment(candidate);
+    const rating = getRating(candidate) ?? 0;
+    const comment = getComment(candidate) ?? '';
     setCurrentRating(rating);
     setCurrentComment(comment);
     setDefaultCurrentRating(rating);

--- a/frontend/src/components/Candidate-Decider/GlobalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/GlobalProgressPanel.tsx
@@ -22,7 +22,7 @@ const GlobalProgressPanel: React.FC<Props> = ({ showOtherVotes, candidates, revi
         size="tiny"
         color="blue"
       >{`${reviews.length}/${candidates.length * allReviewers.length}`}</Progress>
-      <RatingsDisplay ratings={reviews} header="Global Rating Statistics" />
+      {/* <RatingsDisplay ratings={reviews} header="Global Rating Statistics" /> */}
       {showOtherVotes ? (
         <>
           <h3>Per-person Ratings</h3>

--- a/frontend/src/components/Candidate-Decider/GlobalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/GlobalProgressPanel.tsx
@@ -22,7 +22,6 @@ const GlobalProgressPanel: React.FC<Props> = ({ showOtherVotes, candidates, revi
         size="tiny"
         color="blue"
       >{`${reviews.length}/${candidates.length * allReviewers.length}`}</Progress>
-      {/* <RatingsDisplay ratings={reviews} header="Global Rating Statistics" /> */}
       {showOtherVotes ? (
         <>
           <h3>Per-person Ratings</h3>

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -33,7 +33,8 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
         size="tiny"
         color="blue"
       >{`${myRatings.length}/${candidates.length}`}</Progress>
-      <RatingsDisplay ratings={myRatings} header="My Rating Statistics" />
+
+      {/* <RatingsDisplay ratings={myRatings} header="My Rating Statistics" /> */}
       {showOtherVotes && userInfo && LEAD_ROLES.includes(userInfo.role) ? (
         <>
           <RatingsDisplay

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -6,14 +6,12 @@ import RatingsDisplay from './RatingsDisplay';
 import { ratingToString } from './ratings-utils';
 
 type ProgressPanelProps = {
-  showOtherVotes: boolean;
   candidates: CandidateDeciderCandidate[];
   currentCandidate: number;
   reviews: CandidateDeciderReview[];
 };
 
 const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
-  showOtherVotes,
   candidates,
   currentCandidate,
   reviews
@@ -34,7 +32,7 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
         color="blue"
       >{`${myRatings.length}/${candidates.length}`}</Progress>
 
-      {showOtherVotes && userInfo && LEAD_ROLES.includes(userInfo.role) ? (
+      {userInfo && LEAD_ROLES.includes(userInfo.role) ? (
         <>
           <RatingsDisplay
             ratings={currentCandidateReviews}

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -34,7 +34,6 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
         color="blue"
       >{`${myRatings.length}/${candidates.length}`}</Progress>
 
-      {/* <RatingsDisplay ratings={myRatings} header="My Rating Statistics" /> */}
       {showOtherVotes && userInfo && LEAD_ROLES.includes(userInfo.role) ? (
         <>
           <RatingsDisplay

--- a/frontend/src/components/Candidate-Decider/ProgressPanel.module.css
+++ b/frontend/src/components/Candidate-Decider/ProgressPanel.module.css
@@ -1,6 +1,5 @@
 .progressContainer {
   width: 100%;
-  padding: 2%;
 }
 
 .percentageBar {

--- a/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
@@ -1,5 +1,4 @@
 import { Dispatch, SetStateAction } from 'react';
-import { Form, Radio } from 'semantic-ui-react';
 import styles from './ResponsesPanel.module.css';
 import ApplicantCredentials from './ApplicantCredentials';
 
@@ -13,15 +12,6 @@ type Props = {
   seeApplicantName: boolean;
   candidate: number;
 };
-
-const ratings = [
-  { value: 1, text: 'Strong No', color: 'red' },
-  { value: 2, text: 'No', color: 'orange' },
-  { value: 3, text: 'Maybe', color: 'yellow' },
-  { value: 4, text: 'Yes', color: 'green' },
-  { value: 5, text: 'Strong Yes', color: 'green ' },
-  { value: 0, text: 'Undecided', color: 'grey' }
-];
 
 const credentialHeaders = [
   'Email Address',
@@ -96,23 +86,6 @@ const ResponsesPanel: React.FC<Props> = ({
   candidate
 }) => (
   <div>
-    {/* <Form>
-      <Form.Group inline>
-        {ratings.map((rt) => (
-          <Form.Field key={rt.value}>
-            <Radio
-              label={rt.text}
-              name="rating-group"
-              value={rt.value}
-              color={rt.color}
-              checked={rt.value === currentRating}
-              onClick={() => setCurrentRating(rt.value as Rating)}
-            />
-          </Form.Field>
-        ))}
-      </Form.Group>
-      <CommentEditor currentComment={currentComment} setCurrentComment={setCurrentComment} />
-    </Form> */}
     <ApplicantCredentials
       {...getCredentials(headers, responses)}
       seeApplicantName={seeApplicantName}

--- a/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
@@ -96,7 +96,7 @@ const ResponsesPanel: React.FC<Props> = ({
   candidate
 }) => (
   <div>
-    <Form>
+    {/* <Form>
       <Form.Group inline>
         {ratings.map((rt) => (
           <Form.Field key={rt.value}>
@@ -112,7 +112,7 @@ const ResponsesPanel: React.FC<Props> = ({
         ))}
       </Form.Group>
       <CommentEditor currentComment={currentComment} setCurrentComment={setCurrentComment} />
-    </Form>
+    </Form> */}
     <ApplicantCredentials
       {...getCredentials(headers, responses)}
       seeApplicantName={seeApplicantName}
@@ -134,21 +134,4 @@ const ResponsesPanel: React.FC<Props> = ({
   </div>
 );
 
-type CommentEditorProps = {
-  currentComment: string;
-  setCurrentComment: Dispatch<SetStateAction<string | undefined>>;
-};
-
-const CommentEditor: React.FC<CommentEditorProps> = ({ currentComment, setCurrentComment }) => (
-  <div>
-    <Form.Group inline>
-      <Form.Input
-        className="fifteen wide field"
-        placeholder={'Comment...'}
-        onChange={(_, data) => setCurrentComment(data.value)}
-        value={currentComment}
-      />
-    </Form.Group>
-  </div>
-);
 export default ResponsesPanel;

--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -1,3 +1,27 @@
+:root {
+  --fg-default: #171717;
+  --fg-dimmer: #333333;
+  --fg-dimmest: #666666;
+
+  --bg-default: #ffffff;
+  --bg-dimmer: #fafafa;
+  --bg-dimmest: #f2f2f2;
+
+  --border-default: #ebebeb;
+  --border-dimmer: #c9c9c9;
+
+  --accent-focus: #0e4dd4;
+  --accent-strong-no: #d8001b;
+  --accent-no: #ff676c;
+  --accent-maybe: #ff9300;
+  --accent-yes: #28a948;
+  --accent-strong-yes: #0a6e29;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 .App {
   text-align: left;
   min-height: 100vh;
@@ -19,6 +43,7 @@
 
 .appSidebarDimmer {
   width: 100vw;
+  height: 90vh;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
As part of an refresh of our internal tools, we're redesigning the IDOL Candidate Decider based on my new [figma mocks here](https://www.figma.com/design/qHNMOp6rrIFMv1wBXsVtYZ/SP25-IDOL-Candidate-Decider-Tool?node-id=122-1577&t=LZFXidMfUZKVlQcB-11).

This first PR is focused on moving all the components around to fit the new layout of the page. 

- First, I removed a few things:
  - Removed the Ratings statistics (we don't want to show this anymore for bias reasons)
  - Removed Global progress (we already have the "My progress" progress bar)
  - Removed the "Show other people's votes" (we don't want this because of bias)
  - Removed Candidate ID dropdown (we already have navigation with the main dropdown)
- Changed the layout of several components:
  - Clearly defined a left and right column 
  - Moved "Previous" and "Next" buttons to the sides of the navigation dropdown
  - Moved the "My progress bar" to the top of the left column
  - Made the Comments section taller
  - Grouped the Final selection picker with the Save button at the bottom of the left column 
  - Moved the "See applicants name" toggle onto the responses column on the right
  - Moved the Candidate info (name, answers to questions) to the right column

I also added the first CSS color variables in `App.css` as a preliminary step to prepare for the rest of the overhaul. They currently aren't used anywhere but it's to prepare for later!


### A few notes:
- Several of the class names used for styling are temporary. I plan on making them more semantic.
- Many of the styles (eg: `border: 1px solid #666;` are also temporary for now and are used for clarity and debugging purposes. 
- There remains several accessibility and code cleanliness errors, which I will get to eventually.


|Before|After|
|-|-|
|<img width="1542" alt="Screenshot 2025-03-27 at 2 45 35 PM" src="https://github.com/user-attachments/assets/ad14e3ce-75be-41df-8297-1035fcf26804" />|<img width="1542" alt="Screenshot 2025-03-27 at 2 45 18 PM" src="https://github.com/user-attachments/assets/7e58f3df-f29d-4b78-b07b-089fe0ceb0dd" />|

