### PR TITLE
add incubator, remove product redirects

### DIFF
--- a/new-dti-website-redesign/src/components/TeamCard.tsx
+++ b/new-dti-website-redesign/src/components/TeamCard.tsx
@@ -158,18 +158,23 @@ export const MemberDetailsCard = ({
             </div>
             <div className="w-1/2">
               <p className="text-foreground-3">Subteam</p>
-              {user.subteams[0] in productLinks ? (
-                <Link
-                  className="flex gap-2 items-center focusState w-fit rounded-sm"
-                  target="_blank"
-                  href={productLinks[user.subteams[0]].link}
-                >
-                  <p className="underline underline-offset-3">
+              {user.subteams.length > 0 &&
+                (productLinks[user.subteams[0]] && productLinks[user.subteams[0]].link ? (
+                  <Link
+                    className="flex gap-2 items-center focusState w-fit rounded-sm"
+                    target="_blank"
+                    href={productLinks[user.subteams[0]].link as string}
+                  >
+                    <p className="underline underline-offset-3">
+                      {productLinks[user.subteams[0]].name}
+                    </p>
+                    <OpenIcon size={20} />
+                  </Link>
+                ) : (
+                  <p>
                     {productLinks[user.subteams[0]].name}
                   </p>
-                  <OpenIcon size={20} />
-                </Link>
-              ) : null}
+                ))}
             </div>
           </div>
           <div>

--- a/new-dti-website-redesign/src/components/TeamCard.tsx
+++ b/new-dti-website-redesign/src/components/TeamCard.tsx
@@ -171,9 +171,7 @@ export const MemberDetailsCard = ({
                     <OpenIcon size={20} />
                   </Link>
                 ) : (
-                  <p>
-                    {productLinks[user.subteams[0]].name}
-                  </p>
+                  <p>{productLinks[user.subteams[0]].name}</p>
                 ))}
             </div>
           </div>

--- a/new-dti-website-redesign/src/utils/memberUtils.ts
+++ b/new-dti-website-redesign/src/utils/memberUtils.ts
@@ -76,22 +76,22 @@ export const productLinks: { [key: string]: { name: string; link?: string } } = 
     link: 'https://www.cornelldti.org'
   },
   cornellgo: {
-    name: 'Cornell GO',
+    name: 'Cornell GO'
   },
   carriage: {
-    name: 'Carriage',
+    name: 'Carriage'
   },
   leads: {
-    name: 'Lead',
+    name: 'Lead'
   },
   business: {
-    name: 'Business',
+    name: 'Business'
   },
   curaise: {
-    name: 'CU Raise',
+    name: 'CU Raise'
   },
   incubator: {
-    name: 'Incubator',
+    name: 'Incubator'
   },
   zing: {
     name: 'Zing',

--- a/new-dti-website-redesign/src/utils/memberUtils.ts
+++ b/new-dti-website-redesign/src/utils/memberUtils.ts
@@ -54,7 +54,7 @@ export const getRoleColor = (role: Role): string => {
   return colors[generalRole];
 };
 
-export const productLinks: { [key: string]: { name: string; link: string } } = {
+export const productLinks: { [key: string]: { name: string; link?: string } } = {
   courseplan: {
     name: 'CoursePlan',
     link: 'https://courseplan.io/'
@@ -77,23 +77,21 @@ export const productLinks: { [key: string]: { name: string; link: string } } = {
   },
   cornellgo: {
     name: 'Cornell GO',
-    link: ''
   },
   carriage: {
     name: 'Carriage',
-    link: ''
   },
   leads: {
     name: 'Lead',
-    link: ''
   },
   business: {
     name: 'Business',
-    link: ''
   },
   curaise: {
     name: 'CU Raise',
-    link: ''
+  },
+  incubator: {
+    name: 'Incubator',
   },
   zing: {
     name: 'Zing',


### PR DESCRIPTION
### Summary <!-- Required -->
Incubator members' subteam was not being properly displayed. Furthermore, products with no links were being hyperlinked to the team website (e.g. Lead, CU Raise). This PR fixes both bugs.

### Test Plan <!-- Required -->
Verify incubator shows up for incubator members.
<img width="556" height="181" alt="Screenshot 2025-08-29 at 2 15 13 PM" src="https://github.com/user-attachments/assets/e767c0d9-e7a2-4d9a-a95e-3eb738a6405b" />
Verify products with no links do not link to the team page anymore.
<img width="525" height="173" alt="Screenshot 2025-08-29 at 2 16 32 PM" src="https://github.com/user-attachments/assets/84559c2d-c889-4970-8f39-94d758f24858" />
