### PR TITLE
add different displays for interview scheduler calendar

### DIFF
--- a/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
+++ b/frontend/src/components/Interview-Scheduler/InterviewScheduler.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Card, Header, Message } from 'semantic-ui-react';
+import { Button, Card, Dropdown, Header, Message } from 'semantic-ui-react';
 import Link from 'next/link';
 import { LEAD_ROLES } from 'common-types/constants';
 import InterviewSchedulerAPI from '../../API/InterviewSchedulerAPI';
@@ -8,8 +8,27 @@ import styles from './InterviewScheduler.module.css';
 import SchedulingCalendar from './SchedulingCalendar';
 import { Emitters, getDateString, getTimeString } from '../../utils';
 import SchedulingSidePanel from './SchedulingSidePanel';
-import { EditAvailabilityContext, SetSlotsContext } from './SlotHooks';
+import { EditAvailabilityContext, SchedulerDisplay, SetSlotsContext } from './SlotHooks';
 import { useUserEmail } from '../Common/UserProvider/UserProvider';
+
+const displayOptions: { text: string; value: SchedulerDisplay }[] = [
+  {
+    text: 'Time',
+    value: 'time'
+  },
+  {
+    text: 'Members',
+    value: 'member'
+  },
+  {
+    text: 'Applicants',
+    value: 'applicant'
+  },
+  {
+    text: 'Lead',
+    value: 'lead'
+  }
+];
 
 const formatDate = (date: Date): string => {
   const mm = String(date.getMonth() + 1).padStart(2, '0');
@@ -71,6 +90,7 @@ const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
   const [possessedSlot, setPossessedSlot] = useState<InterviewSlot | undefined>();
   const [isEditing, setIsEditing] = useState(false);
   const [tentativeSlots, setTentativeSlots] = useState<InterviewSlot[]>([]);
+  const [display, setDisplay] = useState<SchedulerDisplay>('time');
 
   const isMember = useHasMemberPermission();
   const userEmail = useUserEmail();
@@ -116,7 +136,7 @@ const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
       {!scheduler ? (
         <p>Loading...</p>
       ) : (
-        <SetSlotsContext.Provider value={{ setSlots, setSelectedSlot, setHoveredSlot }}>
+        <SetSlotsContext.Provider value={{ display, setSlots, setSelectedSlot, setHoveredSlot }}>
           <div className={styles.headerContainer}>
             <div>
               <Header as="h2">{scheduler.name}</Header>
@@ -147,15 +167,25 @@ const InterviewScheduler: React.FC<{ uuid: string }> = ({ uuid }) => {
                     </Button>
                   </div>
                 ) : (
-                  <Button
-                    basic
-                    onClick={() => {
-                      setIsEditing(true);
-                      setSelectedSlot(undefined);
-                    }}
-                  >
-                    Add availabilities
-                  </Button>
+                  <>
+                    <Dropdown
+                      selection
+                      value={display}
+                      options={displayOptions}
+                      onChange={(_, data) => {
+                        setDisplay(data.value as SchedulerDisplay);
+                      }}
+                    />
+                    <Button
+                      basic
+                      onClick={() => {
+                        setIsEditing(true);
+                        setSelectedSlot(undefined);
+                      }}
+                    >
+                      Add availabilities
+                    </Button>
+                  </>
                 )}
               </div>
             )}

--- a/frontend/src/components/Interview-Scheduler/SchedulingCalendar.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingCalendar.tsx
@@ -67,7 +67,7 @@ const SlotButton: React.FC<{
   startHour: number;
   tentative?: boolean;
 }> = ({ slot, duration, startHour, tentative = false }) => {
-  const { setHoveredSlot, setSelectedSlot } = useSetSlotsContext();
+  const { display, setHoveredSlot, setSelectedSlot } = useSetSlotsContext();
   const slotStatus = useInterviewSlotStatus(slot);
   const { isEditing, setTentativeSlots } = useEditAvailabilityContext();
 
@@ -87,6 +87,29 @@ const SlotButton: React.FC<{
       )
     );
 
+  let slotDisplay = '';
+  switch (display) {
+    case 'time':
+      slotDisplay = hourIndexToString(
+        new Date(slot.startTime).getHours(),
+        new Date(slot.startTime).getMinutes()
+      );
+      break;
+    case 'applicant':
+      slotDisplay =
+        slot.applicant == null
+          ? 'Vacant'
+          : `${slot.applicant.firstName} ${slot.applicant.lastName}`;
+      break;
+    case 'member':
+      slotDisplay = slot.members
+        .map((mem) => (mem == null ? 'Vacant' : `${mem.firstName} ${mem.lastName}`))
+        .join(', ');
+      break;
+    case 'lead':
+      slotDisplay = slot.lead == null ? 'Vacant' : `${slot.lead.firstName} ${slot.lead.lastName}`;
+  }
+
   return (
     <div onMouseEnter={() => setHoveredSlot(slot)} onMouseLeave={() => setHoveredSlot(undefined)}>
       <Button
@@ -99,10 +122,7 @@ const SlotButton: React.FC<{
         disabled={(isEditing && !tentative) || (!isLead && slotStatus === 'occupied')}
         color={slotStatus === 'possessed' ? 'green' : undefined}
       >
-        {hourIndexToString(
-          new Date(slot.startTime).getHours(),
-          new Date(slot.startTime).getMinutes()
-        )}
+        {slotDisplay}
       </Button>
     </div>
   );

--- a/frontend/src/components/Interview-Scheduler/SlotHooks.tsx
+++ b/frontend/src/components/Interview-Scheduler/SlotHooks.tsx
@@ -3,7 +3,10 @@ import { createContext, Dispatch, SetStateAction, useContext } from 'react';
 import { useHasMemberPermission, useMember } from '../Common/FirestoreDataProvider';
 import { useUserEmail } from '../Common/UserProvider/UserProvider';
 
+export type SchedulerDisplay = 'time' | 'lead' | 'member' | 'applicant';
+
 export const SetSlotsContext = createContext<{
+  display: SchedulerDisplay;
   setSlots: Dispatch<SetStateAction<InterviewSlot[]>>;
   setSelectedSlot: Dispatch<SetStateAction<InterviewSlot | undefined>>;
   setHoveredSlot: Dispatch<SetStateAction<InterviewSlot | undefined>>;


### PR DESCRIPTION
### Summary <!-- Required -->
To provide better visibility for interview scheduler, this PR adds different displays. This facilitates easier tracking of unfulfilled time slots. Previously, it just displayed the start time of the slot. Now, leads can choose to see three extra display options.
* Leads: displaying the name of the lead assigned to the slot.
* Members: displaying the name of the member(s) assigned to the slot, joined by comma.
* Applicant: displaying the name of the applicant.

### Test Plan <!-- Required -->
Member view:
<img width="300" height="250" alt="Screenshot 2025-09-06 at 10 00 31 PM" src="https://github.com/user-attachments/assets/bf477fba-65c6-4a72-bf97-4ce5f24e3b6e" />
Applicant view:
<img width="300" height="250" alt="Screenshot 2025-09-06 at 10 00 48 PM" src="https://github.com/user-attachments/assets/a55cd252-e92f-4e66-806d-f15f488a5844" />
Lead view:
<img width="300" height="250" alt="Screenshot 2025-09-06 at 10 01 16 PM" src="https://github.com/user-attachments/assets/d263086d-40ac-4517-82dc-84c5fda67625" />

