### PR TITLE
[Newer DTI site] New `<Button>` & `<IconButton>` components, imported Lucide icons (v2)

### DIFF
--- a/new-dti-website-redesign/eslint.config.mjs
+++ b/new-dti-website-redesign/eslint.config.mjs
@@ -1,16 +1,14 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+  baseDirectory: __dirname
 });
 
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-];
+const eslintConfig = [...compat.extends('next/core-web-vitals', 'next/typescript')];
 
 export default eslintConfig;

--- a/new-dti-website-redesign/package.json
+++ b/new-dti-website-redesign/package.json
@@ -11,19 +11,20 @@
     "format:check": "yarn prettier --check ."
   },
   "dependencies": {
+    "lucide-react": "^0.487.0",
+    "next": "15.2.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.2.3"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.2.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/new-dti-website-redesign/package.json
+++ b/new-dti-website-redesign/package.json
@@ -18,12 +18,13 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@next/eslint-plugin-next": "^15.2.5",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "15.2.3",
+    "eslint": "^9.24.0",
+    "eslint-config-next": "^15.2.5",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/new-dti-website-redesign/postcss.config.mjs
+++ b/new-dti-website-redesign/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ['@tailwindcss/postcss']
 };
 
 export default config;

--- a/new-dti-website-redesign/src/app/components/Button.tsx
+++ b/new-dti-website-redesign/src/app/components/Button.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+
+type ButtonProps = {
+  label: string;
+  onClick?: () => void;
+  href?: string;
+  className?: string;
+  variant?: 'primary' | 'secondary' | 'tertiary';
+  badge?: React.ReactNode;
+};
+
+export default function Button({
+  label,
+  onClick,
+  href,
+  className = '',
+  variant = 'primary',
+  badge
+}: ButtonProps) {
+  const baseStyles = `
+    px-6 h-12 w-fit rounded-full cursor-pointer inline-flex items-center justify-center gap-2
+    transition-colors duration-[120ms]
+    focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-offset-[3px]
+    focus-visible:outline-[var(--foreground-1)]`;
+
+  const variantStyles = {
+    primary: `bg-foreground-1 text-background-1 hover:bg-foreground-2 ${badge ? 'gap-1 pr-3' : ''}`,
+    secondary: `bg-background-2 border border-border-1 text-foreground-1 hover:bg-background-3`,
+    tertiary: `bg-transparent border border-border-1 text-foreground-1 hover:bg-background-2`
+  }[variant];
+
+  const sharedClasses = `${baseStyles} ${variantStyles} ${className}`;
+
+  const content = (
+    <>
+      <span className="text-rg font-medium">{label}</span>
+      {badge && (
+        <span className="p-2 bg-[#0000001a] text-background-1 rounded-full text-xs font-medium uppercase tracking-wider">
+          {badge}
+        </span>
+      )}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={sharedClasses}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button onClick={onClick} className={sharedClasses} type="button">
+      {content}
+    </button>
+  );
+}

