### PR TITLE
add dontenv to shoutout leaderboard script

### DIFF
--- a/backend/scripts/shoutout-leaderboard.ts
+++ b/backend/scripts/shoutout-leaderboard.ts
@@ -4,6 +4,8 @@ import { configureAccount } from '../src/utils/firebase-utils';
 import { DBShoutout } from '../src/types/DataTypes';
 import { getMemberFromDocumentReference } from '../src/utils/memberUtil';
 
+require('dotenv').config();
+
 const serviceAcc = require('../resources/idol-b6c68-firebase-adminsdk-h4e6t-40e4bd5536.json');
 
 admin.initializeApp({
@@ -13,7 +15,7 @@ admin.initializeApp({
 });
 
 const db = admin.firestore();
-const QUERY_DATE = '2023-08-01';
+const QUERY_DATE = '2025-01-01';
 
 const main = async () => {
   console.log(`Collecting all shoutouts from ${QUERY_DATE} until now...`);


### PR DESCRIPTION
### Summary <!-- Required -->
Shoutout leaderboard script wasn't able to access firebase because it could not read `.env`.

### Test Plan <!-- Required -->
Ran and it now works!
```
Collecting all shoutouts from 2025-04-01 until now...
[
  [ 'Andrew Qian (ajq22)', 31 ],
  [ 'Clément Rozé (cpr58)', 17 ],
  [ 'Olina Zheng (oz36)', 14 ],
  ...
]
```
