### PR TITLE
Sz266/hide candidate decider

### DIFF
--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -44,12 +44,12 @@ export const hasCandidateDeciderInstance = async (user: IdolMember): Promise<boo
   if (await PermissionsManager.isLeadOrAdmin(user)) return true;
   const instances = await candidateDeciderDao.getAllInstances();
   if (
-      instances.some(
-        (instance) =>
-          instance.authorizedMembers.some((member) => member.email === user.email) ||
-          instance.authorizedRoles.includes(user.role)
-      )
-    ) {
+    instances.some(
+      (instance) =>
+        instance.authorizedMembers.some((member) => member.email === user.email) ||
+        instance.authorizedRoles.includes(user.role)
+    )
+  ) {
     return true;
   }
   return false;

--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -36,6 +36,25 @@ export const getAllCandidateDeciderInstances = async (
 };
 
 /**
+ * Returns whether a CandidateDecier instance is assigned to the user
+ * This method checks if a CandidateDecier instance is assigned to the user
+ * @returns {Promise<boolean>} A promise that resolves with a boolean indicating whether the user has access to the instance
+ */
+export const hasCandidateDeciderInstance = async (
+  user: IdolMember
+ ): Promise<boolean> => true;
+//  {
+//   if (await PermissionsManager.isAdmin(user)) return true;
+//   const instances = await candidateDeciderDao.getAllInstances();
+//   for (const instance of instances) {
+//     if (instance.authorizedMembers.some((member) => member.email === user.email) || instance.authorizedRoles.includes(user.role)) {
+//       return true;
+//     }
+//   }
+//   return false;
+// };
+
+/**
  * Creates a new CandidateDecider instance in the database.
  * This method checks if the user has admin permissions before allowing the creation of the instance.
  * @returns {Promise<CandidateDeciderInfo>} A promise that resolves with the created CandidateDeciderInfo object.

--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -40,14 +40,14 @@ export const getAllCandidateDeciderInstances = async (
  * This method checks if a CandidateDecier instance is assigned to the user
  * @returns {Promise<boolean>} A promise that resolves with a boolean indicating whether the user has access to the instance
  */
