### PR TITLE
[New website] New `<Input>` and `<LabeledInput>` components

### DIFF
--- a/new-dti-website-redesign/src/app/components/Input.tsx
+++ b/new-dti-website-redesign/src/app/components/Input.tsx
@@ -9,6 +9,7 @@ type InputProps = {
   resize?: 'none' | 'both' | 'horizontal' | 'vertical';
   disabled?: boolean;
   className?: string;
+  id?: string;
 };
 
 const Input: React.FC<InputProps> = ({
@@ -19,7 +20,8 @@ const Input: React.FC<InputProps> = ({
   height,
   resize = 'none',
   disabled = false,
-  className
+  className,
+  id
 }) => {
   const baseStyles = `
     p-3 text-rg text-foreground-1 placeholder-foreground-3
@@ -53,6 +55,7 @@ const Input: React.FC<InputProps> = ({
         className={`${textareaStyles} ${className ?? ''}`}
         style={{ height, resize }}
         disabled={disabled}
+        id={id}
       />
     );
   }
@@ -65,6 +68,7 @@ const Input: React.FC<InputProps> = ({
       placeholder={placeholder}
       className={`${inputStyles} ${className ?? ''}`}
       disabled={disabled}
+      id={id}
     />
   );
 };

--- a/new-dti-website-redesign/src/app/components/Input.tsx
+++ b/new-dti-website-redesign/src/app/components/Input.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+type InputProps = {
+  value?: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  placeholder?: string;
+  multiline?: boolean;
+  height?: number;
+  resize?: 'none' | 'both' | 'horizontal' | 'vertical';
+  disabled?: boolean;
+};
+
+const Input: React.FC<InputProps> = ({
+  value,
+  onChange,
+  placeholder,
+  multiline = false,
+  height,
+  resize = 'none',
+  disabled = false
+}) => {
+  const baseStyles = `
+    w-full p-3 text-rg text-foreground-1 placeholder-foreground-3
+    bg-background-2 rounded-lg border border-border-1
+    focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-offset-[-1px] focus-visible:outline-[var(--foreground-1)]
+    hover:border-border-2
+    transition duration-[120ms]
+  `;
+
+  const textareaStyles = `
+    ${baseStyles}
+    resize-none
+  `;
+
+  const inputStyles = `
+    ${baseStyles}
+    h-12
+  `;
+
+  const style = {
+    ...(height ? { height } : { height: '48px' }),
+    resize
+  };
+
+  if (multiline) {
+    return (
+      <textarea
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        className={textareaStyles}
+        style={{ height, resize }}
+        disabled={disabled}
+      />
+    );
+  }
+
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      className={inputStyles}
+      disabled={disabled}
+    />
+  );
+};
+
+export default Input;

--- a/new-dti-website-redesign/src/app/components/Input.tsx
+++ b/new-dti-website-redesign/src/app/components/Input.tsx
@@ -29,7 +29,7 @@ const Input: React.FC<InputProps> = ({
 }) => {
   const baseStyles = `
     p-3 text-rg text-foreground-1 placeholder-foreground-3
-    bg-background-2 rounded-lg border border-border-1
+    bg-background-2 rounded-lg border border-border-1 min-w-64 min-h-12
     focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-offset-[-1px] focus-visible:outline-[var(--foreground-1)]
     hover:border-border-2
     transition duration-[120ms]

--- a/new-dti-website-redesign/src/app/components/Input.tsx
+++ b/new-dti-website-redesign/src/app/components/Input.tsx
@@ -10,6 +10,8 @@ type InputProps = {
   disabled?: boolean;
   className?: string;
   id?: string;
+  ariaDescribedby?: string;
+  ariaInvalid?: boolean;
 };
 
 const Input: React.FC<InputProps> = ({
@@ -21,7 +23,9 @@ const Input: React.FC<InputProps> = ({
   resize = 'none',
   disabled = false,
   className,
-  id
+  id,
+  ariaDescribedby,
+  ariaInvalid
 }) => {
   const baseStyles = `
     p-3 text-rg text-foreground-1 placeholder-foreground-3
@@ -56,6 +60,8 @@ const Input: React.FC<InputProps> = ({
         style={{ height, resize }}
         disabled={disabled}
         id={id}
+        aria-describedby={ariaDescribedby}
+        aria-invalid={ariaInvalid}
       />
     );
   }
@@ -69,6 +75,8 @@ const Input: React.FC<InputProps> = ({
       className={`${inputStyles} ${className ?? ''}`}
       disabled={disabled}
       id={id}
+      aria-describedby={ariaDescribedby}
+      aria-invalid={ariaInvalid}
     />
   );
 };

--- a/new-dti-website-redesign/src/app/components/Input.tsx
+++ b/new-dti-website-redesign/src/app/components/Input.tsx
@@ -8,6 +8,7 @@ type InputProps = {
   height?: number;
   resize?: 'none' | 'both' | 'horizontal' | 'vertical';
   disabled?: boolean;
+  className?: string;
 };
 
 const Input: React.FC<InputProps> = ({
@@ -17,10 +18,11 @@ const Input: React.FC<InputProps> = ({
   multiline = false,
   height,
   resize = 'none',
-  disabled = false
+  disabled = false,
+  className
 }) => {
   const baseStyles = `
-    w-full p-3 text-rg text-foreground-1 placeholder-foreground-3
+    p-3 text-rg text-foreground-1 placeholder-foreground-3
     bg-background-2 rounded-lg border border-border-1
     focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-offset-[-1px] focus-visible:outline-[var(--foreground-1)]
     hover:border-border-2
@@ -48,7 +50,7 @@ const Input: React.FC<InputProps> = ({
         value={value}
         onChange={onChange}
         placeholder={placeholder}
-        className={textareaStyles}
+        className={`${textareaStyles} ${className ?? ''}`}
         style={{ height, resize }}
         disabled={disabled}
       />
@@ -61,7 +63,7 @@ const Input: React.FC<InputProps> = ({
       value={value}
       onChange={onChange}
       placeholder={placeholder}
-      className={inputStyles}
+      className={`${inputStyles} ${className ?? ''}`}
       disabled={disabled}
     />
   );

--- a/new-dti-website-redesign/src/app/components/Input.tsx
+++ b/new-dti-website-redesign/src/app/components/Input.tsx
@@ -45,11 +45,6 @@ const Input: React.FC<InputProps> = ({
     h-12
   `;
 
-  const style = {
-    ...(height ? { height } : { height: '48px' }),
-    resize
-  };
-
   if (multiline) {
     return (
       <textarea

--- a/new-dti-website-redesign/src/app/components/LabeledInput.tsx
+++ b/new-dti-website-redesign/src/app/components/LabeledInput.tsx
@@ -9,7 +9,7 @@ type LabeledInputProps = {
 };
 
 const LabeledInput: React.FC<LabeledInputProps> = ({ label, error, inputProps, className }) => {
-  const id = React.useId();
+  const id = React.useId(); // generating a unique ID for the input
   const errorId = `${id}-error`;
 
   return (
@@ -20,9 +20,9 @@ const LabeledInput: React.FC<LabeledInputProps> = ({ label, error, inputProps, c
         </label>
 
         <Input
-          id={id}
-          aria-invalid={!!error}
-          ariaDescribedby={error ? errorId : undefined}
+          id={id} // input gets the id
+          aria-invalid={!!error} // link to the error
+          ariaDescribedby={error ? errorId : undefined} // so that screen reader can read the error
           {...inputProps}
         />
       </div>

--- a/new-dti-website-redesign/src/app/components/LabeledInput.tsx
+++ b/new-dti-website-redesign/src/app/components/LabeledInput.tsx
@@ -11,14 +11,16 @@ const LabeledInput: React.FC<LabeledInputProps> = ({ label, error, inputProps })
   const id = React.useId();
 
   return (
-    <div className="space-y-1">
-      <label htmlFor={id} className="block text-sm font-medium text-foreground-3">
-        {label}
-      </label>
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1">
+        <label htmlFor={id} className="block text-sm font-medium text-foreground-3">
+          {label}
+        </label>
 
-      <Input {...inputProps} />
+        <Input {...inputProps} />
+      </div>
 
-      {error && <p className="text-xs text-red-400">{error}</p>}
+      {error && <p className="text-accent-red">{error}</p>}
     </div>
   );
 };

--- a/new-dti-website-redesign/src/app/components/LabeledInput.tsx
+++ b/new-dti-website-redesign/src/app/components/LabeledInput.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Input from './Input';
+
+type LabeledInputProps = {
+  label: string;
+  error?: string;
+  inputProps: React.ComponentProps<typeof Input>;
+};
+
+const LabeledInput: React.FC<LabeledInputProps> = ({ label, error, inputProps }) => {
+  const id = React.useId();
+
+  return (
+    <div className="space-y-1">
+      <label htmlFor={id} className="block text-sm font-medium text-foreground-3">
+        {label}
+      </label>
+
+      <Input {...inputProps} />
+
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  );
+};
+
+export default LabeledInput;

--- a/new-dti-website-redesign/src/app/components/LabeledInput.tsx
+++ b/new-dti-website-redesign/src/app/components/LabeledInput.tsx
@@ -5,13 +5,14 @@ type LabeledInputProps = {
   label: string;
   error?: string;
   inputProps: React.ComponentProps<typeof Input>;
+  className?: string;
 };
 
-const LabeledInput: React.FC<LabeledInputProps> = ({ label, error, inputProps }) => {
+const LabeledInput: React.FC<LabeledInputProps> = ({ label, error, inputProps, className }) => {
   const id = React.useId();
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className={`flex flex-col gap- ${className ?? ''}`}>
       <div className="flex flex-col gap-1">
         <label htmlFor={id} className="block text-sm font-medium text-foreground-3">
           {label}

--- a/new-dti-website-redesign/src/app/components/LabeledInput.tsx
+++ b/new-dti-website-redesign/src/app/components/LabeledInput.tsx
@@ -10,18 +10,28 @@ type LabeledInputProps = {
 
 const LabeledInput: React.FC<LabeledInputProps> = ({ label, error, inputProps, className }) => {
   const id = React.useId();
+  const errorId = `${id}-error`;
 
   return (
-    <div className={`flex flex-col gap- ${className ?? ''}`}>
+    <div className={`flex flex-col gap-2 ${className ?? ''}`}>
       <div className="flex flex-col gap-1">
         <label htmlFor={id} className="block text-sm font-medium text-foreground-3">
           {label}
         </label>
 
-        <Input id={id} {...inputProps} />
+        <Input
+          id={id}
+          aria-invalid={!!error}
+          ariaDescribedby={error ? errorId : undefined}
+          {...inputProps}
+        />
       </div>
 
-      {error && <p className="text-accent-red">{error}</p>}
+      {error && (
+        <p className="text-accent-red" id={errorId}>
+          {error}
+        </p>
+      )}
     </div>
   );
 };

--- a/new-dti-website-redesign/src/app/components/LabeledInput.tsx
+++ b/new-dti-website-redesign/src/app/components/LabeledInput.tsx
@@ -18,7 +18,7 @@ const LabeledInput: React.FC<LabeledInputProps> = ({ label, error, inputProps, c
           {label}
         </label>
 
-        <Input {...inputProps} />
+        <Input id={id} {...inputProps} />
       </div>
 
       {error && <p className="text-accent-red">{error}</p>}

--- a/new-dti-website-redesign/src/app/test/page.tsx
+++ b/new-dti-website-redesign/src/app/test/page.tsx
@@ -4,8 +4,13 @@ import Link from 'next/link';
 import { Plus } from 'lucide-react';
 import Button from '../components/Button';
 import IconButton from '../components/IconButton';
+import LabeledInput from '../components/LabeledInput';
+import { useState } from 'react';
+import Input from '../components/Input';
 
 export default function TestPage() {
+  const [email, setEmail] = useState('');
+
   return (
     <div className="p-32 flex flex-col gap-16">
       <Link href="/" className="text-accent-red underline">
@@ -81,6 +86,35 @@ export default function TestPage() {
           <IconButton aria-label="Create" variant="tertiary">
             <Plus />
           </IconButton>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <h4>Inputs</h4>
+        <div className="flex gap-4">
+          <Input placeholder="Input placeholder" onChange={() => {}} />
+
+          <Input placeholder="Input placeholder" onChange={() => {}} multiline height={256} />
+        </div>
+
+        <div className="flex gap-4">
+          <LabeledInput
+            label="Input label"
+            inputProps={{
+              onChange: () => {},
+              placeholder: 'Input placeholder'
+            }}
+          />
+
+          <LabeledInput
+            label="Input label"
+            inputProps={{
+              onChange: () => {},
+              placeholder: 'Input placeholder',
+              multiline: true,
+              height: 256
+            }}
+          />
         </div>
       </div>
     </div>

--- a/new-dti-website-redesign/src/app/test/page.tsx
+++ b/new-dti-website-redesign/src/app/test/page.tsx
@@ -97,6 +97,14 @@ export default function TestPage() {
             height={256}
             className="w-128"
           />
+
+          <Input
+            placeholder="Input placeholder"
+            onChange={() => {}}
+            multiline
+            height={256}
+            className="w-128"
+          />
         </div>
 
         <div className="flex gap-8">

--- a/new-dti-website-redesign/src/app/test/page.tsx
+++ b/new-dti-website-redesign/src/app/test/page.tsx
@@ -97,14 +97,6 @@ export default function TestPage() {
             height={256}
             className="w-128"
           />
-
-          <Input
-            placeholder="Input placeholder"
-            onChange={() => {}}
-            multiline
-            height={256}
-            className="w-128"
-          />
         </div>
 
         <div className="flex gap-8">

--- a/new-dti-website-redesign/src/app/test/page.tsx
+++ b/new-dti-website-redesign/src/app/test/page.tsx
@@ -1,16 +1,12 @@
 'use client';
-
 import Link from 'next/link';
 import { Plus } from 'lucide-react';
 import Button from '../components/Button';
 import IconButton from '../components/IconButton';
-import LabeledInput from '../components/LabeledInput';
-import { useState } from 'react';
 import Input from '../components/Input';
+import LabeledInput from '../components/LabeledInput';
 
 export default function TestPage() {
-  const [email, setEmail] = useState('');
-
   return (
     <div className="p-32 flex flex-col gap-16">
       <Link href="/" className="text-accent-red underline">

--- a/new-dti-website-redesign/src/app/test/page.tsx
+++ b/new-dti-website-redesign/src/app/test/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import Link from 'next/link';
 import { Plus } from 'lucide-react';
 import Button from '../components/Button';

--- a/new-dti-website-redesign/src/app/test/page.tsx
+++ b/new-dti-website-redesign/src/app/test/page.tsx
@@ -116,6 +116,28 @@ export default function TestPage() {
             }}
           />
         </div>
+
+        <div className="flex gap-4">
+          <LabeledInput
+            label="Input label"
+            inputProps={{
+              onChange: () => {},
+              placeholder: 'Input placeholder'
+            }}
+            error="Input error message"
+          />
+
+          <LabeledInput
+            label="Input label"
+            inputProps={{
+              onChange: () => {},
+              placeholder: 'Input placeholder',
+              multiline: true,
+              height: 256
+            }}
+            error="Input error message"
+          />
+        </div>
       </div>
     </div>
   );

--- a/new-dti-website-redesign/src/app/test/page.tsx
+++ b/new-dti-website-redesign/src/app/test/page.tsx
@@ -91,14 +91,21 @@ export default function TestPage() {
 
       <div className="flex flex-col gap-6">
         <h4>Inputs</h4>
-        <div className="flex gap-4">
-          <Input placeholder="Input placeholder" onChange={() => {}} />
+        <div className="flex gap-8">
+          <Input placeholder="Input placeholder" onChange={() => {}} className="w-128" />
 
-          <Input placeholder="Input placeholder" onChange={() => {}} multiline height={256} />
+          <Input
+            placeholder="Input placeholder"
+            onChange={() => {}}
+            multiline
+            height={256}
+            className="w-128"
+          />
         </div>
 
-        <div className="flex gap-4">
+        <div className="flex gap-8">
           <LabeledInput
+            className="w-128"
             label="Input label"
             inputProps={{
               onChange: () => {},
@@ -107,6 +114,7 @@ export default function TestPage() {
           />
 
           <LabeledInput
+            className="w-128"
             label="Input label"
             inputProps={{
               onChange: () => {},
@@ -117,8 +125,9 @@ export default function TestPage() {
           />
         </div>
 
-        <div className="flex gap-4">
+        <div className="flex gap-8">
           <LabeledInput
+            className="w-128"
             label="Input label"
             inputProps={{
               onChange: () => {},
@@ -128,6 +137,7 @@ export default function TestPage() {
           />
 
           <LabeledInput
+            className="w-128"
             label="Input label"
             inputProps={{
               onChange: () => {},


### PR DESCRIPTION
# What changed

- Created new `<Input>` and `<LabeledInput>` components
- `<Input>` supports both `<input>` and `<textarea>` 
- Supports basic accessibility attributes like `id`, `aria-describedby`, and `aria-invalid`
- `<LabeledInput>` adds a `label` and optional `error` prop
- Added these components and all their variants in the `/test` page

|State|Pic|
|-|-|
|Default|<img width="1048" alt="Screenshot 2025-04-15 at 10 02 18 PM" src="https://github.com/user-attachments/assets/79b9e797-8932-47d5-b8cc-a937fbb61134" />|
|Hover|<img width="1048" alt="Screenshot 2025-04-15 at 10 02 25 PM" src="https://github.com/user-attachments/assets/1df25e2b-e0a9-4197-983c-1109455de958" />|
|Focus|<img width="1048" alt="Screenshot 2025-04-15 at 10 02 28 PM" src="https://github.com/user-attachments/assets/c7c444ec-0e87-4c53-9adb-6557bad1be3d" />|


# Test plan

- Go to the `/test` page
- Scroll to Inputs section
- Interact with each input/textarea and make sure they look and function as intended 
