### PR TITLE
[Cand decider] New `<ProgressBar>` component

### DIFF
--- a/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
@@ -33,7 +33,13 @@
 .searchBar {
   display: flex;
   gap: 8px;
-  margin-bottom: 1%;
+  align-items: center;
+}
+
+.searchBar > div {
+  flex: 1;
+  display: flex;
+  height: 48px;
 }
 
 .ofNum {
@@ -110,4 +116,14 @@
 
 .navigation {
   padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.commentEditor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
 }

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
@@ -36,6 +36,7 @@
   align-items: center;
 }
 
+/* Selects the wrapper <div> of the combobox element */
 .searchBar > div {
   flex: 1;
   display: flex;

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -32,7 +32,7 @@ type CommentEditorProps = {
 };
 
 const CommentEditor: React.FC<CommentEditorProps> = ({ currentComment, setCurrentComment }) => (
-  <div style={{ width: '100%' }}>
+  <div className={styles.commentEditor}>
     <h4>Comments</h4>
     <Input
       value={currentComment}

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -25,14 +25,6 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
   );
   return (
     <div className={styles.progressContainer}>
-      <h4>My Progress</h4>
-      <Progress
-        value={myRatings.length}
-        total={candidates.length}
-        size="tiny"
-        color="blue"
-      >{`${myRatings.length}/${candidates.length}`}</Progress>
-
       <ProgressBar value={myRatings.length} total={candidates.length} />
 
       {userInfo && LEAD_ROLES.includes(userInfo.role) ? (

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -4,6 +4,7 @@ import styles from './ProgressPanel.module.css';
 import { useSelf } from '../Common/FirestoreDataProvider';
 import RatingsDisplay from './RatingsDisplay';
 import { ratingToString } from './ratings-utils';
+import ProgressBar from '../Common/ProgressBar/ProgressBar';
 
 type ProgressPanelProps = {
   candidates: CandidateDeciderCandidate[];
@@ -31,6 +32,8 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
         size="tiny"
         color="blue"
       >{`${myRatings.length}/${candidates.length}`}</Progress>
+
+      <ProgressBar value={myRatings.length} total={candidates.length} />
 
       {userInfo && LEAD_ROLES.includes(userInfo.role) ? (
         <>

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -1,4 +1,3 @@
-import { Progress } from 'semantic-ui-react';
 import { LEAD_ROLES } from 'common-types/constants';
 import styles from './ProgressPanel.module.css';
 import { useSelf } from '../Common/FirestoreDataProvider';

--- a/frontend/src/components/Common/ProgressBar/ProgressBar.module.css
+++ b/frontend/src/components/Common/ProgressBar/ProgressBar.module.css
@@ -1,0 +1,39 @@
+.progressBarContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progressBarWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.progressBar {
+  height: 28px;
+  border: 1px solid var(--border-default);
+  width: 100%;
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+  border-right: none;
+}
+.progressBar::-webkit-progress-bar {
+  background: var(--bg-default);
+}
+.progressBar::-webkit-progress-value {
+  border-radius: 6px;
+  background: var(--fg-default);
+}
+
+.annotation {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  padding: 4px 12px;
+  background: var(--bg-default);
+  border: 1px solid var(--border-default);
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+  width: fit-content;
+  height: 28px;
+}

--- a/frontend/src/components/Common/ProgressBar/ProgressBar.module.css
+++ b/frontend/src/components/Common/ProgressBar/ProgressBar.module.css
@@ -17,12 +17,17 @@
   border-bottom-left-radius: 6px;
   border-right: none;
 }
+
 .progressBar::-webkit-progress-bar {
   background: var(--bg-default);
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
 }
+
 .progressBar::-webkit-progress-value {
   border-radius: 6px;
   background: var(--fg-default);
+  transition: 120ms ease-out;
 }
 
 .annotation {

--- a/frontend/src/components/Common/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/Common/ProgressBar/ProgressBar.tsx
@@ -6,25 +6,23 @@ type ProgressBarProps = {
   total: number;
 };
 
-const ProgressBar: React.FC<ProgressBarProps> = ({ value, total }) => {
-  return (
-    <div className={styles.progressBarContainer}>
-      <label htmlFor="progress">
-        <h4>My progress:</h4>
-      </label>
-      <div className={styles.progressBarWrapper}>
-        <progress id="progress" max={total} value={value} className={styles.progressBar}>
-          70%
-        </progress>
+const ProgressBar: React.FC<ProgressBarProps> = ({ value, total }) => (
+  <div className={styles.progressBarContainer}>
+    <label htmlFor="progress">
+      <h4>My progress:</h4>
+    </label>
+    <div className={styles.progressBarWrapper}>
+      <progress id="progress" max={total} value={value} className={styles.progressBar}>
+        70%
+      </progress>
 
-        <div className={styles.annotation}>
-          <p className="small">{value}</p>
-          <p className="small">/</p>
-          <p className="small">{total}</p>
-        </div>
+      <div className={styles.annotation}>
+        <p className="small">{value}</p>
+        <p className="small">/</p>
+        <p className="small">{total}</p>
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 export default ProgressBar;

--- a/frontend/src/components/Common/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/Common/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styles from './ProgressBar.module.css';
+
+type ProgressBarProps = {
+  value: number;
+  total: number;
+};
+
+const ProgressBar: React.FC<ProgressBarProps> = ({ value, total }) => {
+  return (
+    <div className={styles.progressBarContainer}>
+      <label htmlFor="progress">
+        <h4>My progress:</h4>
+      </label>
+      <div className={styles.progressBarWrapper}>
+        <progress id="progress" max={total} value={value} className={styles.progressBar}>
+          70%
+        </progress>
+
+        <div className={styles.annotation}>
+          <p className="small">{value}</p>
+          <p className="small">/</p>
+          <p className="small">{total}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -110,3 +110,9 @@ p.small {
 .ui.dimmer .ui.modalLoader.loader:after {
   border-color: #767676 transparent transparent;
 }
+
+/* Workaround to center the label in candidate switcher combobar
+* Ideally in the future, we use our own custom component */
+.ui.search.dropdown > .text {
+  padding-top: 4px;
+}


### PR DESCRIPTION
# Changes

- Made new `<ProgressBar>` component (started off based on [Figma](https://www.figma.com/design/qHNMOp6rrIFMv1wBXsVtYZ/SP25-IDOL-Candidate-Decider-Tool?node-id=122-938&t=NifeuHr64QogmsBV-11), but then I took a different approach to designing it)
- Also fixed the styling of the adjacent elements

# Pics


|Before|After|
|-|-|
|<img width="589" alt="Screenshot 2025-04-23 at 1 06 00 AM" src="https://github.com/user-attachments/assets/b5c8feef-d8ff-4cd5-8320-f5411fcd3289" />|<img width="589" alt="Screenshot 2025-04-23 at 1 05 40 AM" src="https://github.com/user-attachments/assets/73fd3c8e-71a9-476c-9b72-0c8412b36ca1" />|

# Test plan


- Head to cand decider
- Make sure all applicants are selected as "Undecided"
- For each candidate, change their status
- Make sure the bar changes width

https://github.com/user-attachments/assets/502a3cc6-9678-4cb0-9730-9658b85dc783


