### PR TITLE
Add Instances to Interview Status Dashboard

### DIFF
--- a/backend/src/API/candidateDeciderAPI.ts
+++ b/backend/src/API/candidateDeciderAPI.ts
@@ -37,7 +37,7 @@ export const getAllCandidateDeciderInstances = async (
 
 /**
  * Returns whether a CandidateDecier instance is assigned to the user
- * This method checks if a CandidateDecier instance is assigned to the user
+ * This method checks if a CandidateDecider instance is assigned to the user
  * @returns {Promise<boolean>} A promise that resolves with a boolean indicating whether the user has access to the instance
  */
 export const hasCandidateDeciderInstance = async (user: IdolMember): Promise<boolean> => {

--- a/backend/src/API/interviewStatusAPI.ts
+++ b/backend/src/API/interviewStatusAPI.ts
@@ -99,3 +99,15 @@ export const deleteInterviewStatus = async (uuid: string, user: IdolMember): Pro
   }
   await interviewStatusDao.deleteInterviewStatus(uuid);
 };
+
+/**
+ * Delete an entire instance
+ */
+export const deleteInterviewStatusInstance = async (
+  instanceName: string,
+  user: IdolMember
+): Promise<void> => {
+  if (!PermissionsManager.isLeadOrAdmin(user))
+    throw new PermissionError('User does not have permission to delete an interview status.');
+  await InterviewStatusDao.deleteByInstance(instanceName);
+};

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -114,7 +114,8 @@ import {
   getInterviewStatus,
   createInterviewStatus,
   updateInterviewStatus,
-  deleteInterviewStatus
+  deleteInterviewStatus,
+  deleteInterviewStatusInstance
 } from './API/interviewStatusAPI';
 
 import { HandlerError } from './utils/errors';
