### PR TITLE
[Cand decider] New `<Input>` component

### DIFF
--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -10,6 +10,7 @@ import {
   useCandidateDeciderInstance,
   useCandidateDeciderReviews
 } from './useCandidateDeciderInstance';
+import Input from '../Common/Input/Input';
 
 type CandidateDeciderProps = {
   uuid: string;
@@ -32,15 +33,13 @@ type CommentEditorProps = {
 const CommentEditor: React.FC<CommentEditorProps> = ({ currentComment, setCurrentComment }) => (
   <div style={{ width: '100%' }}>
     <h4>Comments</h4>
-    <Form.Group inline>
-      <Form.Input
-        style={{ height: 256, width: '100%' }}
-        className="fifteen wide field"
-        placeholder={'Comment...'}
-        onChange={(event) => setCurrentComment(event.target.value)}
-        value={currentComment}
-      />
-    </Form.Group>
+    <Input
+      value={currentComment}
+      onChange={(event) => setCurrentComment(event.target.value)}
+      placeholder="Comment..."
+      multiline
+      maxHeight={256}
+    />
   </div>
 );
 

--- a/frontend/src/components/Common/Input/Input.module.css
+++ b/frontend/src/components/Common/Input/Input.module.css
@@ -1,0 +1,25 @@
+.input {
+  font-size: 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+  box-sizing: border-box;
+  width: 100%;
+  height: 256px;
+  padding: 16px;
+  transition: 50ms ease-in;
+  font-family: Lato, 'Helvetica Neue', Arial, Helvetica, sans-serif;
+}
+
+.input:hover {
+  border-color: var(--border-dimmer);
+}
+
+.input:focus {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -1px;
+}
+
+input.input::placeholder,
+textarea.input::placeholder {
+  color: var(--fg-dimmer);
+}

--- a/frontend/src/components/Common/Input/Input.module.css
+++ b/frontend/src/components/Common/Input/Input.module.css
@@ -23,3 +23,11 @@ input.input::placeholder,
 textarea.input::placeholder {
   color: var(--fg-dimmer);
 }
+
+.input:disabled {
+  opacity: 50;
+}
+
+.input:disabled:hover {
+  border-color: var(--border-default);
+}

--- a/frontend/src/components/Common/Input/Input.tsx
+++ b/frontend/src/components/Common/Input/Input.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './Input.module.css';
 
 type InputProps = {
-  value: string | undefined;
+  value?: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   placeholder?: string;
   multiline?: boolean;

--- a/frontend/src/components/Common/Input/Input.tsx
+++ b/frontend/src/components/Common/Input/Input.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styles from './Input.module.css';
+
+type InputProps = {
+  value: string | undefined;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  placeholder?: string;
+  multiline?: boolean;
+  maxHeight?: number;
+  resize?: 'none' | 'both' | 'horizontal' | 'vertical';
+};
+
+const Input: React.FC<InputProps> = ({
+  value,
+  onChange,
+  placeholder,
+  multiline = false,
+  maxHeight,
+  resize = 'none'
+}) => {
+  const style = {
+    ...(maxHeight ? { maxHeight } : { height: 48 }),
+    resize
+  };
+
+  if (multiline) {
+    return (
+      <textarea
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        className={styles.input}
+        style={style}
+      />
+    );
+  }
+
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      className={styles.input}
+      style={style}
+    />
+  );
+};
+
+export default Input;

--- a/frontend/src/components/Common/Input/Input.tsx
+++ b/frontend/src/components/Common/Input/Input.tsx
@@ -8,6 +8,7 @@ type InputProps = {
   multiline?: boolean;
   maxHeight?: number;
   resize?: 'none' | 'both' | 'horizontal' | 'vertical';
+  disabled?: boolean;
 };
 
 const Input: React.FC<InputProps> = ({
@@ -16,7 +17,8 @@ const Input: React.FC<InputProps> = ({
   placeholder,
   multiline = false,
   maxHeight,
-  resize = 'none'
+  resize = 'none',
+  disabled = false
 }) => {
   const style = {
     ...(maxHeight ? { maxHeight } : { height: 48 }),
@@ -31,6 +33,7 @@ const Input: React.FC<InputProps> = ({
         placeholder={placeholder}
         className={styles.input}
         style={style}
+        disabled={disabled}
       />
     );
   }
@@ -43,6 +46,7 @@ const Input: React.FC<InputProps> = ({
       placeholder={placeholder}
       className={styles.input}
       style={style}
+      disabled={disabled}
     />
   );
 };


### PR DESCRIPTION
# Summary

- Created new `<Input>` component
- It renders an `<input>` or `<textarea>` component accordingly
- You can also specify the height and resize properties of the input

|X|Before|After|
|-|-|-|
|Default|<img width="577" alt="def bef" src="https://github.com/user-attachments/assets/1a7955ec-897a-4ca5-b6e5-298cd782ee2f" />|<img width="577" alt="def aft" src="https://github.com/user-attachments/assets/82de3475-69de-4609-afd0-8133f1636f9e" />|
|Hover|<img width="577" alt="def bef 2" src="https://github.com/user-attachments/assets/653bb926-a349-4cf8-ae45-121f26e91629" />|<img width="577" alt="hov aft" src="https://github.com/user-attachments/assets/88b9ab1d-fd26-4ea2-98ba-85f9e813fa25" />|
|Focus|<img width="577" alt="Screenshot 2025-04-14 at 2 31 01 PM" src="https://github.com/user-attachments/assets/4be8f422-33c1-4d45-850e-e9c6e713928b" />|<img width="577" alt="focus aft" src="https://github.com/user-attachments/assets/b7dad4e8-d414-4cba-9501-d9a272eff63f" />|
|Disabled|<img width="577" alt="Screenshot 2025-04-14 at 2 40 18 PM" src="https://github.com/user-attachments/assets/b2f5a0e2-4c74-4b12-b7cc-f17db7ef501d" />|<img width="577" alt="Screenshot 2025-04-14 at 2 39 57 PM" src="https://github.com/user-attachments/assets/c6ededa3-a4b9-4165-9869-7bce3fa644c9" />|


[From Figma link Input component](https://www.figma.com/design/qHNMOp6rrIFMv1wBXsVtYZ/SP25-IDOL-Candidate-Decider-Tool?node-id=114-804&m=dev)


# Test plan
- Open cand decider
- Interact with the Input, hover, focus, type in it
- Make sure it works well, make sure it saves properly