### PR TITLE
add accepted applicant summary to app dashboard

### DIFF
--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
@@ -274,12 +274,14 @@ const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
 
   const getSummaryText = () => {
     if (selectedRound === 'All Rounds') {
-      return ROUND_OPTIONS.map(round => {
-        const acceptedCount = filteredApplicants.filter(a => a.round === round.value && a.status === 'Accepted').length;
+      return ROUND_OPTIONS.map((round) => {
+        const acceptedCount = filteredApplicants.filter(
+          (a) => a.round === round.value && a.status === 'Accepted'
+        ).length;
         return `${round.text}: ${acceptedCount} accepted`;
       }).join(' | ');
     } else {
-      const acceptedCount = filteredApplicants.filter(a => a.status === 'Accepted').length;
+      const acceptedCount = filteredApplicants.filter((a) => a.status === 'Accepted').length;
       return `${selectedRound}: ${acceptedCount} accepted`;
     }
   };

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
@@ -274,10 +274,9 @@ const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
 
   const getSummaryText = () => {
     if (selectedRound === 'All Rounds') {
-      const uniqueRounds = Array.from(new Set(filteredApplicants.map(a => a.round)));
-      return uniqueRounds.map(round => {
-        const acceptedCount = filteredApplicants.filter(a => a.round === round && a.status === 'Accepted').length;
-        return `${round}: ${acceptedCount} accepted`;
+      return ROUND_OPTIONS.map(round => {
+        const acceptedCount = filteredApplicants.filter(a => a.round === round.value && a.status === 'Accepted').length;
+        return `${round.text}: ${acceptedCount} accepted`;
       }).join(' | ');
     } else {
       const acceptedCount = filteredApplicants.filter(a => a.status === 'Accepted').length;

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
@@ -280,10 +280,9 @@ const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
         ).length;
         return `${round.text}: ${acceptedCount} accepted`;
       }).join(' | ');
-    } else {
-      const acceptedCount = filteredApplicants.filter((a) => a.status === 'Accepted').length;
-      return `${selectedRound}: ${acceptedCount} accepted`;
     }
+    const acceptedCount = filteredApplicants.filter((a) => a.status === 'Accepted').length;
+    return `${selectedRound}: ${acceptedCount} accepted`;
   };
 
   return (

--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
@@ -272,6 +272,19 @@ const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
 
   const getColor = (status: InterviewStatus): string => colors[status.status] || 'inherit';
 
+  const getSummaryText = () => {
+    if (selectedRound === 'All Rounds') {
+      const uniqueRounds = Array.from(new Set(filteredApplicants.map(a => a.round)));
+      return uniqueRounds.map(round => {
+        const acceptedCount = filteredApplicants.filter(a => a.round === round && a.status === 'Accepted').length;
+        return `${round}: ${acceptedCount} accepted`;
+      }).join(' | ');
+    } else {
+      const acceptedCount = filteredApplicants.filter(a => a.status === 'Accepted').length;
+      return `${selectedRound}: ${acceptedCount} accepted`;
+    }
+  };
+
   return (
     <div className={styles.dashboardContainer}>
       <Header as="h1">Interview Status Dashboard</Header>
@@ -344,6 +357,14 @@ const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
             </Table.Row>
           ))}
         </Table.Body>
+        <Table.Footer>
+          <Table.Row>
+            <Table.HeaderCell colSpan="6">
+              <strong>Applicant summary: </strong>
+              {getSummaryText()}
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Footer>
       </Table>
       <div className={styles.addForm}>
         <CSVUploadInterviewStatus instanceName={instanceName} onDone={refresh} />


### PR DESCRIPTION
### Summary <!-- Required -->
- Added a summary row to bottom of dashboard table listing how many applicants are accepted for each round

### Notion

[Edit application dashboard](https://www.notion.so/FA25-Roadmap-2410ad723ce18141927bea8c5860f4ab?p=2410ad723ce181ef8c39f9602396c0c8&pm=s)

### Test Plan <!-- Required -->
- Go to Interview Status Dashboard
- Add applicants with different statuses
- Check that the summary row at the bottom of table updates accordingly
- Filter by different rounds/applicants and check updated counts


<img width="1080" height="76" alt="Screenshot 2025-09-02 at 5 28 25 PM" src="https://github.com/user-attachments/assets/a28569a0-55a2-4af5-b077-aace1bbcc4a1" />