-export const hasCandidateDeciderInstance = async (
-  user: IdolMember
- ): Promise<boolean> => 
- {
+export const hasCandidateDeciderInstance = async (user: IdolMember): Promise<boolean> => {
   if (await PermissionsManager.isAdmin(user)) return true;
   const instances = await candidateDeciderDao.getAllInstances();
   for (const instance of instances) {
-    if (instance.authorizedMembers.some((member) => member.email === user.email) || instance.authorizedRoles.includes(user.role)) {
+    if (
+      instance.authorizedMembers.some((member) => member.email === user.email) ||
+      instance.authorizedRoles.includes(user.role)
+    ) {
       return true;
     }
   }

--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -42,17 +42,17 @@ export const getAllCandidateDeciderInstances = async (
  */
 export const hasCandidateDeciderInstance = async (
   user: IdolMember
- ): Promise<boolean> => true;
-//  {
-//   if (await PermissionsManager.isAdmin(user)) return true;
-//   const instances = await candidateDeciderDao.getAllInstances();
-//   for (const instance of instances) {
-//     if (instance.authorizedMembers.some((member) => member.email === user.email) || instance.authorizedRoles.includes(user.role)) {
-//       return true;
-//     }
-//   }
-//   return false;
-// };
+ ): Promise<boolean> => 
+ {
+  if (await PermissionsManager.isAdmin(user)) return true;
+  const instances = await candidateDeciderDao.getAllInstances();
+  for (const instance of instances) {
+    if (instance.authorizedMembers.some((member) => member.email === user.email) || instance.authorizedRoles.includes(user.role)) {
+      return true;
+    }
+  }
+  return false;
+};
 
 /**
  * Creates a new CandidateDecider instance in the database.

--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -41,15 +41,16 @@ export const getAllCandidateDeciderInstances = async (
  * @returns {Promise<boolean>} A promise that resolves with a boolean indicating whether the user has access to the instance
  */
 export const hasCandidateDeciderInstance = async (user: IdolMember): Promise<boolean> => {
-  if (await PermissionsManager.isAdmin(user)) return true;
+  if (await PermissionsManager.isLeadOrAdmin(user)) return true;
   const instances = await candidateDeciderDao.getAllInstances();
-  for (const instance of instances) {
-    if (
-      instance.authorizedMembers.some((member) => member.email === user.email) ||
-      instance.authorizedRoles.includes(user.role)
+  if (
+      instances.some(
+        (instance) =>
+          instance.authorizedMembers.some((member) => member.email === user.email) ||
+          instance.authorizedRoles.includes(user.role)
+      )
     ) {
-      return true;
-    }
+    return true;
   }
   return false;
 };

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -433,7 +433,7 @@ loginCheckedPost('/team-event-reminder', async (req, user) => ({
 loginCheckedGet('/candidate-decider', async (_, user) => ({
   instances: await getAllCandidateDeciderInstances(user)
 }));
-loginCheckedGet('/candidate-decider-instance/', async (_, user) => ({
+loginCheckedGet('/candidate-decider-instance', async (_, user) => ({
   hasInstance: await hasCandidateDeciderInstance(user)
   // console.log(`info: ${hasInstance}`)
 }));

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -109,8 +109,8 @@ export const enforceSession = true;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd
-    ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
-    : [/http:\/\/localhost:3000/];
+  ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
+  : [/http:\/\/localhost:3000/];
 
 // Middleware
 app.use(

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -109,8 +109,8 @@ export const enforceSession = true;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd
-  ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
-  : [/http:\/\/localhost:3000/];
+    ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
+    : [/http:\/\/localhost:3000/];
 
 // Middleware
 app.use(

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -435,7 +435,6 @@ loginCheckedGet('/candidate-decider', async (_, user) => ({
 }));
 loginCheckedGet('/candidate-decider-instance', async (_, user) => ({
   hasInstance: await hasCandidateDeciderInstance(user)
-  // console.log(`info: ${hasInstance}`)
 }));
 loginCheckedGet('/candidate-decider/:uuid', async (req, user) => ({
   instance: await getCandidateDeciderInstance(req.params.uuid, user)

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -75,7 +75,8 @@ import {
   getCandidateDeciderInstance,
   updateCandidateDeciderRatingAndComment,
   updateCandidateDeciderInstance,
-  getCandidateDeciderReviews
+  getCandidateDeciderReviews,
+  hasCandidateDeciderInstance
 } from './API/candidateDeciderAPI';
 import {
   getAllDevPortfolios,
@@ -431,6 +432,10 @@ loginCheckedPost('/team-event-reminder', async (req, user) => ({
 // Candidate Decider
 loginCheckedGet('/candidate-decider', async (_, user) => ({
   instances: await getAllCandidateDeciderInstances(user)
+}));
+loginCheckedGet('/candidate-decider-instance/', async (_, user) => ({
+  hasInstance: await hasCandidateDeciderInstance(user)
+  // console.log(`info: ${hasInstance}`)
 }));
 loginCheckedGet('/candidate-decider/:uuid', async (req, user) => ({
   instance: await getCandidateDeciderInstance(req.params.uuid, user)

--- a/frontend/src/API/CandidateDeciderAPI.ts
+++ b/frontend/src/API/CandidateDeciderAPI.ts
@@ -9,7 +9,6 @@ export default class CandidateDeciderAPI {
 
   static async hasCandidateDeciderInstance(user: IdolMember): Promise<boolean> {
     const response = APIWrapper.get(`${backendURL}/candidate-decider-instance/`);
-    // console.log(`info: ${(await response).data.hasInstance}`)
     return response.then((val) => val.data.hasInstance);
   }
 

--- a/frontend/src/API/CandidateDeciderAPI.ts
+++ b/frontend/src/API/CandidateDeciderAPI.ts
@@ -7,7 +7,7 @@ export default class CandidateDeciderAPI {
     return response.then((val) => val.data.instances);
   }
 
-  static async hasCandidateDeciderInstance(user: IdolMember): Promise<boolean> {
+  static async hasCandidateDeciderInstance(): Promise<boolean> {
     const response = APIWrapper.get(`${backendURL}/candidate-decider-instance/`);
     return response.then((val) => val.data.hasInstance);
   }

--- a/frontend/src/API/CandidateDeciderAPI.ts
+++ b/frontend/src/API/CandidateDeciderAPI.ts
@@ -7,6 +7,12 @@ export default class CandidateDeciderAPI {
     return response.then((val) => val.data.instances);
   }
 
+  static async hasCandidateDeciderInstance(user: IdolMember): Promise<boolean> {
+    const response = APIWrapper.get(`${backendURL}/candidate-decider-instance/`);
+    // console.log(`info: ${(await response).data.hasInstance}`)
+    return response.then((val) => val.data.hasInstance);
+  }
+
   static async getInstance(uuid: string): Promise<CandidateDeciderInstance> {
     const response = APIWrapper.get(`${backendURL}/candidate-decider/${uuid}`);
     return response.then((val) => val.data.instance);

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -7,12 +7,14 @@ import { useRouter } from 'next/router';
 import UserProvider from '../components/Common/UserProvider/UserProvider';
 import FirestoreDataProvider, {
   useHasAdminPermission,
-  useHasMemberPermission
+  useHasMemberPermission,
+  useSelf
 } from '../components/Common/FirestoreDataProvider';
 import SiteHeader from '../components/Common/SiteHeader/SiteHeader';
 import { Emitters } from '../utils';
 import ErrorModal from '../components/Modals/ErrorModal';
 import SuccessModal from '../components/Modals/SuccessModal';
+import CandidateDeciderAPI from '../API/CandidateDeciderAPI';
 
 import 'semantic-ui-css/semantic.min.css';
 import './index.css';
@@ -86,7 +88,7 @@ function AppContent({ children }: { readonly children: ReactNode }): JSX.Element
                 }}
                 className="appSidebar"
               >
-                <MenuContent hasAdminPermission={hasAdminPermission} />
+                <MenuContent hasAdminPermission={hasAdminPermission}/>
               </Sidebar>
               <Sidebar.Pushable>
                 <Sidebar.Pusher dimmed={navVisible}>
@@ -101,36 +103,50 @@ function AppContent({ children }: { readonly children: ReactNode }): JSX.Element
   );
 }
 
-const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermission }) => (
-  <>
-    <Link href="/">
-      <Menu.Item>
-        <Icon name="home" />
-        Home
-      </Menu.Item>
-    </Link>
-    {hasAdminPermission && (
-      <Link href="/admin">
+const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermission }) => {
+  const [hasInstance, setHasInstance] = useState<boolean>(false);
+  const self = useSelf();
+  useEffect(() => {
+    if (self) {
+      CandidateDeciderAPI.hasCandidateDeciderInstance(self)
+        .then((result) => {
+          setHasInstance(result)
+    });
+    }
+  }, [self]);
+  return (
+    <>
+      <Link href="/">
         <Menu.Item>
-          <Icon name="shield" />
-          Admin
+          <Icon name="home" />
+          Home
         </Menu.Item>
       </Link>
-    )}
-    <Link href="/forms">
-      <Menu.Item>
-        <Icon name="file alternate" />
-        Forms
-      </Menu.Item>
-    </Link>
-    <Link href="/candidate-decider">
-      <Menu.Item>
-        <Icon name="chart bar outline" />
-        Candidate Decider
-      </Menu.Item>
-    </Link>
-  </>
-);
+      {hasAdminPermission && (
+        <Link href="/admin">
+          <Menu.Item>
+            <Icon name="shield" />
+            Admin
+          </Menu.Item>
+        </Link>
+      )}
+      <Link href="/forms">
+        <Menu.Item>
+          <Icon name="file alternate" />
+          Forms
+        </Menu.Item>
+      </Link>
+      {hasInstance && (
+      <Link href="/candidate-decider">
+        <Menu.Item>
+          <Icon name="chart bar outline" />
+          Candidate Decider
+        </Menu.Item>
+      </Link>
+      )}
+    </>
+  );
+};
 
 const RoutingMiddleware: React.FC<{ children: ReactNode }> = ({ children }) => {
   const router = useRouter();

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -108,7 +108,7 @@ const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermis
   const self = useSelf();
   useEffect(() => {
     if (self) {
-      CandidateDeciderAPI.hasCandidateDeciderInstance(self).then((result) => {
+      CandidateDeciderAPI.hasCandidateDeciderInstance().then((result) => {
         setHasInstance(result);
       });
     }

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -88,7 +88,7 @@ function AppContent({ children }: { readonly children: ReactNode }): JSX.Element
                 }}
                 className="appSidebar"
               >
-                <MenuContent hasAdminPermission={hasAdminPermission}/>
+                <MenuContent hasAdminPermission={hasAdminPermission} />
               </Sidebar>
               <Sidebar.Pushable>
                 <Sidebar.Pusher dimmed={navVisible}>
@@ -108,10 +108,9 @@ const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermis
   const self = useSelf();
   useEffect(() => {
     if (self) {
-      CandidateDeciderAPI.hasCandidateDeciderInstance(self)
-        .then((result) => {
-          setHasInstance(result)
-    });
+      CandidateDeciderAPI.hasCandidateDeciderInstance(self).then((result) => {
+        setHasInstance(result);
+      });
     }
   }, [self]);
   return (
@@ -137,12 +136,12 @@ const MenuContent: React.FC<{ hasAdminPermission: boolean }> = ({ hasAdminPermis
         </Menu.Item>
       </Link>
       {hasInstance && (
-      <Link href="/candidate-decider">
-        <Menu.Item>
-          <Icon name="chart bar outline" />
-          Candidate Decider
-        </Menu.Item>
-      </Link>
+        <Link href="/candidate-decider">
+          <Menu.Item>
+            <Icon name="chart bar outline" />
+            Candidate Decider
+          </Menu.Item>
+        </Link>
       )}
     </>
   );


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Edited candidate decider tab such that the icon to see candidate decider instances is only visible when the user is an admin or has a candidate instance assigned to them or their role.

Admin view: Candidate decider tab displayed and all instances seen

<img width="1337" alt="Screenshot 2025-04-12 at 3 13 03 PM" src="https://github.com/user-attachments/assets/1fa20292-eb26-477d-932d-5de54ed6baa6" />

When Candidate Decider instance is assigned to the user or their role: Candidate decider tab displayed and only assigned instances seen

<img width="1335" alt="Screenshot 2025-04-12 at 3 12 33 PM" src="https://github.com/user-attachments/assets/b2e48929-34da-46fb-aeb0-e0bdba7379dd" />

Member view with no Candidate Decider instance assigned: tab hidden

<img width="1327" alt="Screenshot 2025-04-12 at 3 14 25 PM" src="https://github.com/user-attachments/assets/23ab2799-6816-424a-9766-672947d36e72" />
