### PR TITLE
[New Website] Mobile nav & banner polish, added "Skip to main" link

### DIFF
--- a/new-dti-website-redesign/src/app/design-system/PageLayout.tsx
+++ b/new-dti-website-redesign/src/app/design-system/PageLayout.tsx
@@ -17,7 +17,7 @@ export default function PageLayout({
     <div className="flex flex-1">
       <Sidebar />
 
-      <main className={`flex-1 !pt-0 ml-[261px] ${className}`}>
+      <main className={`flex-1 !pt-0 ml-[261px] ${className}`} id="main-content">
         <section className="p-12 flex flex-col gap-2">
           <h1>{title}</h1>
           {description && <p className="text-foreground-3 h6">{description}</p>}

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
           href="#main-content"
           className={`${baseStyles} absolute -inset-4 opacity-0 z-70
           focus-visible:opacity-100 ${
-            skipToMainOffset ? 'focus-visible:top-16' : 'focus-visible:top-4'
+            skipToMainOffset ? 'focus-visible:top-20' : 'focus-visible:top-4'
           } focus-visible:left-4 transition-all duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit`}
         >
           Skip to main content

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
         <a
           id="skip-to-main"
           href="#main-content"
-          className={`${baseStyles} absolute -inset-4 opacity-0 z-50 p-2
+          className={`${baseStyles} absolute -inset-4 opacity-0 z-50
           focus-visible:opacity-100 focus-visible:top-4 focus-visible:left-4 transition-all duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit`}
         >
           Skip to main content

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -12,7 +12,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const pathname = usePathname();
+
+  // on design system pages, we don't want to show the navbar
   const shouldShowNavbar = !pathname.startsWith('/design-system');
+
+  // on apply page, we want the "Skip to main content" link to be more offset (because of the banner)
+  const skipToMainOffset = pathname.startsWith('/apply');
 
   // Focus <body> on route change to reset tab order
   useEffect(() => {
@@ -29,7 +34,9 @@ export default function RootLayout({
           id="skip-to-main"
           href="#main-content"
           className={`${baseStyles} absolute -inset-4 opacity-0 z-70
-          focus-visible:opacity-100 focus-visible:top-4 focus-visible:left-4 transition-all duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit`}
+          focus-visible:opacity-100 ${
+            skipToMainOffset ? 'focus-visible:top-16' : 'focus-visible:top-4'
+          } focus-visible:left-4 transition-all duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit`}
         >
           Skip to main content
         </a>

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
         <a
           id="skip-to-main"
           href="#main-content"
-          className={`${baseStyles} absolute -inset-4 opacity-0 z-50
+          className={`${baseStyles} absolute -inset-4 opacity-0 z-70
           focus-visible:opacity-100 focus-visible:top-4 focus-visible:left-4 transition-all duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit`}
         >
           Skip to main content

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import './globals.css';
 import { usePathname } from 'next/navigation';
 import Navbar from '../components/Navbar';
@@ -12,9 +13,26 @@ export default function RootLayout({
   const pathname = usePathname();
   const shouldShowNavbar = !pathname.startsWith('/design-system');
 
+  // Focus <body> on route change to reset tab order
+  useEffect(() => {
+    const body = document.body;
+    if (body) {
+      body.focus();
+    }
+  }, [pathname]);
+
   return (
     <html lang="en">
-      <body>
+      <body className="relative" tabIndex={-1}>
+        <a
+          id="skip-to-main"
+          href="#main-content"
+          className="absolute -inset-4 opacity-0 z-50 p-2
+          focus-visible:opacity-100 focus-visible:top-4 focus-visible:left-4 transition-[top] duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit rounded-full flex items-center justify-center font-medium focusState"
+        >
+          Skip to main content
+        </a>
+
         {shouldShowNavbar && <Navbar />}
         {children}
       </body>

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import './globals.css';
 import { usePathname } from 'next/navigation';
 import Navbar from '../components/Navbar';
+import { baseStyles } from '../components/Button';
 
 export default function RootLayout({
   children
@@ -27,8 +28,8 @@ export default function RootLayout({
         <a
           id="skip-to-main"
           href="#main-content"
-          className="absolute -inset-4 opacity-0 z-50 p-2
-          focus-visible:opacity-100 focus-visible:top-4 focus-visible:left-4 transition-[top, background-color] duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit rounded-full flex items-center justify-center font-medium focusState "
+          className={`${baseStyles} absolute -inset-4 opacity-0 z-50 p-2
+          focus-visible:opacity-100 focus-visible:top-4 focus-visible:left-4 transition-all duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit`}
         >
           Skip to main content
         </a>

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
           id="skip-to-main"
           href="#main-content"
           className="absolute -inset-4 opacity-0 z-50 p-2
-          focus-visible:opacity-100 focus-visible:top-4 focus-visible:left-4 transition-[top] duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit rounded-full flex items-center justify-center font-medium focusState"
+          focus-visible:opacity-100 focus-visible:top-4 focus-visible:left-4 transition-[top, background-color] duration-[120ms] px-6 h-12 bg-foreground-1 text-background-1 hover:bg-foreground-2 w-fit rounded-full flex items-center justify-center font-medium focusState "
         >
           Skip to main content
         </a>

--- a/new-dti-website-redesign/src/app/layout.tsx
+++ b/new-dti-website-redesign/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 
   // Focus <body> on route change to reset tab order
   useEffect(() => {
-    const body = document.body;
+    const { body } = document;
     if (body) {
       body.focus();
     }

--- a/new-dti-website-redesign/src/app/page.tsx
+++ b/new-dti-website-redesign/src/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
           imagePosition="right"
           imageAlt="DTI members in front of a whiteboard pasting sticky notes in a brainstorming session"
           button2Label="Learn more"
-          button2Link="/courses"
+          button2Link="/course"
         />
 
         <FeatureSection

--- a/new-dti-website-redesign/src/components/Banner.tsx
+++ b/new-dti-website-redesign/src/components/Banner.tsx
@@ -5,15 +5,15 @@ type Props = {
 };
 
 const Banner = ({ label }: Props): ReactNode => (
-  <div className="flex items-center justify-center sticky top-[72px] z-20 min-[1200px]:pt-4 min-[1200px]:mt-[-67px] w-fit mx-auto">
+  <div className="flex items-center justify-center sticky top-[72px] z-20 md:pt-4 md:mt-[-67px] w-fit mx-auto">
     <div
       className="
-        px-5 py-4 md:py-3 text-center w-full min-[1200px]:w-fit
+        px-5 py-4 md:py-3 text-center w-full md:w-fit
         border-t-1 border-b-1 border-t-border-1 border-b-border-1
-        min-[1200px]:border-t min-[1200px]:border-b min-[1200px]:border-border-1-transparent
-        min-[1200px]:rounded-full
-        bg-background-2 min-[1200px]:bg-background-3-transparent
-        backdrop-blur-[32px] min-[1200px]:mx-auto
+        md:border-t md:border-b md:border-border-1-transparent
+        md:rounded-full
+        bg-background-2 md:bg-background-3-transparent
+        backdrop-blur-[32px] md:mx-auto
       "
     >
       <p>{label}</p>

--- a/new-dti-website-redesign/src/components/Banner.tsx
+++ b/new-dti-website-redesign/src/components/Banner.tsx
@@ -5,7 +5,7 @@ type Props = {
 };
 
 const Banner = ({ label }: Props): ReactNode => (
-  <div className="flex items-center justify-center sticky top-20 z-20 min-[1200px]:pt-4 min-[1200px]:mt-[-67px]">
+  <div className="flex items-center justify-center sticky top-[72px] z-20 min-[1200px]:pt-4 min-[1200px]:mt-[-67px] w-fit mx-auto">
     <div
       className="
         px-5 py-4 md:py-3 text-center w-full min-[1200px]:w-fit

--- a/new-dti-website-redesign/src/components/Button.tsx
+++ b/new-dti-website-redesign/src/components/Button.tsx
@@ -4,6 +4,8 @@ import { forwardRef } from 'react';
 import Link from 'next/link';
 import type { ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
 
+export const baseStyles = `w-fit rounded-full cursor-pointer inline-flex items-center justify-center gap-2 transition-[background-color] duration-[120ms] focusState text-nowrap`;
+
 type ButtonProps = {
   label: string;
   href?: string;
@@ -32,9 +34,6 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
     },
     ref
   ) => {
-    const baseStyles = `w-fit rounded-full cursor-pointer inline-flex items-center justify-center gap-2
-        transition-[background-color] duration-[120ms] focusState text-nowrap`;
-
     const variantStyles = {
       primary: `bg-foreground-1 text-background-1 hover:bg-foreground-2 ${
         badge ? 'gap-1 pr-3' : ''

--- a/new-dti-website-redesign/src/components/Layout.tsx
+++ b/new-dti-website-redesign/src/components/Layout.tsx
@@ -12,7 +12,9 @@ const Layout = ({ children }: Props): React.ReactElement => (
   <>
     <DevNavbar />
 
-    <main role="main">{children}</main>
+    <main role="main" id="main-content">
+      {children}
+    </main>
 
     <Footer />
   </>

--- a/new-dti-website-redesign/src/components/Navbar.tsx
+++ b/new-dti-website-redesign/src/components/Navbar.tsx
@@ -115,6 +115,23 @@ export default function Navbar() {
     };
   }, []);
 
+  // ############################################
+  // REMOVE SCROLL ON BODY WHEN MOBILE MENU OPEN:
+  // ############################################
+
+  useEffect(() => {
+    if (mobileOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    // Clean up on component unmount
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [mobileOpen]);
+
   return (
     <>
       <nav


### PR DESCRIPTION
# Changes

- Made `<Banner>` flushed top to the navbar
- Fixed bug where you could scroll on rest of page when mobile navbar was open
- Added `id`s to `<main>`
- added "Skip to main content" links

# Video


https://github.com/user-attachments/assets/9a52fa39-2e42-4320-8920-1019bfac71a5

# Test plan

### Skip to main content link

It's a little technical but here are some instructions

- Open `localhost:3000`
- Press `tab`
  - Ensure that the "Skip to main content" link is visible
- Press `tab` a few times 
  - Ensure that you're able to navigate around the links **in the navbar** (eg: logo, Team, Products, Course, etc.)
- Reload the page and press `tab` once again
  - Now click `enter`
  - Ensure that when you press `tab` again, you skip over all the links in the navbar. 
  - The first focused element should be the white CTA button in the hero section (eg: "Apply to DTI")
- Then, using `tab`, navigate to some other page using any of the links 
- Press `tab` again, and ensure that "Skip to main content" is still the first element that you focus on


### Banner

- To test the banner, open the website and resize the window
- Head to `/apply` 
- Make sure there isn't an awkward gap between the banner and the navbar (like [this](https://github.com/cornell-dti/idol/pull/972#discussion_r2101676524) – it should be completely flushed)
