### PR TITLE
[New Website] Smoothly animation page links in `<Navbar>`

### DIFF
--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import Navbar from '@/components/Navbar';
+import Navbar from '../components/Navbar';
 
 export const metadata: Metadata = {
   title: 'Create Next App',

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import Navbar from '@/components/Navbar';
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -13,7 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Navbar />
+        {children}
+      </body>
     </html>
   );
 }

--- a/new-dti-website-redesign/src/components/Button.tsx
+++ b/new-dti-website-redesign/src/components/Button.tsx
@@ -8,6 +8,7 @@ type ButtonProps = {
   label: string;
   href?: string;
   variant?: 'primary' | 'secondary' | 'tertiary';
+  size?: 'default' | 'small';
   badge?: React.ReactNode;
   backToTop?: React.ReactNode;
   newTab?: boolean;
@@ -23,6 +24,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       href,
       className = '',
       variant = 'primary',
+      size = 'default',
       badge,
       backToTop,
       newTab = false,
@@ -30,8 +32,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
     },
     ref
   ) => {
-    const baseStyles = `
-        px-6 h-12 w-fit rounded-full cursor-pointer inline-flex items-center justify-center gap-2
+    const baseStyles = `w-fit rounded-full cursor-pointer inline-flex items-center justify-center gap-2
         transition-[background-color] duration-[120ms] focusState text-nowrap`;
 
     const variantStyles = {
@@ -42,7 +43,12 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       tertiary: `bg-transparent border border-border-1 text-foreground-1 hover:bg-background-2`
     }[variant];
 
-    const sharedClasses = `${baseStyles} ${className} ${variantStyles}`;
+    const sizeStyles = {
+      default: 'px-6 h-12',
+      small: 'px-4 h-10'
+    }[size];
+
+    const sharedClasses = `${baseStyles} ${className} ${variantStyles} ${sizeStyles}`;
 
     const content = (
       <>

--- a/new-dti-website-redesign/src/components/Layout.tsx
+++ b/new-dti-website-redesign/src/components/Layout.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { ReactNode } from 'react';
-import Navbar from './Navbar';
 import DevNavbar from './DevNavbar';
 import Footer from './Footer';
 
@@ -11,8 +10,6 @@ type Props = {
 
 const Layout = ({ children }: Props): React.ReactElement => (
   <>
-    <Navbar />
-
     <DevNavbar />
 
     <main role="main" className="max-w-[1184px] mx-4 sm:mx-8 md:mx-32 lg:mx-auto">

--- a/new-dti-website-redesign/src/components/Navbar.tsx
+++ b/new-dti-website-redesign/src/components/Navbar.tsx
@@ -19,6 +19,9 @@ export default function Navbar() {
     { href: '/sponsor', label: 'Sponsor' }
   ];
 
+  // to only show the highlight on the links above (not on Home or Apply)
+  const isNavLink = navLinks.some((link) => link.href === pathname);
+
   const linkRefs = useRef<(HTMLAnchorElement | null)[]>([]);
   const highlightRef = useRef<HTMLSpanElement>(null);
 
@@ -97,6 +100,7 @@ export default function Navbar() {
                 </Link>
               </li>
             ))}
+
             {highlightStyle && (
               <span
                 className="bottom-0 absolute -z-10 rounded-full h-10 bg-background-2"
@@ -104,8 +108,10 @@ export default function Navbar() {
                 style={{
                   left: highlightStyle.left - 16,
                   width: highlightStyle.width + 32,
+                  opacity: isNavLink ? 1 : 0,
+                  pointerEvents: isNavLink ? 'auto' : 'none',
                   transition:
-                    'left 0.2s cubic-bezier(.4,0,.2,1), width 0.2s cubic-bezier(.4,0,.2,1)'
+                    'left 0.2s cubic-bezier(.4,0,.2,1), width 0.2s cubic-bezier(.4,0,.2,1), opacity 0.3s ease'
                 }}
               />
             )}

--- a/new-dti-website-redesign/src/components/Navbar.tsx
+++ b/new-dti-website-redesign/src/components/Navbar.tsx
@@ -101,8 +101,8 @@ export default function Navbar() {
         </Link>
 
         {/* Desktop links */}
-        <div className="flex gap-6 items-center">
-          <ul className="hidden min-[1200px]:flex gap-6 text-foreground-3 h-10 items-center relative">
+        <div className="flex gap-2 items-center">
+          <ul className="hidden min-[1200px]:flex text-foreground-3 h-10 items-center relative">
             {navLinks.map(({ href, label }, i) => (
               <li key={href} className="h-10 flex items-center">
                 <Link
@@ -110,7 +110,7 @@ export default function Navbar() {
                   ref={(el) => {
                     linkRefs.current[i] = el;
                   }}
-                  className={`transition-[color] h-10 duration-[120ms] hover:text-foreground-1 flex items-center relative focusState rounded-sm font-medium ${
+                  className={`transition-[color] h-10 px-4 duration-[120ms] hover:text-foreground-1 flex items-center relative focusState rounded-full font-medium ${
                     pathname === href ? 'text-foreground-1' : 'text-foreground-3'
                   }`}
                 >
@@ -125,8 +125,8 @@ export default function Navbar() {
                 className="bottom-0 absolute -z-10 rounded-full h-10 bg-background-2"
                 ref={highlightRef}
                 style={{
-                  left: highlightStyle.left - 16,
-                  width: highlightStyle.width + 32,
+                  left: highlightStyle.left,
+                  width: highlightStyle.width,
                   opacity: isNavLink ? 1 : 0,
                   pointerEvents: isNavLink ? 'auto' : 'none',
                   transition:

--- a/new-dti-website-redesign/src/components/Navbar.tsx
+++ b/new-dti-website-redesign/src/components/Navbar.tsx
@@ -34,6 +34,9 @@ export default function Navbar() {
   // old one to the new one smoothly
   const prevHighlight = useRef<{ left: number; width: number } | null>(null);
 
+  // to track previous path
+  const prevPathname = useRef<string | null>(null);
+
   // using useLayoutEffect instead of useEffect to ensure that the layout reads and
   // updates the position/width before the screen repaints (to prevent flicker and
   // achieve the smooth animation
@@ -47,21 +50,36 @@ export default function Navbar() {
       const { offsetLeft, offsetWidth } = linkEl;
       const newStyle = { left: offsetLeft, width: offsetWidth };
 
-      // all of this animates movement of highlight from old link to new link smoothly
-      // if there's a previous highlight position, jump to it first, then animate to new one
-      // otherwise set new position directly
-      if (prevHighlight.current) {
-        setHighlightStyle(prevHighlight.current);
+      const cameFromHomeOrApply = prevPathname.current === '/' || prevPathname.current === '/apply';
+      const nowIsNavLink = navLinks.some((link) => link.href === pathname);
 
-        requestAnimationFrame(() => {
-          setHighlightStyle(newStyle);
-          prevHighlight.current = newStyle;
-        });
-      } else {
+      if (cameFromHomeOrApply && nowIsNavLink) {
+        // just set highlight directly with fade-in (no slide animation)
         setHighlightStyle(newStyle);
         prevHighlight.current = newStyle;
+      } else {
+        // all of this animates movement of highlight from old link to new link smoothly
+        // if there's a previous highlight position, jump to it first, then animate to new one
+        // otherwise set new position directly
+        if (prevHighlight.current) {
+          setHighlightStyle(prevHighlight.current);
+
+          requestAnimationFrame(() => {
+            setHighlightStyle(newStyle);
+            prevHighlight.current = newStyle;
+          });
+        } else {
+          setHighlightStyle(newStyle);
+          prevHighlight.current = newStyle;
+        }
       }
+    } else {
+      // no highlight for current pathname (/home and /apply)
+      setHighlightStyle(null);
+      prevHighlight.current = null;
     }
+
+    prevPathname.current = pathname;
   }, [pathname]);
 
   return (

--- a/new-dti-website-redesign/src/components/Navbar.tsx
+++ b/new-dti-website-redesign/src/components/Navbar.tsx
@@ -50,11 +50,12 @@ export default function Navbar() {
       const { offsetLeft, offsetWidth } = linkEl;
       const newStyle = { left: offsetLeft, width: offsetWidth };
 
+      // avoid animating from a stale position when coming from Home or Apply
       const cameFromHomeOrApply = prevPathname.current === '/' || prevPathname.current === '/apply';
       const nowIsNavLink = navLinks.some((link) => link.href === pathname);
 
       if (cameFromHomeOrApply && nowIsNavLink) {
-        // just set highlight directly with fade-in (no slide animation)
+        // just set highlight directly  (no slide animation)
         setHighlightStyle(newStyle);
         prevHighlight.current = newStyle;
       } else {

--- a/new-dti-website-redesign/src/components/Navbar.tsx
+++ b/new-dti-website-redesign/src/components/Navbar.tsx
@@ -88,7 +88,7 @@ export default function Navbar() {
         className="flex justify-between items-center px-4 md:px-8 py-4 max-w-[1184px] fixed z-10 bg-background-1 
         mx-4 sm:mx-8 md:mx-32 lg:mx-auto 
         [width:calc(100%-2rem)] sm:[width:calc(100%-4rem)] md:[width:calc(100%-16rem)] 
-        lg:left-1/2 lg:-translate-x-1/2 lg:transform border-b-1 border-border-1"
+        lg:left-1/2 lg:-translate-x-1/2 lg:transform"
       >
         <Link href="/" className="focusState rounded-sm">
           <Image

--- a/new-dti-website-redesign/src/components/Navbar.tsx
+++ b/new-dti-website-redesign/src/components/Navbar.tsx
@@ -119,6 +119,7 @@ export default function Navbar() {
               </li>
             ))}
 
+            {/* Gray pill shape that highlights currently selected page */}
             {highlightStyle && (
               <span
                 className="bottom-0 absolute -z-10 rounded-full h-10 bg-background-2"

--- a/new-dti-website-redesign/src/components/Navbar.tsx
+++ b/new-dti-website-redesign/src/components/Navbar.tsx
@@ -58,21 +58,19 @@ export default function Navbar() {
         // just set highlight directly  (no slide animation)
         setHighlightStyle(newStyle);
         prevHighlight.current = newStyle;
-      } else {
+      } else if (prevHighlight.current) {
         // all of this animates movement of highlight from old link to new link smoothly
         // if there's a previous highlight position, jump to it first, then animate to new one
         // otherwise set new position directly
-        if (prevHighlight.current) {
-          setHighlightStyle(prevHighlight.current);
+        setHighlightStyle(prevHighlight.current);
 
-          requestAnimationFrame(() => {
-            setHighlightStyle(newStyle);
-            prevHighlight.current = newStyle;
-          });
-        } else {
+        requestAnimationFrame(() => {
           setHighlightStyle(newStyle);
           prevHighlight.current = newStyle;
-        }
+        });
+      } else {
+        setHighlightStyle(newStyle);
+        prevHighlight.current = newStyle;
       }
     } else {
       // no highlight for current pathname (/home and /apply)


### PR DESCRIPTION
# Summary

- The current way of showing which page you were currently on in the navbar involved just a white underline, which wasn't very visible. it also didn't animate when you changed page, which made it kinda choppy

<img width="1295" alt="Screenshot 2025-05-17 at 1 23 09 PM" src="https://github.com/user-attachments/assets/41890e6a-65ce-41cf-ae72-4590f620ded1" />


- This new design uses a pill `<span>` rendered independently of the link. It also uses `useLayoutEffect` to smoothly animate between each page
- For stylistic reasons, the pill highlight should be the same size as the "Apply" button. So I customized the `<Button>` component a bit to add a `small` prop, which is used in `<Navbar>`
- I also had to move `<Navbar>` to the root `layout.tsx` page so that the highlight animation persists across pages and doesn't reset


# Video

https://github.com/user-attachments/assets/0c357822-6909-46d5-a0ad-091915ea00f1

# Test plan
- Navigate to each page in navbar
- For all page that aren't Home or Apply, make sure the pill highlight correctly animates as seen in the video
- When switching from one of those links to Home/Apply, make sure the pill highlight disappears
- When switching from Home/Apply to any of those other pages, make sure the pill highlight comes back
- Ensure no breaking changes in mobile nav (resize window to check – the hamburger menu logic shouldn't be impacted by this)

# Note
- I added lots of inline code comments to try and explain the logic on the animation – it's a bit complex to ensure we cover edge cases and to even make this animation smooth