### PR TITLE
[Cand decider] Typography updates & checkbox state refactoring

### DIFF
--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.module.css
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.module.css
@@ -14,3 +14,15 @@
 .icon {
   margin-right: 10px;
 }
+
+.documents {
+  padding: 24px;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.header {
+  padding: 24px;
+  border-bottom: 1px solid var(--border-default);
+  display: flex;
+  justify-content: space-between;
+}

--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -1,6 +1,6 @@
+import { Checkbox } from 'semantic-ui-react';
 import styles from './ApplicantCredentials.module.css';
 import { formatLink } from '../../utils';
-import { Checkbox } from 'semantic-ui-react';
 import { useHasAdminPermission } from '../Common/FirestoreDataProvider';
 
 type Props = {

--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -1,5 +1,7 @@
 import styles from './ApplicantCredentials.module.css';
 import { formatLink } from '../../utils';
+import { Checkbox } from 'semantic-ui-react';
+import { useHasAdminPermission } from '../Common/FirestoreDataProvider';
 
 type Props = {
   name: string;
@@ -11,11 +13,13 @@ type Props = {
   portfolioURL?: string;
   preferredName?: string;
   seeApplicantName: boolean;
+  setSeeApplicantName: (value: boolean) => void;
   candidate: number;
 };
 
 const ApplicantCredentials: React.FC<Props> = ({
   seeApplicantName,
+  setSeeApplicantName,
   name,
   email,
   gradYear,
@@ -25,32 +29,49 @@ const ApplicantCredentials: React.FC<Props> = ({
   portfolioURL,
   preferredName,
   candidate
-}) => (
-  <div className={styles.credentialContainer}>
-    {seeApplicantName ? (
-      <>
-        <h1>
-          {name} {preferredName && `(${preferredName})`}
-        </h1>
-        <p>{email}</p>
-      </>
-    ) : (
-      <>
-        <h1>Candidate {candidate + 1}</h1>
-      </>
-    )}
-    <p>Class of {gradYear}</p>
-    {seeApplicantName && (
-      <div className={styles.iconsContainer}>
-        <a
-          className={styles.icon}
-          href={formatLink(resumeURL)}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <FileIcon />
-        </a>
-        {githubURL && (
+}) => {
+  const hasAdminPermission = useHasAdminPermission();
+
+  return (
+    <div className={styles.credentialContainer}>
+      <div className={styles.header}>
+        <div className={styles.applicantInformation}>
+          {seeApplicantName ? (
+            <>
+              <h1>
+                {name} {preferredName && `(${preferredName})`}
+              </h1>
+              <p>{email}</p>
+            </>
+          ) : (
+            <h1>Candidate {candidate + 1}</h1>
+          )}
+          <p>Class of {gradYear}</p>
+        </div>
+
+        {hasAdminPermission && (
+          <Checkbox
+            className={styles.seeApplicantName}
+            toggle
+            checked={seeApplicantName}
+            onChange={() => setSeeApplicantName(!seeApplicantName)}
+            label="See applicant name"
+          />
+        )}
+      </div>
+
+      {/* {seeApplicantName && ( */}
+      <div className={styles.documents}>
+        <h3>Documents</h3>
+        <div className={styles.iconsContainer}>
+          <a
+            className={styles.icon}
+            href={formatLink(resumeURL)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FileIcon />
+          </a>
           <a
             className={styles.icon}
             href={formatLink(githubURL)}
@@ -59,8 +80,7 @@ const ApplicantCredentials: React.FC<Props> = ({
           >
             <GithubIcon />
           </a>
-        )}
-        {linkedinURL && (
+
           <a
             className={styles.icon}
             href={formatLink(linkedinURL, 'linkedin')}
@@ -69,8 +89,6 @@ const ApplicantCredentials: React.FC<Props> = ({
           >
             <LinkedinIcon />
           </a>
-        )}
-        {portfolioURL && (
           <a
             className={styles.icon}
             href={formatLink(portfolioURL)}
@@ -79,11 +97,12 @@ const ApplicantCredentials: React.FC<Props> = ({
           >
             <GlobeIcon />
           </a>
-        )}
+        </div>
+        {/* // )} */}
       </div>
-    )}
-  </div>
-);
+    </div>
+  );
+};
 
 const FileIcon = () => (
   <svg

--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -60,46 +60,51 @@ const ApplicantCredentials: React.FC<Props> = ({
         )}
       </div>
 
-      {/* {seeApplicantName && ( */}
-      <div className={styles.documents}>
-        <h3>Documents</h3>
-        <div className={styles.iconsContainer}>
-          <a
-            className={styles.icon}
-            href={formatLink(resumeURL)}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <FileIcon />
-          </a>
-          <a
-            className={styles.icon}
-            href={formatLink(githubURL)}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <GithubIcon />
-          </a>
-
-          <a
-            className={styles.icon}
-            href={formatLink(linkedinURL, 'linkedin')}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <LinkedinIcon />
-          </a>
-          <a
-            className={styles.icon}
-            href={formatLink(portfolioURL)}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <GlobeIcon />
-          </a>
+      {seeApplicantName && (
+        <div className={styles.documents}>
+          <h3>Documents</h3>
+          <div className={styles.iconsContainer}>
+            <a
+              className={styles.icon}
+              href={formatLink(resumeURL)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <FileIcon />
+            </a>
+            {githubURL && (
+              <a
+                className={styles.icon}
+                href={formatLink(githubURL)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <GithubIcon />
+              </a>
+            )}
+            {linkedinURL && (
+              <a
+                className={styles.icon}
+                href={formatLink(linkedinURL, 'linkedin')}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <LinkedinIcon />
+              </a>
+            )}
+            {portfolioURL && (
+              <a
+                className={styles.icon}
+                href={formatLink(portfolioURL)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <GlobeIcon />
+              </a>
+            )}
+          </div>
         </div>
-        {/* // )} */}
-      </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
@@ -60,7 +60,6 @@
   width: 100%;
   flex: 1;
   border: 1px solid #666;
-  padding: 24px;
 }
 
 .top {

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -31,7 +31,7 @@ type CommentEditorProps = {
 
 const CommentEditor: React.FC<CommentEditorProps> = ({ currentComment, setCurrentComment }) => (
   <div style={{ width: '100%' }}>
-    <h4>Comments</h4>
+    <h4 className={styles.h4}>Comments</h4>
     <Form.Group inline>
       <Form.Input
         style={{ height: 256, width: '100%' }}
@@ -267,15 +267,8 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
         </div>
       </div>
       <div className={styles.responsesContainer}>
-        {hasAdminPermission && (
-          <Checkbox
-            className={styles.seeApplicantName}
-            toggle
-            checked={seeApplicantName}
-            onChange={() => setSeeApplicantName((prev) => !prev)}
-            label="See applicant name"
-          />
-        )}
+        {/* TODO: Move CheckBox into ResponsesPanel */}
+
         <ResponsesPanel
           headers={instance.headers}
           responses={instance.candidates[currentCandidate].responses}
@@ -284,6 +277,7 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           currentRating={currentRating ?? 0}
           setCurrentRating={setCurrentRating}
           seeApplicantName={seeApplicantName}
+          setSeeApplicantName={setSeeApplicantName}
           candidate={instance.candidates[currentCandidate].id}
         />
       </div>

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -267,8 +267,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
         </div>
       </div>
       <div className={styles.responsesContainer}>
-        {/* TODO: Move CheckBox into ResponsesPanel */}
-
         <ResponsesPanel
           headers={instance.headers}
           responses={instance.candidates[currentCandidate].responses}

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -31,7 +31,7 @@ type CommentEditorProps = {
 
 const CommentEditor: React.FC<CommentEditorProps> = ({ currentComment, setCurrentComment }) => (
   <div style={{ width: '100%' }}>
-    <h4 className={styles.h4}>Comments</h4>
+    <h4>Comments</h4>
     <Form.Group inline>
       <Form.Input
         style={{ height: 256, width: '100%' }}

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, Dispatch, SetStateAction } from 'react';
-import { Button, Checkbox, Modal, Form, Radio } from 'semantic-ui-react';
+import { Button, Modal, Form, Radio } from 'semantic-ui-react';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import ResponsesPanel from './ResponsesPanel';
 import LocalProgressPanel from './LocalProgressPanel';
-import { useHasAdminPermission, useSelf } from '../Common/FirestoreDataProvider';
+import { useSelf } from '../Common/FirestoreDataProvider';
 import styles from './CandidateDecider.module.css';
 import SearchBar from './SearchBar';
 import {
@@ -53,7 +53,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const userInfo = useSelf();
   const instance = useCandidateDeciderInstance(uuid);
   const [reviews, setReviews] = useCandidateDeciderReviews(uuid);
-  const hasAdminPermission = useHasAdminPermission();
 
   const getRating = (candidate: number) => {
     const rating = reviews.find(

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -24,7 +24,7 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
   );
   return (
     <div className={styles.progressContainer}>
-      <h3>My Progress</h3>
+      <h4>My Progress</h4>
       <Progress
         value={myRatings.length}
         total={candidates.length}

--- a/frontend/src/components/Candidate-Decider/ResponsesPanel.module.css
+++ b/frontend/src/components/Candidate-Decider/ResponsesPanel.module.css
@@ -1,3 +1,7 @@
+.applicantResponses {
+  padding: 24px;
+}
+
 .questionHeader {
   margin: 12px 0;
 }

--- a/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
@@ -1,6 +1,7 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import styles from './ResponsesPanel.module.css';
 import ApplicantCredentials from './ApplicantCredentials';
+import { useHasAdminPermission } from '../Common/FirestoreDataProvider';
 
 type Props = {
   headers: string[];
@@ -10,6 +11,7 @@ type Props = {
   currentComment: string;
   setCurrentComment: Dispatch<SetStateAction<string | undefined>>;
   seeApplicantName: boolean;
+  setSeeApplicantName: Dispatch<SetStateAction<boolean>>;
   candidate: number;
 };
 
@@ -83,27 +85,31 @@ const ResponsesPanel: React.FC<Props> = ({
   currentComment,
   setCurrentComment,
   seeApplicantName,
+  setSeeApplicantName,
   candidate
 }) => (
   <div>
     <ApplicantCredentials
       {...getCredentials(headers, responses)}
       seeApplicantName={seeApplicantName}
+      setSeeApplicantName={setSeeApplicantName}
       candidate={candidate}
     />
-    {headers
-      .map((header, i) => ({ header, response: responses[i] }))
-      .filter(
-        ({ header }) =>
-          !credentialHeaders.includes(header) &&
-          (seeApplicantName || header !== 'Preferred Name (optional)')
-      )
-      .map(({ header, response }, i) => (
-        <div key={i} className={styles.questionResponseContainer}>
-          <h4 className={styles.questionHeader}>{header}</h4>
-          <div className={styles.responseText}>{response}</div>
-        </div>
-      ))}
+    <div className={styles.applicantResponses}>
+      {headers
+        .map((header, i) => ({ header, response: responses[i] }))
+        .filter(
+          ({ header }) =>
+            !credentialHeaders.includes(header) &&
+            (seeApplicantName || header !== 'Preferred Name (optional)')
+        )
+        .map(({ header, response }, i) => (
+          <div key={i} className={styles.questionResponseContainer}>
+            <h4 className={styles.questionHeader}>{header}</h4>
+            <div className={styles.responseText}>{response}</div>
+          </div>
+        ))}
+    </div>
   </div>
 );
 

--- a/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
@@ -1,7 +1,6 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import styles from './ResponsesPanel.module.css';
 import ApplicantCredentials from './ApplicantCredentials';
-import { useHasAdminPermission } from '../Common/FirestoreDataProvider';
 
 type Props = {
   headers: string[];

--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -22,6 +22,40 @@
   box-sizing: border-box;
 }
 
+h1 {
+  font-size: 32px;
+  line-height: 115%;
+  font-weight: 700;
+}
+
+h2 {
+  font-size: 28px;
+  line-height: 115%;
+  font-weight: 700;
+}
+
+h3 {
+  font-size: 24px;
+  line-height: 120%;
+  font-weight: 700;
+}
+
+h4 {
+  font-size: 16px;
+  line-height: 130%;
+  font-weight: 700;
+}
+
+p {
+  font-size: 16px;
+  line-height: 150%;
+  font-weight: 500;
+}
+
+p.small {
+  font-size: 14px;
+}
+
 .App {
   text-align: left;
   min-height: 100vh;

--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -1,3 +1,4 @@
+/* =========== COLORS =========== */
 :root {
   --fg-default: #171717;
   --fg-dimmer: #333333;
@@ -22,36 +23,43 @@
   box-sizing: border-box;
 }
 
+/* =========== TYPOGRAPHY ===========  */
+/* Heading large */
 h1 {
   font-size: 32px;
   line-height: 115%;
   font-weight: 700;
 }
 
+/* Heading regular */
 h2 {
   font-size: 28px;
   line-height: 115%;
   font-weight: 700;
 }
 
+/* Subheading large */
 h3 {
   font-size: 24px;
   line-height: 120%;
   font-weight: 700;
 }
 
+/* Subheading regular */
 h4 {
   font-size: 16px;
   line-height: 130%;
   font-weight: 700;
 }
 
+/* Paragraph */
 p {
   font-size: 16px;
   line-height: 150%;
   font-weight: 500;
 }
 
+/* Paragraph small */
 p.small {
   font-size: 14px;
 }


### PR DESCRIPTION
# Description

- Part of Figma [designs here](https://www.figma.com/design/qHNMOp6rrIFMv1wBXsVtYZ/SP25-IDOL-Candidate-Decider-Tool?node-id=122-1577&t=p0uhtqriGHwRLsGt-11)

- Styling:
  - Several CSS changes to padding, border, spacing
  - Created new typography stylings for `h1 - h4` and `p`

- "See applicant name" switch
  - Essentially I moved this component inside the `ApplicantCredentials` file so that it could be better controlled for styling purposes
  - To make this work, some other misc changes like lifting `seeApplicantName` state up
  - And also passing some of the other props from `CandidateDecider` (original location) to `ApplicantCredentials` (new desired location)

### Cand decider
|Before|After|
|-|-|
|<img width="1855" alt="Screenshot 2025-04-10 at 2 07 33 AM" src="https://github.com/user-attachments/assets/8bd5e649-b9a1-4002-8f14-cc8bbf9ff452" />|<img width="1855" alt="Screenshot 2025-04-10 at 2 06 40 AM" src="https://github.com/user-attachments/assets/c1870c23-a911-40bf-9974-66a4b8b39f34" />|

### Other examples of typography changes
|X|Before|After|
|-|-|-|
|Home|<img width="1892" alt="Screenshot 2025-04-10 at 2 21 16 AM" src="https://github.com/user-attachments/assets/7e3b3c78-e7cf-47ad-b42d-ffd8ea40a6c9" />|<img width="1855" alt="Screenshot 2025-04-10 at 2 21 10 AM" src="https://github.com/user-attachments/assets/becc54fb-c797-423b-b8a1-a406bdbd945e" />|
|Bingo|<img width="1892" alt="Screenshot 2025-04-10 at 2 21 35 AM" src="https://github.com/user-attachments/assets/79b94c28-8179-49ac-9cd2-2be8a94962b2" />|<img width="1855" alt="Screenshot 2025-04-10 at 2 21 39 AM" src="https://github.com/user-attachments/assets/e9132329-08f1-442e-90a6-1ee380a663a8" />|


### Note: ignore the actual font family change. I think it's a weird bug where the production app uses the fallback font, while the dev env uses the specified Lato font. My changes only change the font size and line height properties.


# Test plan

- Open Cand decider
- Compare "After" images and make sure visual changes are there
- Ensure the "See applicant name" switch is correctly placed on the same row as the candidate name
- Test the switch to make sure it shows/hides the applicant name accordingly
  - If it's on, make sure documents correctly appear