### PR TITLE
Interview Scheduler Bug Bashing Fixes

### DIFF
--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -1,6 +1,7 @@
+import { LEAD_ROLES } from '../consts';
 import InterviewSchedulerDao from '../dao/InterviewSchedulerDao';
 import InterviewSlotDao from '../dao/InterviewSlotDao';
-import { NotFoundError, PermissionError } from '../utils/errors';
+import { BadRequestError, NotFoundError, PermissionError } from '../utils/errors';
 import PermissionsManager from '../utils/permissionsManager';
 import { getMember } from './memberAPI';
 
@@ -36,7 +37,7 @@ export const createInterviewScheduler = async (
   instance: InterviewScheduler,
   user: IdolMember
 ): Promise<string> => {
-  if (!(await PermissionsManager.isAdmin(user)))
+  if (!(await PermissionsManager.isLeadOrAdmin(user)))
     throw new PermissionError(
       'User does not have permission to create new Candidate Decider instances.'
     );
@@ -199,26 +200,25 @@ export const updateInterviewSlot = async (
     isApplicant
   );
 
-  if (
-    isApplicant &&
-    (!scheduler.isOpen ||
-      !scheduler.applicants.some((applicant) => applicant.email === email) || // Applicants should be an applicant of the scheduler instance
-      (slot.applicant && slot.applicant.email !== email) || // Applicants may not edit an occupied slot
-      (edits.applicant && edits.applicant.email !== email)) // Applicants may not sign up or cancel other applicants
-  )
-    throw new PermissionError('User does not have permission to edit this interview slot.');
+  const user = await getMember(email);
+  const isLeadOrAdmin = user !== undefined && PermissionsManager.isLeadOrAdmin(user);
+  const isLead = user !== undefined && LEAD_ROLES.includes(user.role);
+
+  if (!isLeadOrAdmin && !scheduler.isOpen)
+    throw new BadRequestError('This interview scheduler is closed.');
+
+  if (isApplicant && scheduler.applicants.every((applicant) => applicant.email !== email))
+    throw new PermissionError('User does not have permission to edit this interview scheduler.');
+
+  if ((!isLead && edits.lead) || (isApplicant && (edits.members)))
+    throw new PermissionError('User does not have permission to edit this interview slot.'); 
 
   const newSlot: InterviewSlot = {
     ...slot,
     ...edits
   };
 
-  const user = await getMember(email);
-
-  return interviewSlotDao.updateSlot(
-    newSlot,
-    user !== undefined && (await PermissionsManager.isLeadOrAdmin(user))
-  );
+  return interviewSlotDao.updateSlot(newSlot, isLead);
 };
 
 /**

--- a/backend/src/API/interviewSchedulerAPI.ts
+++ b/backend/src/API/interviewSchedulerAPI.ts
@@ -197,7 +197,7 @@ export const updateInterviewSlot = async (
   const scheduler = await getInterviewSchedulerInstance(
     edits.interviewSchedulerUuid,
     email,
-    isApplicant
+    false
   );
 
   const user = await getMember(email);

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -571,7 +571,7 @@ router.get('/interview-slots/applicant/:uuid', async (req, res) => {
   });
 });
 
-router.put('/interview-slot/applicant', async (req, res) => {
+router.put('/interview-slots/applicant', async (req, res) => {
   const userEmail = await getUserEmailFromRequest(req);
   res.status(200).send({
     success: await updateInterviewSlot(req.body, userEmail ?? '', true)


### PR DESCRIPTION
### Summary <!-- Required -->
Bug Fixes:
*  Reinforced permission checking for update interview slot endpoint. Members and applicants should not be able to override each other, and only one user may get an approval message when signing up for the same slot on the frontend.
   * Leads are able to bypass this checking. This means that although IDOL subteam members are able to edit the time slot to whomever they want, the checks will still be done. Direct database edits will need to be done to make these changes if not a lead.
*  Fixed an issue where the backend would request the redacted scheduler information. 
*  Fixed an issue where applicants cannot sign up because the returned scheduler from the endpoint redacts all applicants.

### Test Plan <!-- Required -->
Testing during worksesh!

### Notes <!-- Optional -->
Applicants should have much more robust permission checking, especially since this is open-source. This will be one of the only endpoints that allow non-IDOL members to interact with IDOL. It is imperative to make sure that outside users may not make unauthorized endpoint requests.
