### PR TITLE
[New Website] Pages skeleton section

### DIFF
--- a/new-dti-website-redesign/src/app/apply/page.tsx
+++ b/new-dti-website-redesign/src/app/apply/page.tsx
@@ -28,19 +28,19 @@ export default function Apply() {
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Application timeline" section</h4>
+        <h4>Application timeline section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Role descriptions" section</h4>
+        <h4>Role descriptions section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Frequently Asked Questions" section</h4>
+        <h4>Frequently Asked Questions section</h4>
       </section>
 
       <SectionSep />

--- a/new-dti-website-redesign/src/app/apply/page.tsx
+++ b/new-dti-website-redesign/src/app/apply/page.tsx
@@ -1,6 +1,8 @@
 import Hero from '../../components/Hero';
 import Layout from '../../components/Layout';
 import Banner from '../../components/Banner';
+import CtaSection from '../../components/CtaSection';
+import SectionSep from '../../components/SectionSep';
 
 export const metadata = {
   title: 'DTI APPLY PAGE',
@@ -23,15 +25,36 @@ export default function Apply() {
         imageAlt="DTI members hosting a recruitment event with prospective applicants"
       />
 
-      <section className="bg-background-3 h-[800px]">
-        <h2>title</h2>
-        <p className="mt-2">This is the apply page</p>
-      </section>
-      <section className="bg-border-2 h-[800px]">
-        <h2>title</h2>
+      <SectionSep />
 
-        <p className="mt-2">This is the apply page</p>
+      <section className="temporarySection">
+        <h4>"Application timeline" section</h4>
       </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"Role descriptions" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"Frequently Asked Questions" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button1Label="Apply to DTI"
+        button1Link="/apply"
+        button2Label="Meet the team"
+        button2Link="/team"
+      />
+
+      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/course/page.tsx
+++ b/new-dti-website-redesign/src/app/course/page.tsx
@@ -25,31 +25,31 @@ export default function Course() {
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Trends in Web Development" section</h4>
+        <h4>Trends in Web Development section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Details about Trends" section</h4>
+        <h4>Details about Trends section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Course staff" section</h4>
+        <h4>Course staff section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Past student experiences" section</h4>
+        <h4>Past student experiences section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Past student projects" section</h4>
+        <h4>Past student projects section</h4>
       </section>
 
       <SectionSep />

--- a/new-dti-website-redesign/src/app/course/page.tsx
+++ b/new-dti-website-redesign/src/app/course/page.tsx
@@ -1,5 +1,7 @@
 import Hero from '../../components/Hero';
 import Layout from '../../components/Layout';
+import CtaSection from '../../components/CtaSection';
+import SectionSep from '../../components/SectionSep';
 
 export const metadata = {
   title: 'DTI COURSE PAGE',
@@ -20,15 +22,48 @@ export default function Course() {
         imageAlt="DTI member presenting a course to an auditorium"
       />
 
-      <section className="bg-background-3 h-[800px]">
-        <h2>title</h2>
-        <p className="mt-2">This is the COURSE page</p>
-      </section>
-      <section className="bg-border-2 h-[800px]">
-        <h2>title</h2>
+      <SectionSep />
 
-        <p className="mt-2">This is the COURSE page</p>
+      <section className="temporarySection">
+        <h4>"Trends in Web Development" section</h4>
       </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"Details about Trends" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"Course staff" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"Past student experiences" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"Past student projects" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button1Label="Apply to DTI"
+        button1Link="/apply"
+        button2Label="Meet the team"
+        button2Link="/team"
+      />
+
+      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/globals.css
+++ b/new-dti-website-redesign/src/app/globals.css
@@ -204,6 +204,13 @@ subsections of the carousel */
   min-width: fit-content;
 }
 
+/* Temporary styles for skeleton UI */
+.temporarySection {
+  padding: 32px;
+  height: 500px;
+  background: var(--background-2);
+}
+
 ::selection {
   background: var(--background-3);
   color: var(--color-foreground-1);

--- a/new-dti-website-redesign/src/app/initiatives/page.tsx
+++ b/new-dti-website-redesign/src/app/initiatives/page.tsx
@@ -3,6 +3,7 @@ import Hero from '../../components/Hero';
 import Layout from '../../components/Layout';
 import SectionSep from '../../components/SectionSep';
 import FeatureSection from '../../components/FeatureSection';
+import CtaSection from '../../components/CtaSection';
 
 export const metadata = {
   title: 'DTI INITIATIVES PAGE',
@@ -128,15 +129,18 @@ export default function Initiatives() {
         imageAlt="DTI members at the Millenium office"
       />
 
-      <section className="bg-background-3 h-[800px]">
-        <h2>title</h2>
-        <p className="mt-2">This is the INITIATIVES page</p>
-      </section>
-      <section className="bg-border-2 h-[800px]">
-        <h2>title</h2>
+      <SectionSep />
 
-        <p className="mt-2">This is the INITIATIVES page</p>
-      </section>
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button1Label="Apply to DTI"
+        button1Link="/apply"
+        button2Label="Meet the team"
+        button2Link="/team"
+      />
+
+      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/page.tsx
+++ b/new-dti-website-redesign/src/app/page.tsx
@@ -106,24 +106,7 @@ export default function Home() {
           button2Link="/team"
         />
 
-        <section className="bg-background-2 h-[400px]">
-          <h1>Welcome</h1>
-          <p className="mt-2">testing testing 123</p>
-        </section>
-
-        <section className="bg-background-3 h-[400px]">
-          <h2>
-            <Link href="/test-components" className="text-accent-red underline">
-              View and test components
-            </Link>
-          </h2>
-
-          <h2>
-            <Link href="/test-page" className="text-accent-red underline">
-              View full test page
-            </Link>
-          </h2>
-        </section>
+        <SectionSep />
       </Layout>
     </>
   );

--- a/new-dti-website-redesign/src/app/page.tsx
+++ b/new-dti-website-redesign/src/app/page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Link from 'next/link';
 import Layout from '../components/Layout';
 import Hero from '../components/Hero';
 import FeatureSection from '../components/FeatureSection';

--- a/new-dti-website-redesign/src/app/products/page.tsx
+++ b/new-dti-website-redesign/src/app/products/page.tsx
@@ -6,6 +6,7 @@ import Layout from '../../components/Layout';
 import products from './products.json';
 import Product from './Product';
 import Hero from '../../components/Hero';
+import CtaSection from '../../components/CtaSection';
 
 export const metadata = {
   title: 'DTI PRODUCTS PAGE',
@@ -121,15 +122,18 @@ export default function Products() {
         </React.Fragment>
       ))}
 
-      <section className="bg-background-3 h-[800px]">
-        <h2>title</h2>
-        <p className="mt-2">This is the PRODUCTS page</p>
-      </section>
-      <section className="bg-border-2 h-[800px]">
-        <h2>title</h2>
+      <SectionSep />
 
-        <p className="mt-2">This is the PRODUCTS page</p>
-      </section>
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button1Label="Apply to DTI"
+        button1Link="/apply"
+        button2Label="Meet the team"
+        button2Link="/team"
+      />
+
+      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/sponsor/page.tsx
+++ b/new-dti-website-redesign/src/app/sponsor/page.tsx
@@ -1,5 +1,7 @@
 import Hero from '../../components/Hero';
 import Layout from '../../components/Layout';
+import CtaSection from '../../components/CtaSection';
+import SectionSep from '../../components/SectionSep';
 
 export const metadata = {
   title: 'DTI SPONSOR PAGE',
@@ -20,15 +22,42 @@ export default function Sponsor() {
         imageAlt="DTI members collaborating together in front of a laptop"
       />
 
-      <section className="bg-background-3 h-[800px]">
-        <h2>title</h2>
-        <p className="mt-2">This is the SPONSOR page</p>
-      </section>
-      <section className="bg-border-2 h-[800px]">
-        <h2>title</h2>
+      <SectionSep />
 
-        <p className="mt-2">This is the SPONSOR page</p>
+      <section className="temporarySection">
+        <h4>"Become a sponsor!" section</h4>
       </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"row of 3 cards" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"Sponsorship benefits" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <section className="temporarySection">
+        <h4>"Thank you to our sponsors!" section</h4>
+      </section>
+
+      <SectionSep />
+
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button1Label="Apply to DTI"
+        button1Link="/apply"
+        button2Label="Meet the team"
+        button2Link="/team"
+      />
+
+      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/sponsor/page.tsx
+++ b/new-dti-website-redesign/src/app/sponsor/page.tsx
@@ -25,25 +25,25 @@ export default function Sponsor() {
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Become a sponsor!" section</h4>
+        <h4>Become a sponsor! section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"row of 3 cards" section</h4>
+        <h4>row of 3 cards section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Sponsorship benefits" section</h4>
+        <h4>Sponsorship benefits section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Thank you to our sponsors!" section</h4>
+        <h4>Thank you to our sponsors! section</h4>
       </section>
 
       <SectionSep />

--- a/new-dti-website-redesign/src/app/team/page.tsx
+++ b/new-dti-website-redesign/src/app/team/page.tsx
@@ -24,26 +24,26 @@ export default function Team() {
 
       <SectionSep />
 
-      <section className="h-128">
-        <h2>"We are Cornell DTI" section</h2>
+      <section className="temporarySection">
+        <h4>"We are Cornell DTI" section</h4>
       </section>
 
       <SectionSep />
 
-      <section className="h-128">
-        <h2>"Who we are" section</h2>
+      <section className="temporarySection">
+        <h4>"Who we are" section</h4>
       </section>
 
       <SectionSep />
 
-      <section className="h-128">
-        <h2>"Introducing the team" section</h2>
+      <section className="temporarySection">
+        <h4>"Introducing the team" section</h4>
       </section>
 
       <SectionSep />
 
-      <section className="h-128">
-        <h2>"Beyond DTI" section</h2>
+      <section className="temporarySection">
+        <h4>"Beyond DTI" section</h4>
       </section>
 
       <SectionSep />

--- a/new-dti-website-redesign/src/app/team/page.tsx
+++ b/new-dti-website-redesign/src/app/team/page.tsx
@@ -25,25 +25,25 @@ export default function Team() {
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"We are Cornell DTI" section</h4>
+        <h4>We are Cornell DTI section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Who we are" section</h4>
+        <h4>Who we are section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Introducing the team" section</h4>
+        <h4>Introducing the team section</h4>
       </section>
 
       <SectionSep />
 
       <section className="temporarySection">
-        <h4>"Beyond DTI" section</h4>
+        <h4>Beyond DTI section</h4>
       </section>
 
       <SectionSep />

--- a/new-dti-website-redesign/src/app/team/page.tsx
+++ b/new-dti-website-redesign/src/app/team/page.tsx
@@ -1,5 +1,7 @@
 import Layout from '../../components/Layout';
 import Hero from '../../components/Hero';
+import CtaSection from '@/components/CtaSection';
+import SectionSep from '@/components/SectionSep';
 
 export const metadata = {
   title: 'DTI TEAM PAGE',
@@ -19,19 +21,43 @@ export default function Team() {
         image="/team/hero.png"
         imageAlt="DTI members in front of Duffield hall"
       />
-      <section className="bg-background-2 h-[400px]">
-        <h1>Team</h1>
-        <p className="mt-2">This is the team page</p>
-      </section>
-      <section className="bg-background-3 h-[800px]">
-        <h2>title</h2>
-        <p className="mt-2">This is the team page</p>
-      </section>
-      <section className="bg-border-2 h-[800px]">
-        <h2>title</h2>
 
-        <p className="mt-2">This is the team page</p>
+      <SectionSep />
+
+      <section className="h-128">
+        <h2>"We are Cornell DTI" section</h2>
       </section>
+
+      <SectionSep />
+
+      <section className="h-128">
+        <h2>"Who we are" section</h2>
+      </section>
+
+      <SectionSep />
+
+      <section className="h-128">
+        <h2>"Introducing the team" section</h2>
+      </section>
+
+      <SectionSep />
+
+      <section className="h-128">
+        <h2>"Beyond DTI" section</h2>
+      </section>
+
+      <SectionSep />
+
+      <CtaSection
+        heading="Ready to join?"
+        subheading="Be part of something greater today."
+        button1Label="Apply to DTI"
+        button1Link="/apply"
+        button2Label="Meet the team"
+        button2Link="/team"
+      />
+
+      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/team/page.tsx
+++ b/new-dti-website-redesign/src/app/team/page.tsx
@@ -1,7 +1,7 @@
 import Layout from '../../components/Layout';
 import Hero from '../../components/Hero';
-import CtaSection from '@/components/CtaSection';
-import SectionSep from '@/components/SectionSep';
+import CtaSection from '../../components/CtaSection';
+import SectionSep from '../../components/SectionSep';
 
 export const metadata = {
   title: 'DTI TEAM PAGE',

--- a/new-dti-website-redesign/src/components/Footer.tsx
+++ b/new-dti-website-redesign/src/components/Footer.tsx
@@ -203,7 +203,7 @@ export default function Footer() {
   );
 
   return (
-    <footer className="bg-background-1 relative max-w-[1184px] mx-4 sm:mx-8 md:mx-32 lg:mx-auto border-l-1 border-r-1 border-border-1">
+    <footer className="bg-background-1 relative max-w-[1184px] mx-4 sm:mx-8 md:mx-32 lg:mx-auto border-1 border-b-0 border-border-1">
       <div className="p-4 md:p-0 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
         <div className="md:p-8 md:pb-0 md:row-start-1 md:col-start-1 lg:row-auto lg:col-auto lg:pb-8">
           <DTILogoSection />


### PR DESCRIPTION
# Summary 

- Added skeleton sections for each page (just the title) so its easier for ppl to know what section goes where
- Removed old `<section>`s
- Minor styling border changes on footer
- Also added `<CtaSection>` and `<SectionSep>` components on the page 


# Test plan
- Navigate to each page in the navbar (Home, Team, Products, Course, Initiatives, Sponsor, Apply)
- Make sure they have temporary placeholder sections in accordance [with the Figma](https://www.figma.com/design/ttAGEX3pHmzuhMzp8uAyhz/SP25-Cornelldti.org-Website-Revamp?node-id=1325-12127&t=bdZBunMNsB3Opr1d-11)
- Make sure each page has a Cta section (the section with "Ready to join?" and 2 buttons)

# Video: 


https://github.com/user-attachments/assets/bdc82e6b-0c1e-46de-9611-666ac3f30399

