### PR TITLE
[New Website] Created section separator + grids component

### DIFF
--- a/new-dti-website-redesign/src/app/test-page/page.tsx
+++ b/new-dti-website-redesign/src/app/test-page/page.tsx
@@ -5,6 +5,7 @@ import Hero from '../../components/Hero';
 import Layout from '../../components/Layout';
 import CtaSection from '../../components/CtaSection';
 import FeatureSection from '../../components/FeatureSection';
+import SectionSep from '../../components/SectionSep';
 
 export default function TestPage() {
   return (
@@ -26,6 +27,8 @@ export default function TestPage() {
         centered
       />
 
+      <SectionSep grid />
+
       <Hero
         heading="Heading over here"
         subheading="We are a talented, diverse group of students from different colleges and countries striving to make a difference in the Cornell community."
@@ -37,6 +40,8 @@ export default function TestPage() {
         imageAlt="DTI members in front of Gates Hall"
       />
 
+      <SectionSep grid />
+
       <Hero
         heading="Heading over here"
         subheading="We are a talented, diverse group of students from different colleges and countries striving to make a difference in the Cornell community."
@@ -46,6 +51,8 @@ export default function TestPage() {
         imageAlt="DTI members in front of Gates Hall"
       />
 
+      <SectionSep />
+
       <Hero
         heading="Heading over here"
         subheading="We are a talented, diverse group of students from different colleges and countries striving to make a difference in the Cornell community."
@@ -54,6 +61,8 @@ export default function TestPage() {
         image="/heroImages/team.png"
         imageAlt="DTI members in front of Gates Hall"
       />
+
+      <SectionSep />
 
       <Hero
         heading="Heading over here"

--- a/new-dti-website-redesign/src/components/Hero.tsx
+++ b/new-dti-website-redesign/src/components/Hero.tsx
@@ -82,7 +82,7 @@ const Hero = ({
         </div>
 
         {(button1Label && button1Link) || (button2Label && button2Link) ? (
-          <div className="p-4 pt-0 sm:p-4 sm:pt-0 md:p-8 md:pt-8 flex md:flex-col gap-4 md:flex-[1] md:outline-[0.5px] md:outline-accent-green md:justify-center">
+          <div className="p-4 pt-0 sm:p-4 sm:pt-0 md:p-8 md:pt-8 flex md:flex-col gap-4 md:flex-[1] md:outline-[0.5px] md:outline-accent-green md:justify-center max-w-1/4">
             {button1Label && button1Link && (
               <Button
                 variant="primary"

--- a/new-dti-website-redesign/src/components/SectionSep.tsx
+++ b/new-dti-website-redesign/src/components/SectionSep.tsx
@@ -1,0 +1,24 @@
+type SectionSepProps = {
+  grid?: boolean;
+};
+
+export default function SectionSep({ grid = false }: SectionSepProps) {
+  if (!grid) {
+    return <div className="w-full h-16 md:h-32" />;
+  }
+
+  return (
+    <div className="w-full overflow-hidden">
+      <div className="flex justify-center">
+        {Array.from({ length: 16 }).map((_, i) => (
+          <div
+            key={i}
+            className="aspect-square outline-[0.5px] outline-solid outline-border-1 shrink-0
+                  w-[calc(100%/8)] 
+                  md:w-[calc(100%/16)]"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Changes

### Same as [this original PR](https://github.com/cornell-dti/idol/pull/924) but w/o merge conflicts


- Created `<SectionSep>` component which adds visual decoration/space between sections on a space ([Figma](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1322-2367&m=dev))
- Based on [Figma responsiveness guidelines](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1336-13320&m=dev)
- If `grid` prop is true, renders a decorational grid element that is responsive.
- Fixed a bug with the `<Hero>` section component where the right-most container with the buttons wasn't exactly `1/4` of the page width

# Video

https://github.com/user-attachments/assets/dde05fbe-406a-4687-803f-d0fb2617a96f


# Test plan
- go to `/test-page`
- zoom out a bit
- resize window 
- make sure the squares keep their aspect ratio (ie: they are always perfect squares)
- there should always be 16 squares per row
- on the `md` breakpoint (< `768px`, there should be 8 squares per row)

### FYI i'm aware the Hero section looks a bit broken on certain sizes, but I'll fix that in a subsequent PR. The reason is that I'm planning to revamp the responsiveness system (breakpoints etc.), and I can only do that once we've created a few test components to see how the page actually looks like with real elements.

### So to clarify, I'm aware of bugs like this, and will definitely address this bug along with other responsiveness issues in a separate PR asap! :)
<img width="718" alt="Screenshot 2025-04-19 at 10 08 21 PM" src="https://github.com/user-attachments/assets/de1cf5a7-e1b7-477d-829d-99bd8c6eb012" />
