### PR TITLE
[DTI site] Removed `Inter` font import & mobile monospaced bug

### DIFF
--- a/new-dti-website-redesign/eslint.config.mjs
+++ b/new-dti-website-redesign/eslint.config.mjs
@@ -1,16 +1,14 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+  baseDirectory: __dirname
 });
 
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-];
+const eslintConfig = [...compat.extends('next/core-web-vitals', 'next/typescript')];
 
 export default eslintConfig;

--- a/new-dti-website-redesign/postcss.config.mjs
+++ b/new-dti-website-redesign/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ['@tailwindcss/postcss']
 };
 
 export default config;

--- a/new-dti-website/components/initiatives/InitiativeDisplay.tsx
+++ b/new-dti-website/components/initiatives/InitiativeDisplay.tsx
@@ -2,7 +2,6 @@ import Image, { ImageProps } from 'next/image';
 import initiatives from './data/initiatives.json';
 import useScreenSize from '../../src/hooks/useScreenSize';
 import { LAPTOP_BREAKPOINT } from '../../src/consts';
-import { ibm_plex_mono } from '../../src/app/layout';
 
 type InitiativeProps = {
   title: string;
@@ -14,8 +13,6 @@ type InitiativeProps = {
 };
 
 const Initiative = ({ title, subtitle, icon, image, description, className }: InitiativeProps) => {
-  const { width } = useScreenSize();
-
   return (
     <article className={`flex flex-col gap-10 ${className}`}>
       <div className="flex flex-col gap-[14px]">

--- a/new-dti-website/components/initiatives/InitiativeDisplay.tsx
+++ b/new-dti-website/components/initiatives/InitiativeDisplay.tsx
@@ -12,26 +12,24 @@ type InitiativeProps = {
   className?: string;
 };
 
-const Initiative = ({ title, subtitle, icon, image, description, className }: InitiativeProps) => {
-  return (
-    <article className={`flex flex-col gap-10 ${className}`}>
-      <div className="flex flex-col gap-[14px]">
-        <div className="flex-col gap-2 min-h-10">
-          <Image {...icon} />
-          <h3 className="font-semibold text-[32px] leading-10">{title}</h3>
-        </div>
-        <p className="font-semibold text-[22px] leading-[26px]">{subtitle}</p>
-        <div className="flex justify-center">
-          <Image
-            {...image}
-            className="xs:h-[260px] md:h-[375px] lg:h-[260px] w-full object-cover rounded-xl"
-          />
-        </div>
+const Initiative = ({ title, subtitle, icon, image, description, className }: InitiativeProps) => (
+  <article className={`flex flex-col gap-10 ${className}`}>
+    <div className="flex flex-col gap-[14px]">
+      <div className="flex-col gap-2 min-h-10">
+        <Image {...icon} />
+        <h3 className="font-semibold text-[32px] leading-10">{title}</h3>
       </div>
-      <p>{description}</p>
-    </article>
-  );
-};
+      <p className="font-semibold text-[22px] leading-[26px]">{subtitle}</p>
+      <div className="flex justify-center">
+        <Image
+          {...image}
+          className="xs:h-[260px] md:h-[375px] lg:h-[260px] w-full object-cover rounded-xl"
+        />
+      </div>
+    </div>
+    <p>{description}</p>
+  </article>
+);
 
 const InitiativeDisplay = () => {
   const { width } = useScreenSize();

--- a/new-dti-website/components/initiatives/InitiativeDisplay.tsx
+++ b/new-dti-website/components/initiatives/InitiativeDisplay.tsx
@@ -1,11 +1,8 @@
 import Image, { ImageProps } from 'next/image';
-import { Inter } from 'next/font/google';
 import initiatives from './data/initiatives.json';
 import useScreenSize from '../../src/hooks/useScreenSize';
 import { LAPTOP_BREAKPOINT } from '../../src/consts';
 import { ibm_plex_mono } from '../../src/app/layout';
-
-const inter = Inter({ subsets: ['latin'] });
 
 type InitiativeProps = {
   title: string;
@@ -34,13 +31,7 @@ const Initiative = ({ title, subtitle, icon, image, description, className }: In
           />
         </div>
       </div>
-      <p
-        className={`text-lg ${
-          width >= LAPTOP_BREAKPOINT ? inter.className : ibm_plex_mono.className
-        }`}
-      >
-        {description}
-      </p>
+      <p>{description}</p>
     </article>
   );
 };


### PR DESCRIPTION
# Description

For some reason, some text on the Initiatives page turns monospaced on mobile (????)

I think the `import { Inter } from 'next/font/google';` is also causing issues with my other [PR](https://github.com/cornell-dti/idol/pull/909) – specifically, it seems to [make the deploy fail](https://app.netlify.com/sites/cornelldti-idol/deploys/67f766dfc340750008ba5597).

# Changes
- format fixes
- removed `Inter` font import – this should be OK since I think we're already setting the font in `new-dti-website/src/app/layout.tsx`
- Also removed the super weird conditional font family rendering for those `<p>` tags lol
- removed other unused code too

|Before|After|
|-|-|
|<img width="556" alt="Screenshot 2025-04-12 at 12 39 22 AM" src="https://github.com/user-attachments/assets/92cfb730-63b4-4a0d-bfee-22e360435b5a" />|<img width="556" alt="Screenshot 2025-04-12 at 12 39 06 AM" src="https://github.com/user-attachments/assets/acd5f094-3139-45e8-9f4c-64c23301d384" />|


# Test plan
- Go to https://www.cornelldti.org/initiatives
- Make sure the page loads with the correct Inter font
- Resize the window so that it is less than `1000px` and ensure the font stays the same (i.e: doesn't change to IBM Plex Mono.