### PR TITLE
[New Website] Created `<CtaSection>` component + added to `/test-page`

### DIFF
--- a/new-dti-website-redesign/src/app/components/CtaSection.tsx
+++ b/new-dti-website-redesign/src/app/components/CtaSection.tsx
@@ -17,38 +17,31 @@ const CtaSection = ({
   button1Link,
   button2Label,
   button2Link
-}: Props): ReactNode => {
-  return (
-    <section className="flex flex-col-reverse md:flex-col">
-      <div className="flex flex-col outline-[0.5px] outline-accent-green  p-4 sm:px-8 sm:py-16">
-        <div className="flex flex-col m-auto  items-center gap-4 max-w-120">
-          <div className="flex flex-col items-center gap-2">
-            <h2 className="text-center">{heading}</h2>
-            <h6 className="text-center text-foreground-3">{subheading}</h6>
-          </div>
+}: Props): ReactNode => (
+  <section className="flex flex-col-reverse md:flex-col">
+    <div className="flex flex-col outline-[0.5px] outline-accent-green  p-4 sm:px-8 sm:py-16">
+      <div className="flex flex-col m-auto  items-center gap-4 max-w-120">
+        <div className="flex flex-col items-center gap-2">
+          <h2 className="text-center">{heading}</h2>
+          <h6 className="text-center text-foreground-3">{subheading}</h6>
+        </div>
 
-          <div className="flex gap-4">
-            {button1Label && button1Link && (
-              <Button
-                variant="primary"
-                label={button1Label}
-                href={button1Link}
-                className="w-full"
-              />
-            )}
-            {button2Label && button2Link && (
-              <Button
-                variant="secondary"
-                label={button2Label}
-                href={button2Link}
-                className="w-full"
-              />
-            )}
-          </div>
+        <div className="flex gap-4">
+          {button1Label && button1Link && (
+            <Button variant="primary" label={button1Label} href={button1Link} className="w-full" />
+          )}
+          {button2Label && button2Link && (
+            <Button
+              variant="secondary"
+              label={button2Label}
+              href={button2Link}
+              className="w-full"
+            />
+          )}
         </div>
       </div>
-    </section>
-  );
-};
+    </div>
+  </section>
+);
 
 export default CtaSection;

--- a/new-dti-website-redesign/src/app/components/CtaSection.tsx
+++ b/new-dti-website-redesign/src/app/components/CtaSection.tsx
@@ -1,0 +1,54 @@
+import React, { ReactNode } from 'react';
+import Button from './Button';
+
+type Props = {
+  heading: ReactNode;
+  subheading: ReactNode;
+  button1Label?: string;
+  button1Link?: string;
+  button2Label?: string;
+  button2Link?: string;
+};
+
+const CtaSection = ({
+  heading,
+  subheading,
+  button1Label,
+  button1Link,
+  button2Label,
+  button2Link
+}: Props): ReactNode => {
+  return (
+    <section className="flex flex-col-reverse md:flex-col">
+      <div className="flex flex-col outline-[0.5px] outline-accent-green  p-4 sm:px-8 sm:py-16">
+        <div className="flex flex-col m-auto  items-center gap-4 max-w-120">
+          <div className="flex flex-col items-center gap-2">
+            <h2 className="text-center">{heading}</h2>
+            <h6 className="text-center text-foreground-3">{subheading}</h6>
+          </div>
+
+          <div className="flex gap-4">
+            {button1Label && button1Link && (
+              <Button
+                variant="primary"
+                label={button1Label}
+                href={button1Link}
+                className="w-full"
+              />
+            )}
+            {button2Label && button2Link && (
+              <Button
+                variant="secondary"
+                label={button2Label}
+                href={button2Link}
+                className="w-full"
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CtaSection;

--- a/new-dti-website-redesign/src/app/test-page/page.tsx
+++ b/new-dti-website-redesign/src/app/test-page/page.tsx
@@ -83,6 +83,8 @@ export default function TestPage() {
         button2Link="/team"
       />
 
+      <CtaSection heading="Ready to join?" subheading="Be part of something greater today." />
+
       <section className="h-128" />
     </Layout>
   );

--- a/new-dti-website-redesign/src/app/test-page/page.tsx
+++ b/new-dti-website-redesign/src/app/test-page/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import CtaSection from '../components/CtaSection';
 import Hero from '../components/Hero';
 import Layout from '../components/Layout';
 
@@ -58,6 +59,30 @@ export default function TestPage() {
         image="/heroImages/team.png"
         imageAlt="DTI members in front of Gates Hall"
       />
+
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button1Label="Apply to DTI"
+        button1Link="/apply"
+        button2Label="Meet the team"
+        button2Link="/team"
+      />
+
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button1Label="Apply to DTI"
+        button1Link="/apply"
+      />
+
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button2Label="Meet the team"
+        button2Link="/team"
+      />
+
       <section className="h-128" />
     </Layout>
   );

--- a/new-dti-website-redesign/src/app/test-page/page.tsx
+++ b/new-dti-website-redesign/src/app/test-page/page.tsx
@@ -77,8 +77,19 @@ export default function TestPage() {
       />
 
       <CtaSection
-        heading="Ready to join?"
-        subheading="Be part of something greater today."
+        heading={
+          <>
+            <span className="block text-accent-red">Building the Future</span>
+            <span className="block">of Tech @ Cornell</span>
+          </>
+        }
+        subheading={
+          <>
+            <span>Be part of something </span>
+            <span className="text-accent-blue">greater</span>
+            <span> today</span>
+          </>
+        }
         button2Label="Meet the team"
         button2Link="/team"
       />


### PR DESCRIPTION
# Changes

- [Figma](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1336-16568&m=dev)
- Created `<CtaSection>` (modeled on `<Hero>`)
- Props for heading, subheading, and links/labels for 2 buttons
- Added it 4 variants (2 buttons, 1 primary button, 1 secondary button, no buttons (on `/test-page`)

# Picture

|Desktop|Mobile|
|-|-|
|<img width="1189" alt="Screenshot 2025-04-19 at 5 02 07 PM" src="https://github.com/user-attachments/assets/316edf10-e28c-49b2-bce2-981c7de88068" />|<img width="417" alt="Screenshot 2025-04-19 at 5 03 11 PM" src="https://github.com/user-attachments/assets/26983941-3723-439f-a5ec-1bf71897ee7e" />|

# Test plan
- Navigate to `/test-page` and ensure that all 4 variants look good as pictured
- Resize window to ensure that they are responsive

### FYI am aware the green lines look bad. This is fixed in [this PR](https://github.com/cornell-dti/idol/pull/922)