### PR TITLE
[Cand decider] New `<Switch>` component

### DIFF
--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -1,6 +1,5 @@
 import styles from './ApplicantCredentials.module.css';
 import { formatLink } from '../../utils';
-import { useHasAdminPermission } from '../Common/FirestoreDataProvider';
 
 type Props = {
   name: string;
@@ -28,75 +27,71 @@ const ApplicantCredentials: React.FC<Props> = ({
   portfolioURL,
   preferredName,
   candidate
-}) => {
-  const hasAdminPermission = useHasAdminPermission();
-
-  return (
-    <div className={styles.credentialContainer}>
-      <div className={styles.header}>
-        <div className={styles.applicantInformation}>
-          {seeApplicantName ? (
-            <>
-              <h1>
-                {name} {preferredName && `(${preferredName})`}
-              </h1>
-              <p>{email}</p>
-            </>
-          ) : (
-            <h1>Candidate {candidate + 1}</h1>
-          )}
-          <p>Class of {gradYear}</p>
-        </div>
+}) => (
+  <div className={styles.credentialContainer}>
+    <div className={styles.header}>
+      <div className={styles.applicantInformation}>
+        {seeApplicantName ? (
+          <>
+            <h1>
+              {name} {preferredName && `(${preferredName})`}
+            </h1>
+            <p>{email}</p>
+          </>
+        ) : (
+          <h1>Candidate {candidate + 1}</h1>
+        )}
+        <p>Class of {gradYear}</p>
       </div>
+    </div>
 
-      {seeApplicantName && (
-        <div className={styles.documents}>
-          <h3>Documents</h3>
-          <div className={styles.iconsContainer}>
+    {seeApplicantName && (
+      <div className={styles.documents}>
+        <h3>Documents</h3>
+        <div className={styles.iconsContainer}>
+          <a
+            className={styles.icon}
+            href={formatLink(resumeURL)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FileIcon />
+          </a>
+          {githubURL && (
             <a
               className={styles.icon}
-              href={formatLink(resumeURL)}
+              href={formatLink(githubURL)}
               target="_blank"
               rel="noopener noreferrer"
             >
-              <FileIcon />
+              <GithubIcon />
             </a>
-            {githubURL && (
-              <a
-                className={styles.icon}
-                href={formatLink(githubURL)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <GithubIcon />
-              </a>
-            )}
-            {linkedinURL && (
-              <a
-                className={styles.icon}
-                href={formatLink(linkedinURL, 'linkedin')}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <LinkedinIcon />
-              </a>
-            )}
-            {portfolioURL && (
-              <a
-                className={styles.icon}
-                href={formatLink(portfolioURL)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <GlobeIcon />
-              </a>
-            )}
-          </div>
+          )}
+          {linkedinURL && (
+            <a
+              className={styles.icon}
+              href={formatLink(linkedinURL, 'linkedin')}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <LinkedinIcon />
+            </a>
+          )}
+          {portfolioURL && (
+            <a
+              className={styles.icon}
+              href={formatLink(portfolioURL)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <GlobeIcon />
+            </a>
+          )}
         </div>
-      )}
-    </div>
-  );
-};
+      </div>
+    )}
+  </div>
+);
 
 const FileIcon = () => (
   <svg

--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -11,13 +11,11 @@ type Props = {
   portfolioURL?: string;
   preferredName?: string;
   seeApplicantName: boolean;
-  setSeeApplicantName: (value: boolean) => void;
   candidate: number;
 };
 
 const ApplicantCredentials: React.FC<Props> = ({
   seeApplicantName,
-  setSeeApplicantName,
   name,
   email,
   gradYear,

--- a/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
+++ b/frontend/src/components/Candidate-Decider/ApplicantCredentials.tsx
@@ -1,4 +1,3 @@
-import { Checkbox } from 'semantic-ui-react';
 import styles from './ApplicantCredentials.module.css';
 import { formatLink } from '../../utils';
 import { useHasAdminPermission } from '../Common/FirestoreDataProvider';
@@ -48,16 +47,6 @@ const ApplicantCredentials: React.FC<Props> = ({
           )}
           <p>Class of {gradYear}</p>
         </div>
-
-        {hasAdminPermission && (
-          <Checkbox
-            className={styles.seeApplicantName}
-            toggle
-            checked={seeApplicantName}
-            onChange={() => setSeeApplicantName(!seeApplicantName)}
-            label="See applicant name"
-          />
-        )}
       </div>
 
       {seeApplicantName && (

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
@@ -45,11 +45,6 @@
   margin-left: 1%;
 }
 
-.seeApplicantName {
-  margin-bottom: 1%;
-  margin-left: 1%;
-}
-
 .previousNextButtonContainer {
   margin-right: 0.5% !important;
 }

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -273,7 +273,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
             checked={seeApplicantName}
             onChange={() => setSeeApplicantName((prev) => !prev)}
             label="See applicant name"
-            className={styles.seeApplicantName}
           />
         )}
         <ResponsesPanel

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -3,7 +3,7 @@ import { Button, Modal, Form, Radio } from 'semantic-ui-react';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import ResponsesPanel from './ResponsesPanel';
 import LocalProgressPanel from './LocalProgressPanel';
-import { useSelf } from '../Common/FirestoreDataProvider';
+import { useHasAdminPermission, useSelf } from '../Common/FirestoreDataProvider';
 import styles from './CandidateDecider.module.css';
 import SearchBar from './SearchBar';
 import {
@@ -142,6 +142,8 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
     setNextCandidate(null);
     setIsModalOpen(false);
   };
+
+  const hasAdminPermission = useHasAdminPermission();
 
   return instance.candidates.length === 0 ? (
     <div></div>

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -284,7 +284,6 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
           currentRating={currentRating ?? 0}
           setCurrentRating={setCurrentRating}
           seeApplicantName={seeApplicantName}
-          setSeeApplicantName={setSeeApplicantName}
           candidate={instance.candidates[currentCandidate].id}
         />
       </div>

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, Dispatch, SetStateAction } from 'react';
-import { Button, Checkbox, Modal, Form, Radio } from 'semantic-ui-react';
+import { Button, Modal, Form, Radio } from 'semantic-ui-react';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import ResponsesPanel from './ResponsesPanel';
 import LocalProgressPanel from './LocalProgressPanel';

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -10,6 +10,7 @@ import {
   useCandidateDeciderInstance,
   useCandidateDeciderReviews
 } from './useCandidateDeciderInstance';
+import Switch from '../Common/Switch/Switch';
 
 type CandidateDeciderProps = {
   uuid: string;
@@ -268,12 +269,11 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
       </div>
       <div className={styles.responsesContainer}>
         {hasAdminPermission && (
-          <Checkbox
-            className={styles.seeApplicantName}
-            toggle
+          <Switch
             checked={seeApplicantName}
             onChange={() => setSeeApplicantName((prev) => !prev)}
             label="See applicant name"
+            className={styles.seeApplicantName}
           />
         )}
         <ResponsesPanel

--- a/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/ResponsesPanel.tsx
@@ -10,7 +10,6 @@ type Props = {
   currentComment: string;
   setCurrentComment: Dispatch<SetStateAction<string | undefined>>;
   seeApplicantName: boolean;
-  setSeeApplicantName: Dispatch<SetStateAction<boolean>>;
   candidate: number;
 };
 
@@ -84,14 +83,12 @@ const ResponsesPanel: React.FC<Props> = ({
   currentComment,
   setCurrentComment,
   seeApplicantName,
-  setSeeApplicantName,
   candidate
 }) => (
   <div>
     <ApplicantCredentials
       {...getCredentials(headers, responses)}
       seeApplicantName={seeApplicantName}
-      setSeeApplicantName={setSeeApplicantName}
       candidate={candidate}
     />
     <div className={styles.applicantResponses}>

--- a/frontend/src/components/Common/Switch/Switch.module.css
+++ b/frontend/src/components/Common/Switch/Switch.module.css
@@ -78,6 +78,10 @@
   background-color: var(--fg-default);
 }
 
+.switch:hover input:checked + .slider {
+  background-color: var(--fg-dimmer);
+}
+
 .switch input:checked + .slider::before {
   transform: translateX(18px);
 }

--- a/frontend/src/components/Common/Switch/Switch.module.css
+++ b/frontend/src/components/Common/Switch/Switch.module.css
@@ -23,6 +23,7 @@
   width: 0;
   height: 0;
   position: relative;
+  opacity: 0;
 }
 
 /* This is the focus state element. It's a <span> that is hidden by default, but shows on :focus-visible */

--- a/frontend/src/components/Common/Switch/Switch.module.css
+++ b/frontend/src/components/Common/Switch/Switch.module.css
@@ -1,7 +1,8 @@
+/* Wrapper styles (input + label) */
 .switchWrapper {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   cursor: pointer;
   user-select: none;
 }
@@ -11,6 +12,7 @@
   font-weight: 500;
 }
 
+/* Bae layout */
 .switch {
   position: relative;
   width: 36px;
@@ -18,25 +20,32 @@
 }
 
 .switch input {
-  opacity: 0;
   width: 0;
   height: 0;
   position: relative;
 }
 
-.switch:hover {
-  background-color: var(--fg-dimmest);
-}
-
-.switch input:focus-visible + span::after {
-  outline: 2px solid red;
+/* This is the focus state element. It's a <span> that is hidden by default, but shows on :focus-visible */
+.switch .focusState {
+  content: '';
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 2px;
+  border-radius: 128px;
   position: absolute;
   top: 0;
   left: 0;
   width: 36px;
   height: 18px;
+  display: block;
+  opacity: 0;
 }
 
+/* Shows focus state (outline) is tab'ed on */
+.switch input:focus-visible ~ .focusState {
+  opacity: 1;
+}
+
+/* Slider track and thumb */
 .slider {
   position: absolute;
   cursor: pointer;
@@ -49,6 +58,10 @@
   transition: background-color 0.2s;
 }
 
+.switch:hover .slider {
+  background-color: var(--fg-dimmest);
+}
+
 .slider::before {
   position: absolute;
   content: '';
@@ -57,7 +70,8 @@
   left: 1px;
   bottom: 1px;
   background-color: var(--bg-default);
-  border-radius: 50%;
+  border-radius: 8px;
+  transition: 50ms ease-in-out;
 }
 
 .switch input:checked + .slider {
@@ -66,4 +80,15 @@
 
 .switch input:checked + .slider::before {
   transform: translateX(18px);
+}
+
+/* These make the thumb of the switch distort a bit when :active for a cool pressed effect */
+.switch:active input + .slider::before {
+  width: 20px;
+  transform: translateX(0);
+}
+
+.switch:active input:checked + .slider::before {
+  width: 20px;
+  transform: translateX(14px);
 }

--- a/frontend/src/components/Common/Switch/Switch.module.css
+++ b/frontend/src/components/Common/Switch/Switch.module.css
@@ -1,32 +1,69 @@
 .switchWrapper {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   cursor: pointer;
+  user-select: none;
 }
 
-.label {
+.labelText {
   font-size: 16px;
+  font-weight: 500;
 }
 
 .switch {
-  width: 40px;
-  height: 22px;
-  background-color: #ccc;
-  border-radius: 999px;
-  padding: 3px;
-  transition: background-color 0.2s ease;
+  position: relative;
+  width: 36px;
+  height: 18px;
 }
 
-.thumb {
-  width: 16px;
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: relative;
+}
+
+.switch:hover {
+  background-color: var(--fg-dimmest);
+}
+
+.switch input:focus-visible + span::after {
+  outline: 2px solid red;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 36px;
+  height: 18px;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--border-dimmer);
+  border-radius: 34px;
+  transition: background-color 0.2s;
+}
+
+.slider::before {
+  position: absolute;
+  content: '';
   height: 16px;
-  background-color: white;
+  width: 16px;
+  left: 1px;
+  bottom: 1px;
+  background-color: var(--bg-default);
   border-radius: 50%;
-  transition: transform 0.2s ease;
 }
 
-.checked {
+.switch input:checked + .slider {
+  background-color: var(--fg-default);
+}
+
+.switch input:checked + .slider::before {
   transform: translateX(18px);
-  background-color: #4caf50;
 }

--- a/frontend/src/components/Common/Switch/Switch.module.css
+++ b/frontend/src/components/Common/Switch/Switch.module.css
@@ -12,7 +12,7 @@
   font-weight: 500;
 }
 
-/* Bae layout */
+/* Base layout */
 .switch {
   position: relative;
   width: 36px;

--- a/frontend/src/components/Common/Switch/Switch.module.css
+++ b/frontend/src/components/Common/Switch/Switch.module.css
@@ -1,0 +1,32 @@
+.switchWrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.label {
+  font-size: 16px;
+}
+
+.switch {
+  width: 40px;
+  height: 22px;
+  background-color: #ccc;
+  border-radius: 999px;
+  padding: 3px;
+  transition: background-color 0.2s ease;
+}
+
+.thumb {
+  width: 16px;
+  height: 16px;
+  background-color: white;
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+}
+
+.checked {
+  transform: translateX(18px);
+  background-color: #4caf50;
+}

--- a/frontend/src/components/Common/Switch/Switch.tsx
+++ b/frontend/src/components/Common/Switch/Switch.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styles from './Switch.module.css';
+
+type SwitchProps = {
+  checked: boolean;
+  onChange: () => void;
+  label?: string;
+  className?: string;
+};
+
+const Switch: React.FC<SwitchProps> = ({ checked, onChange, label, className }) => {
+  return (
+    <label className={`${styles.switchWrapper} ${className}`}>
+      <div className={styles.switch} onClick={onChange}>
+        <div className={`${styles.thumb} ${checked ? styles.checked : ''}`} />
+      </div>
+      <span className={styles.label}>{label}</span>
+    </label>
+  );
+};
+
+export default Switch;

--- a/frontend/src/components/Common/Switch/Switch.tsx
+++ b/frontend/src/components/Common/Switch/Switch.tsx
@@ -14,8 +14,9 @@ const Switch = ({ checked, onChange, label, className = '' }: SwitchProps) => {
       <div className={styles.switch}>
         <input type="checkbox" checked={checked} onChange={onChange} />
         <span className={styles.slider} />
+        <span className={styles.focusState} />
       </div>
-      <span className={styles.labelText}>{label}</span>
+      <p className={styles.labelText}>{label}</p>
     </label>
   );
 };

--- a/frontend/src/components/Common/Switch/Switch.tsx
+++ b/frontend/src/components/Common/Switch/Switch.tsx
@@ -8,17 +8,15 @@ type SwitchProps = {
   className?: string;
 };
 
-const Switch = ({ checked, onChange, label, className = '' }: SwitchProps) => {
-  return (
-    <label className={`${styles.switchWrapper} ${className}`}>
-      <div className={styles.switch}>
-        <input type="checkbox" checked={checked} onChange={onChange} />
-        <span className={styles.slider} />
-        <span className={styles.focusState} />
-      </div>
-      <p className={styles.labelText}>{label}</p>
-    </label>
-  );
-};
+const Switch = ({ checked, onChange, label, className = '' }: SwitchProps) => (
+  <label className={`${styles.switchWrapper} ${className}`}>
+    <div className={styles.switch}>
+      <input type="checkbox" checked={checked} onChange={onChange} />
+      <span className={styles.slider} />
+      <span className={styles.focusState} />
+    </div>
+    <p className={styles.labelText}>{label}</p>
+  </label>
+);
 
 export default Switch;

--- a/frontend/src/components/Common/Switch/Switch.tsx
+++ b/frontend/src/components/Common/Switch/Switch.tsx
@@ -4,17 +4,18 @@ import styles from './Switch.module.css';
 type SwitchProps = {
   checked: boolean;
   onChange: () => void;
-  label?: string;
+  label: string;
   className?: string;
 };
 
-const Switch: React.FC<SwitchProps> = ({ checked, onChange, label, className }) => {
+const Switch = ({ checked, onChange, label, className = '' }: SwitchProps) => {
   return (
     <label className={`${styles.switchWrapper} ${className}`}>
-      <div className={styles.switch} onClick={onChange}>
-        <div className={`${styles.thumb} ${checked ? styles.checked : ''}`} />
+      <div className={styles.switch}>
+        <input type="checkbox" checked={checked} onChange={onChange} />
+        <span className={styles.slider} />
       </div>
-      <span className={styles.label}>{label}</span>
+      <span className={styles.labelText}>{label}</span>
     </label>
   );
 };


### PR DESCRIPTION
# Summary <!-- Required -->

- Created new `<Switch>` component
- Added styling
- Removed old `<Checkbox>` component
- [Based off of Figma designs](https://www.figma.com/design/qHNMOp6rrIFMv1wBXsVtYZ/SP25-IDOL-Candidate-Decider-Tool?node-id=122-471&m=dev)

| X | Before | After |
|-|-|-|
|Default|<img width="334" alt="def bef" src="https://github.com/user-attachments/assets/32c9f262-2fa3-46fe-bc6f-7ce5f947bc40" />|<img width="334" alt="def aft" src="https://github.com/user-attachments/assets/4bb4c2e5-dd02-4d97-a2eb-7babd87f57fb" />|
|Hover|<img width="334" alt="hov bef" src="https://github.com/user-attachments/assets/f7c786b2-b48f-422a-ba8e-18404e1443f5" />|<img width="334" alt="hov aft" src="https://github.com/user-attachments/assets/dde7d91f-f8c3-4db4-a965-01854fcb4c09" />|
|Active|<img width="334" alt="act bef" src="https://github.com/user-attachments/assets/138f7d46-c700-427f-8a66-df0a5b0c8564" />|<img width="334" alt="act aft" src="https://github.com/user-attachments/assets/adb77ba5-cf6b-4a47-ad7b-9e0d6cd28d0b" />|
|Focus|<img width="334" alt="focus bef" src="https://github.com/user-attachments/assets/42732bae-15fb-47a7-bb21-6ec24f5a5e73" />|<img width="334" alt="focus aft" src="https://github.com/user-attachments/assets/56895be2-0f76-43ea-8da7-667ba0beba28" />|

### Behavior:


https://github.com/user-attachments/assets/37bd1285-0556-49b3-95a4-887ff4058c90




# Test Plan <!-- Required -->

- Go to Cand decider
- Turn the switch on and off, make sure applicant is anonymized based on the state
- Check styles are visually the same 
- Press `tab` a bunch of and ensure clicking `space` activates the switch
