### PR TITLE
[New website] Updates to `<Button>`, `<Tabs>` component, heading semantic fixes 

### DIFF
--- a/new-dti-website-redesign/src/app/test-components/page.tsx
+++ b/new-dti-website-redesign/src/app/test-components/page.tsx
@@ -263,7 +263,7 @@ export default function TestComponents() {
             {
               label: 'Tab 1',
               content: (
-                <div className="w-128 h-128 bg-accent-blue p-8">
+                <div className="w-128 h-128 bg-accent-blue p-8 focusState" tabIndex={0}>
                   <h3>Tab panel 1</h3>
 
                   <p>A lovely tab 1 with just an image</p>
@@ -289,7 +289,7 @@ export default function TestComponents() {
             {
               label: 'Tab 3',
               content: (
-                <div className="w-128 h-128 bg-accent-red p-8">
+                <div className="w-128 h-128 bg-accent-red p-8 focusState" tabIndex={0}>
                   <h3>Tab panel 3</h3>
                   <p className="small caps">helloooo</p>
                 </div>

--- a/new-dti-website-redesign/src/app/test-components/page.tsx
+++ b/new-dti-website-redesign/src/app/test-components/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 
 import Button from '../../components/Button';
 import IconButton from '../../components/IconButton';
@@ -8,6 +9,7 @@ import Input from '../../components/Input';
 import LabeledInput from '../../components/LabeledInput';
 import TestimonialCard from '../../components/TestimonialCard';
 import IconWrapper from '../../components/IconWrapper';
+import Tabs from '../../components/Tabs';
 
 export default function TestComponents() {
   return (
@@ -252,6 +254,49 @@ export default function TestComponents() {
             </svg>
           </IconWrapper>
         </div>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <h4>Tab</h4>
+        <Tabs
+          tabs={[
+            {
+              label: 'Tab 1',
+              content: (
+                <div className="w-128 h-128 bg-accent-blue p-8">
+                  <h3>Tab panel 1</h3>
+
+                  <p>A lovely tab 1 with just an image</p>
+
+                  <Image src="/clem.jpg" alt="Clément's pic" width={128} height={128} />
+                </div>
+              )
+            },
+            {
+              label: 'Tab 2',
+              content: (
+                <div className="w-128 h-128 bg-accent-yellow p-8">
+                  <h3>Tab panel 2</h3>
+
+                  <p>A lovely tab 2 with interactive elements</p>
+
+                  <Input placeholder="Input placeholder" onChange={() => {}} className="w-64" />
+
+                  <Button label="Hey hey" variant="secondary" />
+                </div>
+              )
+            },
+            {
+              label: 'Tab 3',
+              content: (
+                <div className="w-128 h-128 bg-accent-red p-8">
+                  <h3>Tab panel 3</h3>
+                  <p className="small caps">helloooo</p>
+                </div>
+              )
+            }
+          ]}
+        />
       </div>
     </div>
   );

--- a/new-dti-website-redesign/src/components/Button.tsx
+++ b/new-dti-website-redesign/src/components/Button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef } from 'react';
+import { forwardRef, Ref } from 'react';
 import Link from 'next/link';
 
 type ButtonProps = {
@@ -44,14 +44,20 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
 
     if (href) {
       return (
-        <Link href={href} className={sharedClasses} {...rest} ref={ref as any}>
+        <Link href={href} className={sharedClasses} {...rest} ref={ref as Ref<HTMLAnchorElement>}>
           {content}
         </Link>
       );
     }
 
     return (
-      <button onClick={onClick} className={sharedClasses} role={role} {...rest} ref={ref as any}>
+      <button
+        onClick={onClick}
+        className={sharedClasses}
+        role={role}
+        {...rest}
+        ref={ref as Ref<HTMLButtonElement>}
+      >
         {content}
       </button>
     );

--- a/new-dti-website-redesign/src/components/Button.tsx
+++ b/new-dti-website-redesign/src/components/Button.tsx
@@ -1,58 +1,62 @@
 'use client';
 
+import { forwardRef } from 'react';
 import Link from 'next/link';
 
 type ButtonProps = {
   label: string;
-  onClick?: () => void;
   href?: string;
-  className?: string;
   variant?: 'primary' | 'secondary' | 'tertiary';
   badge?: React.ReactNode;
-};
+  role?: string;
+} & React.ButtonHTMLAttributes<HTMLButtonElement> &
+  React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
-export default function Button({
-  label,
-  onClick,
-  href,
-  className = '',
-  variant = 'primary',
-  badge
-}: ButtonProps) {
-  const baseStyles = `
-    px-6 h-12 w-fit rounded-full cursor-pointer inline-flex items-center justify-center gap-2
-    transition-[background-color] duration-[120ms] focusState text-nowrap`;
+const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
+  (
+    { label, onClick, href, className = '', variant = 'primary', badge, role = 'button', ...rest },
+    ref
+  ) => {
+    const baseStyles = `
+      px-6 h-12 w-fit rounded-full cursor-pointer inline-flex items-center justify-center gap-2
+      transition-[background-color] duration-[120ms] focusState text-nowrap`;
 
-  const variantStyles = {
-    primary: `bg-foreground-1 text-background-1 hover:bg-foreground-2 ${badge ? 'gap-1 pr-3' : ''}`,
-    secondary: `bg-background-2 border border-border-1 text-foreground-1 hover:bg-background-3`,
-    tertiary: `bg-transparent border border-border-1 text-foreground-1 hover:bg-background-2`
-  }[variant];
+    const variantStyles = {
+      primary: `bg-foreground-1 text-background-1 hover:bg-foreground-2 ${
+        badge ? 'gap-1 pr-3' : ''
+      }`,
+      secondary: `bg-background-2 border border-border-1 text-foreground-1 hover:bg-background-3`,
+      tertiary: `bg-transparent border border-border-1 text-foreground-1 hover:bg-background-2`
+    }[variant];
 
-  const sharedClasses = `${baseStyles} ${variantStyles} ${className}`;
+    const sharedClasses = `${baseStyles} ${variantStyles} ${className}`;
 
-  const content = (
-    <>
-      <span className="text-rg font-medium">{label}</span>
-      {badge && (
-        <span className="p-2 bg-[#0000001a] text-background-1 rounded-full text-xs font-medium uppercase tracking-wider">
-          {badge}
-        </span>
-      )}
-    </>
-  );
+    const content = (
+      <>
+        <span className="text-rg font-medium">{label}</span>
+        {badge && (
+          <span className="p-2 bg-[#0000001a] text-background-1 rounded-full text-xs font-medium uppercase tracking-wider">
+            {badge}
+          </span>
+        )}
+      </>
+    );
 
-  if (href) {
+    if (href) {
+      return (
+        <Link href={href} className={sharedClasses} {...rest} ref={ref as any}>
+          {content}
+        </Link>
+      );
+    }
+
     return (
-      <Link href={href} className={sharedClasses}>
+      <button onClick={onClick} className={sharedClasses} role={role} {...rest} ref={ref as any}>
         {content}
-      </Link>
+      </button>
     );
   }
+);
 
-  return (
-    <button onClick={onClick} className={sharedClasses} type="button">
-      {content}
-    </button>
-  );
-}
+Button.displayName = 'Button';
+export default Button;

--- a/new-dti-website-redesign/src/components/CtaSection.tsx
+++ b/new-dti-website-redesign/src/components/CtaSection.tsx
@@ -23,7 +23,7 @@ const CtaSection = ({
       <div className="flex flex-col m-auto  items-center gap-4 max-w-120">
         <div className="flex flex-col items-center gap-2">
           <h2 className="text-center">{heading}</h2>
-          <h6 className="text-center text-foreground-3">{subheading}</h6>
+          <p className="h6 text-center text-foreground-3">{subheading}</p>
         </div>
 
         <div className="flex gap-4">

--- a/new-dti-website-redesign/src/components/Hero.tsx
+++ b/new-dti-website-redesign/src/components/Hero.tsx
@@ -33,7 +33,7 @@ const Hero = ({
           <div className="flex flex-col m-auto  items-center gap-4 max-w-120">
             <div className="flex flex-col items-center gap-2">
               <h1 className="text-center">{heading}</h1>
-              <h6 className="text-center text-foreground-3">{subheading}</h6>
+              <p className="h6 text-center text-foreground-3">{subheading}</p>
             </div>
 
             <div className="flex gap-4">
@@ -84,7 +84,7 @@ const Hero = ({
       <div className="flex-col md:flex-row flex">
         <div className="p-4 sm:p-4 md:p-8 flex flex-col gap-2 md:flex-[3] md:outline-[0.5px] md:outline-border-1">
           <h1>{heading}</h1>
-          <h6 className="text-foreground-3">{subheading}</h6>
+          <p className="h6 text-foreground-3">{subheading}</p>
         </div>
 
         {(button1Label && button1Link) || (button2Label && button2Link) ? (

--- a/new-dti-website-redesign/src/components/Tabs.tsx
+++ b/new-dti-website-redesign/src/components/Tabs.tsx
@@ -56,6 +56,23 @@ export default function Tabs({ tabs, className = '' }: TabsProps) {
         ))}
       </div>
 
+      {/* IMPORTANT: according to the W3C (official accessibility documentation, https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)
+       * When a tabpanel doesn't contain any focusable elements, the rendered should have tabindex="0" so that it's included in the tab sequence of the page. Make sure to also include focusState for the proper outline styling too!
+
+       Example implementation:
+        <Tabs
+          tabs={[
+            {
+              label: 'Tab 1',
+              content: (
+                <div className="focusState" tabIndex={0}>
+                  <p>No interactive content in this tab panel, so need tabIndex</p>
+                </div>
+              )
+            }
+          ]}
+        />
+       */}
       <div role="tabpanel" id={`panel-${activeIndex}`} aria-labelledby={`tab-${activeIndex}`}>
         {tabs[activeIndex]?.content}
       </div>

--- a/new-dti-website-redesign/src/components/Tabs.tsx
+++ b/new-dti-website-redesign/src/components/Tabs.tsx
@@ -24,7 +24,7 @@ export default function Tabs({ tabs, className = '' }: TabsProps) {
       e.preventDefault();
       // +1 for going to right, -1 for going to left
       const dir = e.key === 'ArrowRight' ? 1 : -1;
-      const nextIndex = (activeIndex + dir) % tabs.length;
+      const nextIndex = (activeIndex + dir + tabs.length) % tabs.length;
       setActiveIndex(nextIndex);
       tabsRef.current[nextIndex]?.focus(); // Moves focus to next tab
     }

--- a/new-dti-website-redesign/src/components/Tabs.tsx
+++ b/new-dti-website-redesign/src/components/Tabs.tsx
@@ -17,7 +17,7 @@ export default function Tabs({ tabs, className = '' }: TabsProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const tabsRef = useRef<(HTMLButtonElement | HTMLAnchorElement | null)[]>([]);
 
-  // You should be able to user the left/right arrow keys to navigate between tabs
+  // You should be able to use the left/right arrow keys to navigate between tabs
   // This piece of code handles keyboard navigation so that the tabs are accessible
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {

--- a/new-dti-website-redesign/src/components/Tabs.tsx
+++ b/new-dti-website-redesign/src/components/Tabs.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import Button from './Button';
+
+type Tab = {
+  label: string;
+  content: React.ReactNode;
+};
+
+type TabsProps = {
+  tabs: Tab[];
+  className?: string;
+};
+
+export default function Tabs({ tabs, className = '' }: TabsProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const tabsRef = useRef<(HTMLButtonElement | HTMLAnchorElement | null)[]>([]);
+
+  // You should be able to user the left/right arrow keys to navigate between tabs
+  // This piece of code handles keyboard navigation so that the tabs are accessible
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      // +1 for going to right, -1 for going to left
+      const dir = e.key === 'ArrowRight' ? 1 : -1;
+      const nextIndex = (activeIndex + dir + tabs.length) % tabs.length;
+      setActiveIndex(nextIndex);
+      tabsRef.current[nextIndex]?.focus(); // Moves focus to next tab
+    }
+  };
+
+  return (
+    <div className={`flex flex-col gap-8 ${className}`}>
+      <div
+        className="flex flex-wrap gap-4"
+        role="tablist"
+        aria-label="Tabbed content"
+        onKeyDown={handleKeyDown}
+      >
+        {tabs.map((tab, index) => (
+          <Button
+            key={tab.label}
+            ref={(el) => {
+              tabsRef.current[index] = el;
+            }}
+            label={tab.label}
+            onClick={() => setActiveIndex(index)}
+            variant={activeIndex === index ? 'primary' : 'tertiary'}
+            role="tab"
+            aria-selected={activeIndex === index}
+            aria-controls={`panel-${index}`}
+            id={`tab-${index}`}
+            tabIndex={activeIndex === index ? 0 : -1}
+          />
+        ))}
+      </div>
+
+      <div role="tabpanel" id={`panel-${activeIndex}`} aria-labelledby={`tab-${activeIndex}`}>
+        {tabs[activeIndex]?.content}
+      </div>
+    </div>
+  );
+}

--- a/new-dti-website-redesign/src/components/Tabs.tsx
+++ b/new-dti-website-redesign/src/components/Tabs.tsx
@@ -57,7 +57,7 @@ export default function Tabs({ tabs, className = '' }: TabsProps) {
       </div>
 
       {/* IMPORTANT: according to the W3C (official accessibility documentation, https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)
-       * When a tabpanel doesn't contain any focusable elements, the rendered should have tabindex="0" so that it's included in the tab sequence of the page. Make sure to also include focusState for the proper outline styling too!
+       * When a tabpanel doesn't contain any focusable elements, the rendered panel should have tabindex="0" so that it's included in the tab sequence of the page. Make sure to also include focusState for the proper outline styling too!
 
        Example implementation:
         <Tabs

--- a/new-dti-website-redesign/src/components/Tabs.tsx
+++ b/new-dti-website-redesign/src/components/Tabs.tsx
@@ -24,7 +24,7 @@ export default function Tabs({ tabs, className = '' }: TabsProps) {
       e.preventDefault();
       // +1 for going to right, -1 for going to left
       const dir = e.key === 'ArrowRight' ? 1 : -1;
-      const nextIndex = (activeIndex + dir + tabs.length) % tabs.length;
+      const nextIndex = (activeIndex + dir) % tabs.length;
       setActiveIndex(nextIndex);
       tabsRef.current[nextIndex]?.focus(); // Moves focus to next tab
     }


### PR DESCRIPTION
# Changes

- Made changes to `<Button>`:
  - Refactored into `forwardRef` to support native props better
  - Added `role` so that we can differentiate `role="tab"` and the regular `role="button"`
- `<Hero>` and `<CtaSection>` components: made the subheadings more semantic by using `<p>` instead of `<h6>`
- Created `<Tabs>` component that uses `<Button>`
  - `label` (str) and `content` (`React.ReactNode`) for the tab label and for the actual children of the tab panel
  - Added some logic to support proper keyboard navigation between tabs for accessibility
  - Used instances of `<Tabs>` on the `/test-components` page



# Video

https://github.com/user-attachments/assets/07dc0386-8d21-476d-8187-7a8a6e2c1ec7

# Test plan

- Head to `/test-components`
- Click the tabs and make sure they change the panel
- Use `tab` on your keyboard, and the left/right arrows to switch between tabs
- For tab panel 1 and tab panel 2, hitting `tab` should focus the panel itself. For tab panel 2, `tab` should focus the `<Input>`



