### PR TITLE
[New Website] New `<Button>` variant, `<CtaSection>` changes, `<Footer>` changes

### DIFF
--- a/new-dti-website-redesign/src/app/apply/page.tsx
+++ b/new-dti-website-redesign/src/app/apply/page.tsx
@@ -58,8 +58,6 @@ export default function Apply() {
         <h4>Frequently Asked Questions section</h4>
       </section>
 
-      <SectionSep />
-
       <CtaSection
         heading="Ready to join?"
         subheading="Be part of something greater today."
@@ -68,8 +66,6 @@ export default function Apply() {
         button2Label="Meet the team"
         button2Link="/team"
       />
-
-      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/course/page.tsx
+++ b/new-dti-website-redesign/src/app/course/page.tsx
@@ -49,8 +49,6 @@ export default function Course() {
         <h4>Past student projects section</h4>
       </section>
 
-      <SectionSep />
-
       <CtaSection
         heading="Ready to join?"
         subheading="Be part of something greater today."
@@ -59,8 +57,6 @@ export default function Course() {
         button2Label="Meet the team"
         button2Link="/team"
       />
-
-      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/design-system/components/button/page.tsx
+++ b/new-dti-website-redesign/src/app/design-system/components/button/page.tsx
@@ -17,6 +17,12 @@ export default function ButtonPage() {
 
         <Button label="Apply today" variant="tertiary" />
 
+        <div className="flex w-100 h-50 items-center justify-center bg-[url(/CtaSection.jpg)] bg-no-repeat bg-center bg-cover">
+          <Button label="Apply today" variant="transparent" />
+        </div>
+
+        <Button label="Apply today" variant="tertiary" />
+
         <Button label="Apply today" size="small" />
 
         <Button label="Apply" badge="12D 2H" size="small" />
@@ -24,6 +30,10 @@ export default function ButtonPage() {
         <Button label="Apply today" variant="secondary" size="small" />
 
         <Button label="Apply today" variant="tertiary" size="small" />
+
+        <div className="flex w-100 h-50 items-center justify-center bg-[url(/CtaSection.jpg)] bg-no-repeat bg-center bg-cover">
+          <Button label="Apply today" variant="transparent" size="small" />
+        </div>
       </PageSection>
 
       <PageSection title="Icon button" description="Use when you just need an icon">

--- a/new-dti-website-redesign/src/app/globals.css
+++ b/new-dti-website-redesign/src/app/globals.css
@@ -181,13 +181,12 @@ a {
   line-height: 160%;
 }
 
-main,
-section:not(.hero),
+section:not(.hero):not(.ctaSection),
 .sectionStyles {
   outline: 0.5px solid var(--border-1);
 }
 
-section:not(.hero),
+section:not(.hero):not(.ctaSection),
 .sectionSep {
   max-width: 1184px;
   margin: auto;

--- a/new-dti-website-redesign/src/app/initiatives/page.tsx
+++ b/new-dti-website-redesign/src/app/initiatives/page.tsx
@@ -126,8 +126,6 @@ export default function Initiatives() {
         imageAlt="DTI members at the Millenium office"
       />
 
-      <SectionSep />
-
       <CtaSection
         heading="Ready to join?"
         subheading="Be part of something greater today."
@@ -136,8 +134,6 @@ export default function Initiatives() {
         button2Label="Meet the team"
         button2Link="/team"
       />
-
-      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/page.tsx
+++ b/new-dti-website-redesign/src/app/page.tsx
@@ -106,8 +106,6 @@ export default function Home() {
           button2Link="/apply"
         />
 
-        <SectionSep />
-
         <CtaSection
           heading="Ready to join?"
           subheading="Be part of something greater today."
@@ -116,8 +114,6 @@ export default function Home() {
           button2Label="Meet the team"
           button2Link="/team"
         />
-
-        <SectionSep />
       </Layout>
     </>
   );

--- a/new-dti-website-redesign/src/app/products/page.tsx
+++ b/new-dti-website-redesign/src/app/products/page.tsx
@@ -48,8 +48,6 @@ export default function Products() {
         </React.Fragment>
       ))}
 
-      <SectionSep />
-
       <CtaSection
         heading="Ready to join?"
         subheading="Be part of something greater today."
@@ -58,8 +56,6 @@ export default function Products() {
         button2Label="Meet the team"
         button2Link="/team"
       />
-
-      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/sponsor/page.tsx
+++ b/new-dti-website-redesign/src/app/sponsor/page.tsx
@@ -51,7 +51,7 @@ export default function Sponsor() {
 
       <section>
         <div className="grid min-[1000px]:grid-cols-4">
-          <div className="col-span-2 flex items-center justify-center border-b-1 border-border-1 min-[1000px]:p-0 p-8">
+          <div className="col-span-2 flex items-center justify-center min-[1000px]:p-0 p-8">
             <h2 className="h4 text-center">Thank you to our sponsors!</h2>
           </div>
           {logos.map((logo, index) => (
@@ -59,8 +59,6 @@ export default function Sponsor() {
           ))}
         </div>
       </section>
-
-      <SectionSep />
 
       <CtaSection
         heading="Ready to join?"
@@ -70,8 +68,6 @@ export default function Sponsor() {
         button2Label="Meet the team"
         button2Link="/team"
       />
-
-      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/app/team/page.tsx
+++ b/new-dti-website-redesign/src/app/team/page.tsx
@@ -43,8 +43,6 @@ export default function Team() {
         <h4>Beyond DTI section</h4>
       </section>
 
-      <SectionSep />
-
       <CtaSection
         heading="Ready to join?"
         subheading="Be part of something greater today."
@@ -53,8 +51,6 @@ export default function Team() {
         button2Label="Meet the team"
         button2Link="/team"
       />
-
-      <SectionSep />
     </Layout>
   );
 }

--- a/new-dti-website-redesign/src/components/Button.tsx
+++ b/new-dti-website-redesign/src/components/Button.tsx
@@ -7,7 +7,7 @@ import type { ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
 type ButtonProps = {
   label: string;
   href?: string;
-  variant?: 'primary' | 'secondary' | 'tertiary';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'transparent';
   size?: 'default' | 'small';
   badge?: React.ReactNode;
   backToTop?: React.ReactNode;
@@ -40,7 +40,8 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
         badge ? 'gap-1 pr-3' : ''
       }`,
       secondary: `bg-background-2 border border-border-1 text-foreground-1 hover:bg-background-3`,
-      tertiary: `bg-transparent border border-border-1 text-foreground-1 hover:bg-background-2`
+      tertiary: `bg-transparent border border-border-1 text-foreground-1 hover:bg-background-2`,
+      transparent: `bg-[rgba(255,255,255,0.1)] border-1 border-[rgba(255,255,255,0.1)] backdrop-blur-[32px] hover:bg-[rgba(255,255,255,0.15)]`
     }[variant];
 
     const sizeStyles = {

--- a/new-dti-website-redesign/src/components/CtaSection.tsx
+++ b/new-dti-website-redesign/src/components/CtaSection.tsx
@@ -1,4 +1,6 @@
-import React, { ReactNode } from 'react';
+'use client';
+
+import React, { ReactNode, useEffect, useRef } from 'react';
 import Button from './Button';
 
 type Props = {
@@ -17,10 +19,36 @@ const CtaSection = ({
   button1Link,
   button2Label,
   button2Link
-}: Props): ReactNode => (
-  <section className="flex flex-col-reverse md:flex-col">
-    <div className="flex flex-col outline-[0.5px] outline-accent-green  p-4 sm:px-8 sm:py-16">
-      <div className="flex flex-col m-auto  items-center gap-4 max-w-120">
+}: Props): ReactNode => {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  // Adds bottom border radius and overflow hidden to the previous sibling element
+  useEffect(() => {
+    if (sectionRef.current) {
+      const prevSibling = sectionRef.current.previousElementSibling as HTMLElement | null;
+      if (prevSibling) {
+        prevSibling.classList.add('rounded-b-2xl', 'overflow-hidden');
+      }
+    }
+  }, []);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="ctaSection flex flex-col-reverse md:flex-col h-125 justify-center
+  bg-[url(/CtaSection.jpg)] bg-no-repeat bg-center bg-cover relative mt-8"
+    >
+      <div
+        className="absolute inset-0 w-full h-full z-[5]"
+        style={{
+          backgroundImage: `
+      radial-gradient(262.42% 155.53% at 50% 153.47%, color-mix(in srgb, var(--background-1) 0%, transparent) 11.11%, var(--background-1) 100%),
+      radial-gradient(95.79% 95.78% at 50% 0%, color-mix(in srgb, var(--background-1) 0%, transparent) 21.15%, var(--background-1) 100%)
+    `
+        }}
+      ></div>
+
+      <div className="z-10 flex flex-col m-auto p-4 sm:px-8 sm:py-16 items-center gap-4 max-w-120">
         <div className="flex flex-col items-center gap-2">
           <h2 className="text-center">{heading}</h2>
           <p className="h6 text-center text-foreground-3">{subheading}</p>
@@ -32,7 +60,7 @@ const CtaSection = ({
           )}
           {button2Label && button2Link && (
             <Button
-              variant="secondary"
+              variant="transparent"
               label={button2Label}
               href={button2Link}
               className="w-full"
@@ -40,8 +68,8 @@ const CtaSection = ({
           )}
         </div>
       </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};
 
 export default CtaSection;

--- a/new-dti-website-redesign/src/components/Footer.tsx
+++ b/new-dti-website-redesign/src/components/Footer.tsx
@@ -203,7 +203,11 @@ export default function Footer() {
   );
 
   return (
-    <footer className="bg-background-1 relative max-w-[1184px] mx-4 sm:mx-8 md:mx-32 lg:mx-auto border-1 border-b-0 border-border-1">
+    <footer
+      className="max-w-[1184px] mx-4 sm:mx-8 md:mx-32 lg:mx-auto rounded-t-2xl bg-[linear-gradient(to_bottom,#121212,#0D0D0D)] mt-1
+    
+    relative before:content-[''] before:absolute before:-top-px before:-left-px before:w-[calc(100%+2px)] before:h-[calc(100%+1px)] before:z-[-2] before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.1),rgba(255,255,255,0.02))] before:rounded-t-2xl"
+    >
       <div className="p-4 md:p-0 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
         <div className="md:p-8 md:pb-0 md:row-start-1 md:col-start-1 lg:row-auto lg:col-auto lg:pb-8">
           <DTILogoSection />

--- a/new-dti-website-redesign/src/components/Footer.tsx
+++ b/new-dti-website-redesign/src/components/Footer.tsx
@@ -205,7 +205,6 @@ export default function Footer() {
   return (
     <footer
       className="max-w-[1184px] sm:mx-8 md:mx-32 lg:mx-auto sm:rounded-t-2xl bg-[linear-gradient(to_bottom,#121212,#0D0D0D)] mt-1
-    
     relative before:content-[''] before:absolute before:-top-px before:-left-px before:w-[calc(100%+2px)] before:h-[calc(100%+1px)] before:z-[-2] before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.1),rgba(255,255,255,0.02))] before:sm:rounded-t-2xl"
     >
       <div className="p-4 md:p-0 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4">

--- a/new-dti-website-redesign/src/components/Footer.tsx
+++ b/new-dti-website-redesign/src/components/Footer.tsx
@@ -204,9 +204,9 @@ export default function Footer() {
 
   return (
     <footer
-      className="max-w-[1184px] mx-4 sm:mx-8 md:mx-32 lg:mx-auto rounded-t-2xl bg-[linear-gradient(to_bottom,#121212,#0D0D0D)] mt-1
+      className="max-w-[1184px] sm:mx-8 md:mx-32 lg:mx-auto sm:rounded-t-2xl bg-[linear-gradient(to_bottom,#121212,#0D0D0D)] mt-1
     
-    relative before:content-[''] before:absolute before:-top-px before:-left-px before:w-[calc(100%+2px)] before:h-[calc(100%+1px)] before:z-[-2] before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.1),rgba(255,255,255,0.02))] before:rounded-t-2xl"
+    relative before:content-[''] before:absolute before:-top-px before:-left-px before:w-[calc(100%+2px)] before:h-[calc(100%+1px)] before:z-[-2] before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.1),rgba(255,255,255,0.02))] before:sm:rounded-t-2xl"
     >
       <div className="p-4 md:p-0 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
         <div className="md:p-8 md:pb-0 md:row-start-1 md:col-start-1 lg:row-auto lg:col-auto lg:pb-8">

--- a/new-dti-website-redesign/src/components/Hero.tsx
+++ b/new-dti-website-redesign/src/components/Hero.tsx
@@ -31,7 +31,21 @@ const Hero = ({
         className="flex items-end h-[800px] relative bg-no-repeat bg-center bg-cover"
         style={{ backgroundImage: `url('${image}')` }}
       >
-        <div className="absolute inset-0 w-full h-full z-5 bg-[linear-gradient(181.82deg,rgba(13,13,13,0.9)_1.54%,rgba(13,13,13,0.2)_75.51%),radial-gradient(116.68%_116.67%_at_50%_-16.67%,rgba(13,13,13,0)_40%,#0D0D0D_100%)]"></div>
+        <div
+          className="absolute inset-0 w-full h-full z-[5]"
+          style={{
+            backgroundImage: `
+            linear-gradient(181.82deg,
+              color-mix(in srgb, var(--background-1) 90%, transparent) 1.54%,
+              color-mix(in srgb, var(--background-1) 20%, transparent) 75.51%
+            ),
+            radial-gradient(116.68% 116.67% at 50% -16.67%,
+              transparent 40%,
+              var(--background-1) 100%
+            )
+          `
+          }}
+        ></div>
 
         <div className="flex flex-col md:flex-row z-10 md:items-center w-full p-8 pb-16 max-w-[1184px] mx-auto gap-4">
           <div className="flex flex-col gap-1 md:max-w-1/2">

--- a/new-dti-website-redesign/src/components/Hero.tsx
+++ b/new-dti-website-redesign/src/components/Hero.tsx
@@ -35,7 +35,7 @@ const Hero = ({
           className="absolute inset-0 w-full h-full z-[5]"
           style={{
             backgroundImage: `
-            linear-gradient(181.82deg,
+          linear-gradient(181.82deg,
               color-mix(in srgb, var(--background-1) 90%, transparent) 1.54%,
               color-mix(in srgb, var(--background-1) 20%, transparent) 75.51%
             ),
@@ -65,7 +65,7 @@ const Hero = ({
               )}
               {button2Label && button2Link && (
                 <Button
-                  variant="secondary"
+                  variant="transparent"
                   label={button2Label}
                   href={button2Link}
                   className="w-fit"


### PR DESCRIPTION
# Changes

- Added a `transparent` variant to `<Button>`, and update the design system library to show the change
- Changed the `<CtaSection>` component to include a full bleed background image (similar to the `<Hero>`)
- Some colorstylistic changes to `<Footer>`



# Pictures

|X|Before|After|
|-|-|-|
|CTA Section|<img width="1505" alt="Screenshot 2025-05-22 at 12 20 35 AM" src="https://github.com/user-attachments/assets/6b298ab2-86b5-4ac1-b10f-f618c9571a61" />|<img width="1505" alt="Screenshot 2025-05-22 at 12 21 02 AM" src="https://github.com/user-attachments/assets/bf7bd594-e5df-42fc-a5a6-9389ee6c9566" />
|Footer|<img width="1503" alt="Screenshot 2025-05-22 at 12 20 13 AM" src="https://github.com/user-attachments/assets/288cc9ac-b78b-48e9-ba45-695678fb513d" />|<img width="1503" alt="Screenshot 2025-05-22 at 12 19 43 AM" src="https://github.com/user-attachments/assets/8a495448-3d52-4d82-828c-a9ef770872dc" />|


# Test plan

- Go to `/design-system`, go to Button, make sure new transparent button variant is there:
<img width="300" alt="Screenshot 2025-05-22 at 12 21 33 AM" src="https://github.com/user-attachments/assets/468e5e0e-1a94-4473-a019-e24b198d6960" />

- Head to every page in the navbar, scroll to the bottom, ensure that the CTa section and the footer reflect the new changes
- Also ensure that the element right before the Cta section has a bottom border radius
- 