@@ -626,6 +627,10 @@ loginCheckedPut('/interview-status', async (req, user) => ({
 
 loginCheckedDelete('/interview-status/:uuid', async (req, user) =>
   deleteInterviewStatus(req.params.uuid, user).then(() => ({}))
+);
+
+loginCheckedDelete('/interview-status/instance/:instanceName', async (req, user) =>
+  deleteInterviewStatusInstance(req.params.instanceName, user).then(() => ({}))
 );
 
 app.use('/.netlify/functions/api', router);

--- a/backend/src/dao/InterviewStatusDao.ts
+++ b/backend/src/dao/InterviewStatusDao.ts
@@ -78,4 +78,14 @@ export default class InterviewStatusDao extends BaseDao<InterviewStatus, Intervi
   async getAllInterviewStatuses(): Promise<InterviewStatus[]> {
     return this.getDocuments();
   }
+
+  /**
+   * Deletes all Interview Statuses of an instance
+   */
+  static async deleteByInstance(instanceName: string): Promise<void> {
+    const toDelete = await interviewStatusCollection.where('instance', '==', instanceName).get();
+    const batch = db.batch();
+    toDelete.forEach((doc) => batch.delete(doc.ref));
+    await batch.commit();
+  }
 }

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -322,7 +322,13 @@ interface InterviewSlotEdit {
   applicant?: Applicant | null;
 }
 
+interface StatusInstance {
+  instanceName: string;
+  statuses: InterviewStatus[];
+}
+
 interface InterviewStatus {
+  instance: string;
   name: string;
   netid: string;
   role: GeneralRole;

--- a/frontend/src/API/InterviewStatusAPI.ts
+++ b/frontend/src/API/InterviewStatusAPI.ts
@@ -76,6 +76,14 @@ export class InterviewStatusAPI {
   }
 
   /**
+   * Delete an interview status instance by its instanceName.
+   * @param instanceName - name of the instance to delete
+   */
+  public static async deleteInterviewStatusInstance(instanceName: string): Promise<void> {
+    await APIWrapper.delete(`${backendURL}/interview-status/instance/${instanceName}`);
+  }
+
+  /**
    * Clears all interview statuses.
    */
   public static async clearAllInterviewStatuses(): Promise<void> {

--- a/frontend/src/components/Admin/InterviewStatus/AddInterviewStatusForm.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/AddInterviewStatusForm.tsx
@@ -14,9 +14,10 @@ const displayToRoleMap: Record<string, GeneralRole> = {
 
 interface AddInterviewStatusFormProps {
   onAddApplicant: (applicant: InterviewStatus) => void;
+  instanceName: string;
 }
 
-const AddInterviewStatusForm: React.FC<AddInterviewStatusFormProps> = ({ onAddApplicant }) => {
+const AddInterviewStatusForm: React.FC<AddInterviewStatusFormProps> = ({ onAddApplicant, instanceName }) => {
   const [name, setName] = useState('');
   const [netid, setNetid] = useState('');
   const [round, setRound] = useState<Round | ''>('');
@@ -36,6 +37,7 @@ const AddInterviewStatusForm: React.FC<AddInterviewStatusFormProps> = ({ onAddAp
 
     setIsSubmitting(true);
     const createdApplicant = await InterviewStatusAPI.createInterviewStatus({
+      instance: instanceName,
       name,
       netid,
       round: round as Round,

--- a/frontend/src/components/Admin/InterviewStatus/AddInterviewStatusForm.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/AddInterviewStatusForm.tsx
@@ -17,7 +17,10 @@ interface AddInterviewStatusFormProps {
   instanceName: string;
 }
 
-const AddInterviewStatusForm: React.FC<AddInterviewStatusFormProps> = ({ onAddApplicant, instanceName }) => {
+const AddInterviewStatusForm: React.FC<AddInterviewStatusFormProps> = ({
+  onAddApplicant,
+  instanceName
+}) => {
   const [name, setName] = useState('');
   const [netid, setNetid] = useState('');
   const [round, setRound] = useState<Round | ''>('');

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.module.css
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.module.css
@@ -14,7 +14,9 @@
   cursor: pointer;
   border-radius: 0.5rem !important;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
-  transition: transform 0.2s ease, box-shadow 0.2s ease !important;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease !important;
 }
 
 .card:hover {

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.module.css
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.module.css
@@ -1,0 +1,30 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.loading {
+  text-align: center;
+  font-size: 1.5rem;
+  color: #555;
+}
+
+.card {
+  cursor: pointer;
+  border-radius: 0.5rem !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
+  transition: transform 0.2s ease, box-shadow 0.2s ease !important;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15) !important;
+}
+
+.newInstanceCard {
+  border: 2px dashed #ccc !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.module.css
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.module.css
@@ -4,24 +4,24 @@
   padding: 2rem;
 }
 
+.buttonRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.selectedView {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+}
+
 .loading {
   text-align: center;
   font-size: 1.5rem;
-  color: #555;
-}
-
-.card {
-  cursor: pointer;
-  border-radius: 0.5rem !important;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease !important;
-}
-
-.card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15) !important;
+  color: var(--fg-dimmest);
 }
 
 .newInstanceCard {
@@ -29,4 +29,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.card:hover {
+  transform: translateY(-3px);
+}
+
+.card {
+  cursor: pointer;
 }

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.module.css
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.module.css
@@ -6,14 +6,12 @@
 
 .buttonRow {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  width: 100%;
   margin-bottom: 1rem;
 }
 
 .selectedView {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem;
   display: flex;
   flex-direction: column;
 }

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -31,6 +31,17 @@ const InterviewStatusBase: React.FC = () => {
       .finally(() => setIsLoading(false));
   }, [selected]);
 
+  const handleDeleteInstance = async (instanceName: string) => {
+    if (!window.confirm(`Really delete instance “${instanceName}” and all its statuses?`)) {
+      return;
+    }
+    setIsLoading(true);
+    await InterviewStatusAPI.deleteInterviewStatusInstance(instanceName);
+    setGroups((prev) => prev.filter((g) => g.instanceName !== instanceName));
+    setSelected(null);
+    setIsLoading(false);
+  };
+
   const handleNewEmptyInstance = async () => {
     const raw = window.prompt('Enter a name for your new instance:');
     const name = raw?.trim();
@@ -61,6 +72,11 @@ const InterviewStatusBase: React.FC = () => {
       <div className={styles.selectedView}>
         <div className={styles.buttonRow}>
           <Button label="Back to Instances" onClick={() => setSelected(null)} />
+          <Button
+            label="Delete Instance"
+            onClick={() => handleDeleteInstance(selected.instanceName)}
+            variant="negative"
+          />
         </div>
         <InterviewStatusDashboard
           instanceName={selected.instanceName}

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import { Button, Card } from 'semantic-ui-react';
+import { Card } from 'semantic-ui-react';
 import Link from 'next/link';
 import { InterviewStatusAPI } from '../../../API/InterviewStatusAPI';
 import InterviewStatusDashboard from './InterviewStatusDashboard';
 import styles from './InterviewStatusBase.module.css';
 import { Emitters } from '../../../utils';
+import Button from '../../Common/Button/Button';
 
 const InterviewStatusBase: React.FC = () => {
   const [groups, setGroups] = useState<StatusInstance[]>([]);
@@ -48,15 +49,20 @@ const InterviewStatusBase: React.FC = () => {
   };
 
   if (isLoading) {
-    return <div className={styles.loading}>Loading...</div>;
+    return <div className={styles.loading}>
+      <p>Loading...</p>
+    </div>;
   }
 
   if (selected) {
     return (
-      <div>
-        <Button onClick={() => setSelected(null)} basic>
-          Back to Instances
-        </Button>
+      <div className={styles.selectedView}>
+        <div className={styles.buttonRow}>
+          <Button
+            label="Back to Instances"
+            onClick={() => setSelected(null)}
+          />
+        </div>
         <InterviewStatusDashboard
           instanceName={selected.instanceName}
           statuses={selected.statuses}
@@ -80,6 +86,8 @@ const InterviewStatusBase: React.FC = () => {
               onClick={() => setSelected(group)}
               key={group.instanceName}
               className={styles.card}
+              as="button"
+              type="button"
             >
               <Card.Content>
                 <Card.Header>{group.instanceName}</Card.Header>
@@ -89,6 +97,8 @@ const InterviewStatusBase: React.FC = () => {
           <Card
             onClick={handleNewEmptyInstance}
             className={`${styles.card} ${styles.newInstanceCard}`}
+            as="button"
+            type="button"
           >
             <Card.Content>
               <Card.Header>{'+ New Empty Instance'}</Card.Header>

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -22,10 +22,11 @@ const InterviewStatusBase: React.FC = () => {
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([instanceName, statuses]) => ({
             instanceName,
-            statuses,
+            statuses
           }));
         setGroups(grouped);
-      }).finally(() => setIsLoading(false));
+      })
+      .finally(() => setIsLoading(false));
   }, []);
 
   if (isLoading) {

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -70,18 +70,20 @@ const InterviewStatusBase: React.FC = () => {
   if (selected) {
     return (
       <div className={styles.selectedView}>
-        <div className={styles.buttonRow}>
-          <Button label="Back to Instances" onClick={() => setSelected(null)} />
-          <Button
-            label="Delete Instance"
-            onClick={() => handleDeleteInstance(selected.instanceName)}
-            variant="negative"
+        <div className={styles.container}>
+          <div className={styles.buttonRow}>
+            <Button label="Back to Instances" onClick={() => setSelected(null)} />
+            <Button
+              label="Delete Instance"
+              onClick={() => handleDeleteInstance(selected.instanceName)}
+              variant="negative"
+            />
+          </div>
+          <InterviewStatusDashboard
+            instanceName={selected.instanceName}
+            statuses={selected.statuses}
           />
         </div>
-        <InterviewStatusDashboard
-          instanceName={selected.instanceName}
-          statuses={selected.statuses}
-        />
       </div>
     );
   }

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { InterviewStatusAPI } from '../../../API/InterviewStatusAPI';
 import InterviewStatusDashboard from './InterviewStatusDashboard';
 import styles from './InterviewStatusBase.module.css';
+import { Emitters } from '../../../utils';
 
 const InterviewStatusBase: React.FC = () => {
   const [groups, setGroups] = useState<StatusInstance[]>([]);
@@ -30,8 +31,16 @@ const InterviewStatusBase: React.FC = () => {
   }, [selected]);
 
   const handleNewEmptyInstance = async () => {
-    const name = window.prompt('Enter a name for your new instance:');
-    if (!name?.trim()) return;
+    const raw = window.prompt('Enter a name for your new instance:');
+    const name = raw?.trim();
+    if (!name) return;
+    if (groups.some((g) => g.instanceName === name)) {
+      Emitters.generalError.emit({
+        headerMsg: `${name} Instance Already Exists`,
+        contentMsg: `Please choose a different name to proceed.`
+      });
+      return;
+    }
     setIsLoading(true);
     const emptyInstance: StatusInstance = { instanceName: name, statuses: [] };
     setSelected(emptyInstance);

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -1,0 +1,72 @@
+// InterviewStatusBase.tsx
+import { useState, useEffect } from 'react';
+import { Button, Card } from 'semantic-ui-react';
+import Link from 'next/link';
+import { InterviewStatusAPI } from '../../../API/InterviewStatusAPI';
+import InterviewStatusDashboard from './InterviewStatusDashboard';
+
+const InterviewStatusBase: React.FC = () => {
+  const [groups, setGroups] = useState<StatusInstance[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selected, setSelected] = useState<StatusInstance | null>(null);
+
+  useEffect(() => {
+    InterviewStatusAPI.getAllInterviewStatuses()
+      .then((all: InterviewStatus[]) => {
+        const map = all.reduce<Record<string, InterviewStatus[]>>((acc, st) => {
+          (acc[st.instance] ||= []).push(st);
+          return acc;
+        }, {});
+
+        const grouped: StatusInstance[] = Object.entries(map)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([instanceName, statuses]) => ({
+            instanceName,
+            statuses,
+          }));
+        setGroups(grouped);
+      }).finally(() => setIsLoading(false));
+  }, []);
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (selected) {
+    return (
+      <div>
+        <Button onClick={() => setSelected(null)} basic>
+          Back to Instances
+        </Button>
+        <InterviewStatusDashboard
+          instanceName={selected.instanceName}
+          statuses={selected.statuses}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {!groups || groups.length === 0 ? (
+        <h1>
+          You currently do not have access to any interview status instances! Please contact{' '}
+          <Link href="https://cornelldti.slack.com/channels/idol-support">#idol-support</Link> if
+          you think this is a mistake.
+        </h1>
+      ) : (
+        <Card.Group>
+          {groups.map((group) => (
+            <Card onClick={() => setSelected(group)} key={group.instanceName}>
+              <Card.Content>
+                <Card.Header>{group.instanceName}</Card.Header>
+              </Card.Content>
+            </Card>
+          ))}
+        </Card.Group>
+      )}
+    </div>
+  );
+};
+
+export default InterviewStatusBase;

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -1,9 +1,9 @@
-// InterviewStatusBase.tsx
 import { useState, useEffect } from 'react';
 import { Button, Card } from 'semantic-ui-react';
 import Link from 'next/link';
 import { InterviewStatusAPI } from '../../../API/InterviewStatusAPI';
 import InterviewStatusDashboard from './InterviewStatusDashboard';
+import styles from './InterviewStatusBase.module.css';
 
 const InterviewStatusBase: React.FC = () => {
   const [groups, setGroups] = useState<StatusInstance[]>([]);
@@ -29,14 +29,24 @@ const InterviewStatusBase: React.FC = () => {
       .finally(() => setIsLoading(false));
   }, []);
 
+  const handleNewEmptyInstance = async () => {
+    const name = window.prompt('Enter a name for your new instance:');
+    if (!name?.trim()) return;
+    setIsLoading(true);
+    const emptyInstance: StatusInstance = { instanceName: name, statuses: [] };
+    setSelected(emptyInstance);
+    setIsLoading(false);
+  }
+
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <div className={styles.loading}>Loading...</div>;
   }
 
   if (selected) {
     return (
       <div>
-        <Button onClick={() => setSelected(null)} basic>
+        <Button
+          onClick={() => setSelected(null)} basic>
           Back to Instances
         </Button>
         <InterviewStatusDashboard
@@ -48,7 +58,7 @@ const InterviewStatusBase: React.FC = () => {
   }
 
   return (
-    <div>
+    <div className={styles.container}>
       {!groups || groups.length === 0 ? (
         <h1>
           You currently do not have access to any interview status instances! Please contact{' '}
@@ -58,12 +68,19 @@ const InterviewStatusBase: React.FC = () => {
       ) : (
         <Card.Group>
           {groups.map((group) => (
-            <Card onClick={() => setSelected(group)} key={group.instanceName}>
+            <Card onClick={() => setSelected(group)} key={group.instanceName}
+              className={styles.card}>
               <Card.Content>
                 <Card.Header>{group.instanceName}</Card.Header>
               </Card.Content>
             </Card>
           ))}
+          <Card onClick={handleNewEmptyInstance}
+            className={`${styles.card} ${styles.newInstanceCard}`}>
+            <Card.Content>
+              <Card.Header>{'+ New Empty Instance'}</Card.Header>
+            </Card.Content>
+          </Card>
         </Card.Group>
       )}
     </div>

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -49,19 +49,18 @@ const InterviewStatusBase: React.FC = () => {
   };
 
   if (isLoading) {
-    return <div className={styles.loading}>
-      <p>Loading...</p>
-    </div>;
+    return (
+      <div className={styles.loading}>
+        <p>Loading...</p>
+      </div>
+    );
   }
 
   if (selected) {
     return (
       <div className={styles.selectedView}>
         <div className={styles.buttonRow}>
-          <Button
-            label="Back to Instances"
-            onClick={() => setSelected(null)}
-          />
+          <Button label="Back to Instances" onClick={() => setSelected(null)} />
         </div>
         <InterviewStatusDashboard
           instanceName={selected.instanceName}

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusBase.tsx
@@ -27,7 +27,7 @@ const InterviewStatusBase: React.FC = () => {
         setGroups(grouped);
       })
       .finally(() => setIsLoading(false));
-  }, []);
+  }, [selected]);
 
   const handleNewEmptyInstance = async () => {
     const name = window.prompt('Enter a name for your new instance:');
@@ -36,7 +36,7 @@ const InterviewStatusBase: React.FC = () => {
     const emptyInstance: StatusInstance = { instanceName: name, statuses: [] };
     setSelected(emptyInstance);
     setIsLoading(false);
-  }
+  };
 
   if (isLoading) {
     return <div className={styles.loading}>Loading...</div>;
@@ -45,8 +45,7 @@ const InterviewStatusBase: React.FC = () => {
   if (selected) {
     return (
       <div>
-        <Button
-          onClick={() => setSelected(null)} basic>
+        <Button onClick={() => setSelected(null)} basic>
           Back to Instances
         </Button>
         <InterviewStatusDashboard
@@ -68,15 +67,20 @@ const InterviewStatusBase: React.FC = () => {
       ) : (
         <Card.Group>
           {groups.map((group) => (
-            <Card onClick={() => setSelected(group)} key={group.instanceName}
-              className={styles.card}>
+            <Card
+              onClick={() => setSelected(group)}
+              key={group.instanceName}
+              className={styles.card}
+            >
               <Card.Content>
                 <Card.Header>{group.instanceName}</Card.Header>
               </Card.Content>
             </Card>
           ))}
-          <Card onClick={handleNewEmptyInstance}
-            className={`${styles.card} ${styles.newInstanceCard}`}>
+          <Card
+            onClick={handleNewEmptyInstance}
+            className={`${styles.card} ${styles.newInstanceCard}`}
+          >
             <Card.Content>
               <Card.Header>{'+ New Empty Instance'}</Card.Header>
             </Card.Content>

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
@@ -21,7 +21,7 @@ interface InterviewStatusDashboardProps {
 
 const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
   instanceName,
-  statuses,
+  statuses
 }) => {
   const [applicants, setApplicants] = useState<InterviewStatus[]>([]);
   const [filteredApplicants, setFilteredApplicants] = useState<InterviewStatus[]>([]);
@@ -181,10 +181,10 @@ const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
       prev.map((applicant) =>
         uuidsToPromote.includes(applicant.uuid!)
           ? {
-            ...applicant,
-            round: applicant.round === 'Behavioral' ? 'Technical' : 'Behavioral',
-            status: 'Undecided'
-          }
+              ...applicant,
+              round: applicant.round === 'Behavioral' ? 'Technical' : 'Behavioral',
+              status: 'Undecided'
+            }
           : applicant
       )
     );
@@ -192,10 +192,10 @@ const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
       prev.map((applicant) =>
         uuidsToPromote.includes(applicant.uuid!)
           ? {
-            ...applicant,
-            round: applicant.round === 'Behavioral' ? 'Technical' : 'Behavioral',
-            status: 'Undecided'
-          }
+              ...applicant,
+              round: applicant.round === 'Behavioral' ? 'Technical' : 'Behavioral',
+              status: 'Undecided'
+            }
           : applicant
       )
     );

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
@@ -14,7 +14,15 @@ import AddInterviewStatusForm from './AddInterviewStatusForm';
 import { Emitters } from '../../../utils';
 import { ROLE_OPTIONS, ROUND_OPTIONS, STATUS_OPTIONS } from '../../../consts';
 
-const InterviewStatusDashboard: React.FC = () => {
+interface InterviewStatusDashboardProps {
+  instanceName: string;
+  statuses: InterviewStatus[];
+}
+
+const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
+  instanceName,
+  statuses,
+}) => {
   const [applicants, setApplicants] = useState<InterviewStatus[]>([]);
   const [filteredApplicants, setFilteredApplicants] = useState<InterviewStatus[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -22,16 +30,11 @@ const InterviewStatusDashboard: React.FC = () => {
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
   const [selectedApplicants, setSelectedApplicants] = useState<Set<string>>(new Set());
 
-  const fetchApplicants = async () => {
-    const data = await InterviewStatusAPI.getAllInterviewStatuses();
-    setApplicants(data || []);
-    setFilteredApplicants(data || []);
-    setIsLoading(false);
-  };
-
   useEffect(() => {
-    fetchApplicants();
-  }, []);
+    setApplicants(statuses);
+    setFilteredApplicants(statuses);
+    setIsLoading(false);
+  }, [statuses]);
 
   const handleAddApplicant = (newApplicant: InterviewStatus) => {
     setApplicants((prev) => [...prev, newApplicant]);
@@ -119,8 +122,8 @@ const InterviewStatusDashboard: React.FC = () => {
       );
       setSelectedApplicants(new Set());
       Emitters.generalSuccess.emit({
-        headerMsg: 'Sucess!',
-        contentMsg: `Selected interview statuses are now deleted.`
+        headerMsg: 'Deleted!',
+        contentMsg: `Selected interview statuses removed.`
       });
     }
   };
@@ -178,10 +181,10 @@ const InterviewStatusDashboard: React.FC = () => {
       prev.map((applicant) =>
         uuidsToPromote.includes(applicant.uuid!)
           ? {
-              ...applicant,
-              round: applicant.round === 'Behavioral' ? 'Technical' : 'Behavioral',
-              status: 'Undecided'
-            }
+            ...applicant,
+            round: applicant.round === 'Behavioral' ? 'Technical' : 'Behavioral',
+            status: 'Undecided'
+          }
           : applicant
       )
     );
@@ -189,10 +192,10 @@ const InterviewStatusDashboard: React.FC = () => {
       prev.map((applicant) =>
         uuidsToPromote.includes(applicant.uuid!)
           ? {
-              ...applicant,
-              round: applicant.round === 'Behavioral' ? 'Technical' : 'Behavioral',
-              status: 'Undecided'
-            }
+            ...applicant,
+            round: applicant.round === 'Behavioral' ? 'Technical' : 'Behavioral',
+            status: 'Undecided'
+          }
           : applicant
       )
     );
@@ -360,7 +363,7 @@ const InterviewStatusDashboard: React.FC = () => {
         </Table.Body>
       </Table>
       <div className={styles.addForm}>
-        <AddInterviewStatusForm onAddApplicant={handleAddApplicant} />
+        <AddInterviewStatusForm onAddApplicant={handleAddApplicant} instanceName={instanceName} />
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/interview-status/index.tsx
+++ b/frontend/src/pages/admin/interview-status/index.tsx
@@ -1,5 +1,4 @@
-import InterviewStatusBase from "../../../components/Admin/InterviewStatus/InterviewStatusBase";
-
+import InterviewStatusBase from '../../../components/Admin/InterviewStatus/InterviewStatusBase';
 
 const InterviewStatusList: React.FC = () => <InterviewStatusBase />;
 

--- a/frontend/src/pages/admin/interview-status/index.tsx
+++ b/frontend/src/pages/admin/interview-status/index.tsx
@@ -1,3 +1,6 @@
-import InterviewStatusDashboard from '../../../components/Admin/InterviewStatus/InterviewStatusDashboard';
+import InterviewStatusBase from "../../../components/Admin/InterviewStatus/InterviewStatusBase";
 
-export default InterviewStatusDashboard;
+
+const InterviewStatusList: React.FC = () => <InterviewStatusBase />;
+
+export default InterviewStatusList;


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request sorts interview statuses into separate instances and adds the ability for users to create brand‐new interview‐status instances. 

* **Feature:**

  * Created `InterviewStatusBase` page that sorts applicants into instances.
  * Added a “+ New Instance” button below the instance list in `InterviewStatusBase`.
  * Implemented `handleNewEmptyInstance()` to prompt the user for a name and create an empty instance with that name.
  * Implemented sorting that ensures that the applicants' statuses are always in a consistent order on the dashboard. 
  * Added a delete instances endpoint in the InterviewStatusAPI

### Test Plan <!-- Required -->

https://github.com/user-attachments/assets/86a84c25-65a8-4ce2-ba03-fa61edaf6c8a

1. **Test plan**

   * Load the base screen: verify the “+ New Instance” button renders below existing cards
   * Click “+ New Instance”: a browser prompt should appear asking for the new instance name
   * Enter a unique name: confirm that the UI shows a loading indicator, then a new card with that name appears
   * Click the new card: verify that `InterviewStatusDashboard` opens with an empty statuses list
   * Select an instance and click delete instance button: verify that the instance is deleted and no longer appears as a card

2. **Edge cases**

   * Dismiss prompt or submit a blank name: verify nothing breaks and no new instance is created
   * Submit a duplicate name: verify that error is displayed to user

### Notes
 * I plan to improve the UI and change the window prompt into an actual form 
 * I plan to implement uploading an instance from a CSV and from a candidate decider instance

