### PR TITLE
update candidate decider to 6 options and fix candidate indexing

### DIFF
--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -156,7 +156,7 @@ interface Image {
   readonly fileName: string;
 }
 
-type Rating = 0 | 1 | 2 | 3 | 4 | 5;
+type Rating = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 interface CandidateDeciderRating {
   readonly reviewer: IdolMember;

--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -21,9 +21,10 @@ type CandidateDeciderProps = {
 const ratings: RatingOptions[] = [
   { value: 1, text: 'Strong No', color: 'red' },
   { value: 2, text: 'No', color: 'orange' },
-  { value: 3, text: 'Maybe', color: 'yellow' },
-  { value: 4, text: 'Yes', color: 'green' },
-  { value: 5, text: 'Strong Yes', color: 'darkgreen' },
+  { value: 3, text: 'Lean No', color: 'yellow' },
+  { value: 4, text: 'Lean Yes', color: 'lightgreen' },
+  { value: 5, text: 'Yes', color: 'green' },
+  { value: 6, text: 'Strong Yes', color: 'darkgreen' },
   { value: 0, text: 'Undecided', color: 'gray' }
 ];
 

--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -30,10 +30,10 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
         <>
           <RatingsDisplay
             ratings={currentCandidateReviews}
-            header={`Candidate ${currentCandidate} Global Ratings`}
+            header={`Candidate ${currentCandidate + 1} Global Ratings`}
           />
           <div>
-            <h3>All Votes on Candidate {currentCandidate}</h3>
+            <h3>All Votes on Candidate {currentCandidate + 1}</h3>
             <div className={styles.verticalContentContainer}>
               {currentCandidateReviews
                 .filter((rating) => rating.rating !== 0)
@@ -46,7 +46,7 @@ const LocalProgressPanel: React.FC<ProgressPanelProps> = ({
                   )}`}</span>
                 ))}
             </div>
-            <h3>All Comments on Candidate {currentCandidate}</h3>
+            <h3>All Comments on Candidate {currentCandidate + 1}</h3>
             <div className={styles.verticalContentContainer}>
               {currentCandidateReviews.map((review) => (
                 <span

--- a/frontend/src/components/Candidate-Decider/RatingsDisplay.tsx
+++ b/frontend/src/components/Candidate-Decider/RatingsDisplay.tsx
@@ -26,7 +26,7 @@ const StyledProgressBar = styled(Progress)`
 
 const RatingsDisplay: React.FC<Props> = ({ ratings, header }) => {
   const counts = groupRatings(ratings);
-  const allRatings: Rating[] = [1, 2, 3, 4, 5];
+  const allRatings: Rating[] = [1, 2, 3, 4, 5, 6];
   return (
     <div className={styles.statisticsList}>
       <h3>{header}</h3>

--- a/frontend/src/components/Candidate-Decider/ratings-utils.ts
+++ b/frontend/src/components/Candidate-Decider/ratings-utils.ts
@@ -5,10 +5,12 @@ export const ratingToString = (rating: number): string => {
     case 2:
       return 'No';
     case 3:
-      return 'Maybe';
+      return 'Lean No';
     case 4:
-      return 'Yes';
+      return 'Lean Yes';
     case 5:
+      return 'Yes';
+    case 6:
       return 'Strong Yes';
     default:
       throw new Error();
@@ -29,6 +31,8 @@ export const ratingToColor = (rating: Rating): string => {
       return 'olive';
     case 5:
       return 'green';
+    case 6:
+      return 'teal';
     default:
       throw new Error();
   }

--- a/frontend/src/components/Common/Selector/Selector.module.css
+++ b/frontend/src/components/Common/Selector/Selector.module.css
@@ -41,10 +41,17 @@
 }
 
 .yellow {
-  color: var(--accent-maybe);
+  color: var(--accent-lean-no);
 }
 .yellowSelected {
-  background: var(--accent-maybe);
+  background: var(--accent-lean-no);
+}
+
+.lightgreen {
+  color: var(--accent-lean-yes)
+}
+.lightgreenSelected {
+  background: var(--accent-lean-yes)
 }
 
 .green {

--- a/frontend/src/components/Common/Selector/Selector.tsx
+++ b/frontend/src/components/Common/Selector/Selector.tsx
@@ -4,7 +4,7 @@ import styles from './Selector.module.css';
 export interface RatingOptions {
   value: number;
   text: string;
-  color: 'red' | 'orange' | 'yellow' | 'green' | 'darkgreen' | 'gray';
+  color: 'red' | 'orange' | 'yellow' | 'lightgreen' | 'green' | 'darkgreen' | 'gray';
 }
 
 interface SelectorProps {

--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -15,7 +15,8 @@
   --accent-focus: #0e4dd4;
   --accent-strong-no: #d8001b;
   --accent-no: #ff676c;
-  --accent-maybe: #ff9300;
+  --accent-lean-no: #ff9300;
+  --accent-lean-yes: #7eb133;
   --accent-yes: #28a948;
   --accent-strong-yes: #0a6e29;
 }

--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -18,7 +18,7 @@
   --accent-lean-no: #ff9300;
   --accent-lean-yes: #7eb133;
   --accent-yes: #28a948;
-  --accent-strong-yes: #0a6e29;
+  --accent-strong-yes: #008080;
 }
 
 * {


### PR DESCRIPTION
### Summary <!-- Required -->
This PR introduces hotfixes before the first round of deliberations. There were discrepancies between candidate ids being 0 or 1 indexed. This has now been changed to 1-indexing to be consistent. Leads wanted to increase final selection options from 5 to 6 to force deliberators to choose one side and not the middle ground of `Maybe`. 

### Test Plan <!-- Required -->
Verified functionalities remained the same in local progress bar and aggregate scoring. 
<img width="557" height="183" alt="Screenshot 2025-09-05 at 1 21 18 AM" src="https://github.com/user-attachments/assets/6bd31bc5-5482-4685-bfae-1d114b526167" />
<img width="567" height="122" alt="Screenshot 2025-09-05 at 1 22 12 AM" src="https://github.com/user-attachments/assets/0e1e0685-d810-4a1c-a705-d950502890df" />
<img width="572" height="270" alt="Screenshot 2025-09-05 at 1 23 23 AM" src="https://github.com/user-attachments/assets/52b9783a-9382-4c23-b728-2726ba72c349" />
