### PR TITLE
[New Website] Added compliance text to footer

### DIFF
--- a/new-dti-website-redesign/src/components/Footer.tsx
+++ b/new-dti-website-redesign/src/components/Footer.tsx
@@ -142,7 +142,7 @@ export default function Footer() {
   return (
     <footer
       className="max-w-[1184px] mx-auto sm:rounded-t-2xl bg-[linear-gradient(to_bottom,#121212,#0D0D0D)] !mt-px
-    relative before:content-[''] before:absolute before:-top-px before:-left-px before:w-[calc(100%+2px)] before:h-[calc(100%+1px)] before:z-[-2] before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.1),rgba(255,255,255,0.02))] before:sm:rounded-t-2xl"
+    relative before:content-[''] before:absolute before:-top-px before:-left-px before:w-[calc(100%+2px)] before:h-[calc(100%+1px)] before:z-[-2] before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.1),rgba(255,255,255,0.02))] before:sm:rounded-t-2xl flex flex-col gap-2"
     >
       <div className="flex flex-col min-[1000px]:flex-row ">
         <div className="w-full sm:w-3/4 min-[1000px]:w-1/4 p-4 sm:p-8">
@@ -171,6 +171,17 @@ export default function Footer() {
               });
             }}
           />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-8 p-4 sm:p-8 pt-0">
+        <div className="w-full h-px bg-border-1" />
+
+        <div className="sm:flex-row flex-col flex sm:gap-0 gap-4 justify-between">
+          <p className="!text-sm text-foreground-3">
+            This organization is a registered student organization of Cornell University.
+          </p>
+          <p className="!text-sm text-foreground-3">&copy; 2025 Cornell DTI</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
- Leads wanted this text to figure on the footer for compliance ([slack link](https://cornelldti.slack.com/archives/C0960JD5BLK/p1753487763331439))


<img width="1505" height="1113" alt="Screenshot 2025-07-27 at 1 54 15 PM" src="https://github.com/user-attachments/assets/908460e5-849e-4b84-83e2-a5922c455e04" />


Also added copyright notice

Test plan: open new website, scroll to bottom, ensure footer has text