### PR TITLE
Update Coffee Chat Bingo Categories

### DIFF
--- a/backend/src/consts.ts
+++ b/backend/src/consts.ts
@@ -1,8 +1,8 @@
 const COFFEE_CHAT_BINGO_BOARD = [
-  ['has studied abroad', 'a newbie', 'plays DTI on roblox', 'sleeps before 12am'],
-  ['double major', 'uses windows', 'is an advisor', 'loves to cook'],
-  ['attended a hackathon', 'collects blindboxes', 'lives in ctown', 'plays a sport'],
-  ['lives on west', 'is left handed', 'has a digital camera', 'loves pineapple on pizza']
+  ['a newbie', 'owns a labubu', 'loves matcha', 'switched majors'],
+  ['from west coast', 'from NYC', 'sleeps with socks on', 'been on DTI for > 3 sem'],
+  ['runs regularly', 'can cook a signature dish', 'works on campus', 'loves to fish'],
+  ['dancer', 'not from the US', 'can whistle', 'has a sibling']
 ];
 
 export default COFFEE_CHAT_BINGO_BOARD;


### PR DESCRIPTION
### Summary <!-- Required -->
- Changed the coffee chat bingo categories to new FA25 ones 
- Will also reset current coffee chat history
- For future note: Coffee chat suggestions look like they need to be changed manually, so we might need to look into automating that

### Linear
[update coffee chat bingo](https://linear.app/cornelldti/issue/IDOL-24/update-coffee-chat-bingo)