### PR TITLE
[New Website] Added new type to `<IconWrapper>`

### DIFF
--- a/new-dti-website-redesign/src/app/test-components/page.tsx
+++ b/new-dti-website-redesign/src/app/test-components/page.tsx
@@ -216,7 +216,7 @@ export default function TestComponents() {
       <div className="flex flex-col gap-6">
         <h4>Icon wrappers</h4>
         <div className="flex gap-4">
-          <IconWrapper size="default">
+          <IconWrapper size="default" type="primary">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -236,7 +236,49 @@ export default function TestComponents() {
             </svg>
           </IconWrapper>
 
-          <IconWrapper size="small">
+          <IconWrapper size="small" type="primary">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              className="lucide lucide-rocket-icon lucide-rocket"
+            >
+              <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+              <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+              <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+              <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+            </svg>
+          </IconWrapper>
+        </div>
+
+        <div className="flex gap-4">
+          <IconWrapper size="default" type="default">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              className="lucide lucide-rocket-icon lucide-rocket"
+            >
+              <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+              <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+              <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+              <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+            </svg>
+          </IconWrapper>
+
+          <IconWrapper size="small" type="default">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"

--- a/new-dti-website-redesign/src/components/IconWrapper.tsx
+++ b/new-dti-website-redesign/src/components/IconWrapper.tsx
@@ -1,22 +1,28 @@
 type IconWrapperProps = {
   children: React.ReactNode;
   size?: 'default' | 'small';
+  type?: 'primary' | 'default';
   className?: string;
 };
 
 export default function IconWrapper({
   children,
   size = 'default',
+  type = 'default',
   className = ''
 }: IconWrapperProps) {
   const wrapperSize = size === 'small' ? 'w-12 h-12' : 'w-16 h-16';
+  const wrapperColor =
+    type === 'primary'
+      ? 'bg-foreground-1 text-background-1'
+      : 'bg-background-2 border border-border-1';
   // default: parent wrapper = 64px, child icon = 32px
   // small: parent wrapper = 48px, child icon = 24px
   const iconSize = size === 'small' ? '[&>svg]:w-6 [&>svg]:h-6' : '[&>svg]:w-8 [&>svg]:h-8';
 
   return (
     <div
-      className={`flex items-center justify-center rounded-full bg-background-2 border border-border-1 ${wrapperSize} ${iconSize} ${className}`}
+      className={`flex items-center justify-center rounded-full ${wrapperSize} ${wrapperColor} ${iconSize} ${className}`}
     >
       {children}
     </div>


### PR DESCRIPTION
# Changes

[Figma specs](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1336-16568&m=dev)
Realized that we needed a white colored iconwrapper so added that type (i had forgotten to add it when i created the component initially lol)


# Pic 
<img width="326" alt="image" src="https://github.com/user-attachments/assets/b571acd6-b9e9-43f0-a765-9bc2b051701f" />


# Test plan
- Navigate to `/test-components`
- Scroll down to "Icon wrappers" section
- Ensure that there are 4 icon wrappers
  - 2 primary (white colored), 1 default (`64px`) and 1 small (`48px`)
  - 2 default (dark gray colored), 1 default (`64px`) and 1 small (`48px`