--- a/new-dti-website-redesign/src/app/components/IconButton.tsx
+++ b/new-dti-website-redesign/src/app/components/IconButton.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+type IconButtonProps = {
+  'aria-label': string;
+  onClick?: () => void;
+  href?: string;
+  className?: string;
+  variant?: 'primary' | 'secondary' | 'tertiary';
+  children: ReactNode;
+};
+
+export default function IconButton({
+  'aria-label': ariaLabel,
+  onClick,
+  href,
+  className = '',
+  variant = 'primary',
+  children
+}: IconButtonProps) {
+  const baseStyles = `
+    w-12 h-12 rounded-full cursor-pointer inline-flex items-center justify-center
+    transition-colors duration-[120ms]
+    focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-offset-[3px]
+    focus-visible:outline-[var(--foreground-1)]`;
+
+  const variantStyles = {
+    primary: `bg-foreground-1 text-background-1 hover:bg-foreground-2`,
+    secondary: `bg-background-2 border border-border-1 text-foreground-1 hover:bg-background-3`,
+    tertiary: `bg-transparent border border-border-1 text-foreground-1 hover:bg-background-2`
+  }[variant];
+
+  const sharedClasses = `${baseStyles} ${variantStyles} ${className}`;
+
+  const iconContent = <span className="w-6 h-6 flex items-center justify-center">{children}</span>;
+
+  if (href) {
+    return (
+      <Link href={href} className={sharedClasses} aria-label={ariaLabel}>
+        {iconContent}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={onClick} className={sharedClasses} aria-label={ariaLabel}>
+      {iconContent}
+    </button>
+  );
+}

--- a/new-dti-website-redesign/src/app/test/page.tsx
+++ b/new-dti-website-redesign/src/app/test/page.tsx
@@ -1,4 +1,9 @@
+'use client';
+
 import Link from 'next/link';
+import { Plus } from 'lucide-react';
+import Button from '../components/Button';
+import IconButton from '../components/IconButton';
 
 export default function TestPage() {
   return (
@@ -10,6 +15,7 @@ export default function TestPage() {
       <h3 className="text-accent-blue">TEST PAGE WITH STYLES & COMPONENTS:</h3>
 
       <div className="flex flex-col gap-8">
+        <h4>Typography</h4>
         <h1>Building the Future of Tech @ Cornell</h1>
         <h2>Building the Future of Tech @ Cornell</h2>
         <h3>Building the Future of Tech @ Cornell</h3>
@@ -23,6 +29,7 @@ export default function TestPage() {
       </div>
 
       <div className="flex flex-col gap-6">
+        <h4>Colors</h4>
         <div className="flex gap-4">
           <div className="bg-background-1 w-24 h-24 rounded-md border border-border-1"></div>
           <div className="bg-background-2 w-24 h-24 rounded-md"></div>
@@ -46,6 +53,34 @@ export default function TestPage() {
           <div className="bg-accent-blue w-24 h-24 rounded-md"></div>
           <div className="bg-accent-yellow w-24 h-24 rounded-md"></div>
           <div className="bg-accent-purple w-24 h-24 rounded-md"></div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <h4>Buttons</h4>
+        <div className="flex gap-4">
+          <Button label="Apply today" />
+
+          <Button label="Apply" badge="12D 2H" />
+
+          <Button label="Apply today" variant="secondary" />
+
+          <Button label="Apply today" variant="tertiary" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <h4>Icon buttons</h4>
+        <div className="flex gap-4">
+          <IconButton aria-label="Create">
+            <Plus />
+          </IconButton>
+          <IconButton aria-label="Create" variant="secondary">
+            <Plus />
+          </IconButton>
+          <IconButton aria-label="Create" variant="tertiary">
+            <Plus />
+          </IconButton>
         </div>
       </div>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,10 +1537,10 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.9.1.tgz#449dfa81a57a1d755b09aa58d826c1262e4283b4"
   integrity sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==
 
-"@eslint/config-array@^0.19.2":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.19.2.tgz#3060b809e111abfc97adb0bb1172778b90cb46aa"
-  integrity sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==
+"@eslint/config-array@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.20.0.tgz#7a1232e82376712d3340012a2f561a2764d1988f"
+  integrity sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==
   dependencies:
     "@eslint/object-schema" "^2.1.6"
     debug "^4.3.1"
@@ -1615,10 +1615,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.51.0.tgz#6d419c240cfb2b66da37df230f7e7eef801c32fa"
   integrity sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==
 
-"@eslint/js@9.23.0":
-  version "9.23.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.23.0.tgz#c09ded4f3dc63b40b933bcaeb853fceddb64da30"
-  integrity sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==
+"@eslint/js@9.24.0":
+  version "9.24.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.24.0.tgz#685277980bb7bf84ecc8e4e133ccdda7545a691e"
+  integrity sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==
 
 "@eslint/object-schema@^2.1.6":
   version "2.1.6"
@@ -2616,10 +2616,10 @@
   dependencies:
     glob "7.1.7"
 
-"@next/eslint-plugin-next@15.2.3":
-  version "15.2.3"
-  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-15.2.3.tgz#c2f869c10ca6d44ede4dbe2e21838df8a0b4a95e"
-  integrity sha512-eNSOIMJtjs+dp4Ms1tB1PPPJUQHP3uZK+OQ7iFY9qXpGO6ojT6imCL+KcUOqE/GXGidWbBZJzYdgAdPHqeCEPA==
+"@next/eslint-plugin-next@15.2.5", "@next/eslint-plugin-next@^15.2.5":
+  version "15.2.5"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-15.2.5.tgz#c43bb00dd50aeaef28785e74a7ded0a213d57d59"
+  integrity sha512-Q1ncASVFKSy+AbabimYxr/2HH/h+qlKlwu1fYV48xUefGzVimS3i3nKwYsM2w+rLdpMFdJyoVowrYyjKu47rBw==
   dependencies:
     fast-glob "3.3.1"
 
@@ -8522,12 +8522,12 @@ eslint-config-airbnb@^18.2.1:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
-eslint-config-next@15.2.3:
-  version "15.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-config-next/-/eslint-config-next-15.2.3.tgz#0b830f10b25b1fb43b49bebbebe85549ad9d5d55"
-  integrity sha512-VDQwbajhNMFmrhLWVyUXCqsGPN+zz5G8Ys/QwFubfsxTIrkqdx3N3x3QPW+pERz8bzGPP0IgEm8cNbZcd8PFRQ==
+eslint-config-next@^15.2.5:
+  version "15.2.5"
+  resolved "https://registry.yarnpkg.com/eslint-config-next/-/eslint-config-next-15.2.5.tgz#1a512cd02d70a5ad47bdfeeaa2abd22bca9276f5"
+  integrity sha512-/aUpN5FVI3FD+OB4gY0GyD2TwIOjLk8mG0B9NxVsSn8/svNmzFaIAaS80ZO1zWaIcWxrzTy2FcPVdsCK7eiceA==
   dependencies:
-    "@next/eslint-plugin-next" "15.2.3"
+    "@next/eslint-plugin-next" "15.2.5"
     "@rushstack/eslint-patch" "^1.10.3"
     "@typescript-eslint/eslint-plugin" "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0"
     "@typescript-eslint/parser" "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -8945,18 +8945,18 @@ eslint@^7.32.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^9:
-  version "9.23.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.23.0.tgz#b88f3ab6dc83bcb927fdb54407c69ffe5f2441a6"
-  integrity sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==
+eslint@^9.24.0:
+  version "9.24.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.24.0.tgz#9a7f2e6cb2de81c405ab244b02f4584c79dc6bee"
+  integrity sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.12.1"
-    "@eslint/config-array" "^0.19.2"
+    "@eslint/config-array" "^0.20.0"
     "@eslint/config-helpers" "^0.2.0"
     "@eslint/core" "^0.12.0"
     "@eslint/eslintrc" "^3.3.1"
-    "@eslint/js" "9.23.0"
+    "@eslint/js" "9.24.0"
     "@eslint/plugin-kit" "^0.2.7"
     "@humanfs/node" "^0.16.6"
     "@humanwhocodes/module-importer" "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13380,6 +13380,11 @@ lru-memoizer@^2.2.0:
     lodash.clonedeep "^4.5.0"
     lru-cache "~4.0.0"
 
+lucide-react@^0.487.0:
+  version "0.487.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.487.0.tgz#c18a463404e8ef106d46a7c9cceddf9fc8b9ff6b"
+  integrity sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==
+
 luxon@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"


### PR DESCRIPTION
- New PR in favor of [old one](https://github.com/cornell-dti/idol/pull/904/) because `git rebase` is dumb :(

- Created `<Button>` component
  - [Figma](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1336-16568&t=OZU0wfHmAXC81yDx-11)
  - Renders either a `<button>` or an `<a>` tag depending on the situation
  - has `primary`, `secondary`, and `tertiary` variants
  - accepts optional `badge` prop

- Created `<IconButton>` component
  - [Figma](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1336-16568&t=OZU0wfHmAXC81yDx-11)
  - Renders either a `<button>` or an `<a>` tag depending on the situation
  - has `primary`, `secondary`, and `tertiary` variants
  - accepts React icon as child
  - has `aria-label` prop for accessibility

- Imported [Lucide icons](https://lucide.dev/)

<img width="768" alt="Screenshot 2025-04-07 at 11 07 52 PM" src="https://github.com/user-attachments/assets/b4dee6b0-dca4-4700-984c-19c18e61f76d" />
