### PR TITLE
Fix Filter Bug for Interview Status Dashboard

### DIFF
--- a/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
+++ b/frontend/src/components/Admin/InterviewStatus/InterviewStatusDashboard.tsx
@@ -70,7 +70,7 @@ const InterviewStatusDashboard: React.FC<InterviewStatusDashboardProps> = ({
 
     if (applicantFilters.length > 0) {
       filtered = filtered.filter((applicant) =>
-        applicantFilters.every(
+        applicantFilters.some(
           (filter) => applicant.status === filter || applicant.role === DISPLAY_TO_ROLE_MAP[filter]
         )
       );


### PR DESCRIPTION
### Summary

This pull request fixes a minor bug where the Interview Status Dashboard only displayed results matching _all_ selected filters instead of _any_.

### Test Plan 

<img width="1156" height="476" alt="Screenshot 2025-09-05 at 12 33 20 PM" src="https://github.com/user-attachments/assets/c2edfc9a-f83b-46fe-952d-3da1de9a1e71" />

1. Apply multiple filters in the Interview Status Dashboard.
2. Verify that results include instances matching _any_ of the selected filters.
3. Confirm that results update correctly when filters are added or removed.
