### PR TITLE
specify pm apps only open to upperclassmen

### DIFF
--- a/new-dti-website-redesign/src/app/apply/roleDescriptions.json
+++ b/new-dti-website-redesign/src/app/apply/roleDescriptions.json
@@ -53,7 +53,8 @@
       "Understanding of user needs and product thinking/the product cycle",
       "Eagerness to lead and build team culture",
       "Excellent organization, communication, and documentation skills",
-      "Familiarity with coding and/or design recommended but not required"
+      "Familiarity with coding and/or design recommended but not required",
+      "Must be a member of the Class of 2028"
     ],
     "responsibilities": [
       "Determine high-level product direction based on changing user needs and situations",


### PR DESCRIPTION
### Summary <!-- Required -->
PMs are only recruiting upperclassmen for the upperclassmen cycle.