### PR TITLE
keyboard shortcuts

### DIFF
--- a/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+import { useEffect, useState, Dispatch, SetStateAction, useCallback } from 'react';
 import { Modal } from 'semantic-ui-react';
 import CandidateDeciderAPI from '../../API/CandidateDeciderAPI';
 import ResponsesPanel from './ResponsesPanel';
@@ -13,6 +13,7 @@ import {
 import Button from '../Common/Button/Button';
 import Input from '../Common/Input/Input';
 import Selector, { RatingOptions } from '../Common/Selector/Selector';
+import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 
 type CandidateDeciderProps = {
   uuid: string;
@@ -56,20 +57,26 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const instance = useCandidateDeciderInstance(uuid);
   const [reviews, setReviews] = useCandidateDeciderReviews(uuid);
 
-  const getRating = (candidate: number) => {
-    const rating = reviews.find(
-      (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
-    );
-    return rating ? rating.rating : undefined;
-  };
+  const getRating = useCallback(
+    (candidate: number) => {
+      const rating = reviews.find(
+        (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
+      );
+      return rating ? rating.rating : undefined;
+    },
+    [reviews, userInfo]
+  );
 
-  const getComment = (candidate: number) => {
-    const comment = reviews.find(
-      (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
-    );
-    if (comment) return comment.comment;
-    return undefined;
-  };
+  const getComment = useCallback(
+    (candidate: number) => {
+      const comment = reviews.find(
+        (rt) => rt.reviewer.email === userInfo?.email && rt.candidateId === candidate
+      );
+      if (comment) return comment.comment;
+      return undefined;
+    },
+    [reviews, userInfo]
+  );
 
   const [currentRating, setCurrentRating] = useState<Rating>();
   const [currentComment, setCurrentComment] = useState<string>();
@@ -79,14 +86,17 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
   const isSaved =
     currentComment === defaultCurrentComment && currentRating === defaultCurrentRating;
 
-  const populateReviewForCandidate = (candidate: number) => {
-    const rating = getRating(candidate) ?? 0;
-    const comment = getComment(candidate) ?? '';
-    setCurrentRating(rating);
-    setCurrentComment(comment);
-    setDefaultCurrentRating(rating);
-    setDefaultCurrentComment(comment);
-  };
+  const populateReviewForCandidate = useCallback(
+    (candidate: number) => {
+      const rating = getRating(candidate) ?? 0;
+      const comment = getComment(candidate) ?? '';
+      setCurrentRating(rating);
+      setCurrentComment(comment);
+      setDefaultCurrentRating(rating);
+      setDefaultCurrentComment(comment);
+    },
+    [getRating, getComment]
+  );
 
   const completedReviews = reviews.filter((review) => review.rating !== 0);
 
@@ -101,41 +111,56 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentCandidate, instance.candidates, reviews]);
 
-  const handleRatingAndCommentChange = (id: number, rating: Rating, comment: string) => {
-    CandidateDeciderAPI.updateRatingAndComment(instance.uuid, id, rating, comment);
-    if (userInfo) {
-      setCurrentRating(rating);
-      setCurrentComment(comment);
-      setDefaultCurrentRating(rating);
-      setDefaultCurrentComment(comment);
-      setReviews((reviews) => [
-        ...reviews.filter(
-          (review) => review.candidateId !== id || review.reviewer.email !== userInfo.email
-        ),
-        {
-          rating,
-          comment,
-          candidateDeciderInstanceUuid: uuid,
-          candidateId: id,
-          reviewer: userInfo,
-          uuid: ''
-        }
-      ]);
-    }
-  };
+  const handleRatingAndCommentChange = useCallback(
+    (id: number, rating: Rating, comment: string) => {
+      CandidateDeciderAPI.updateRatingAndComment(instance.uuid, id, rating, comment);
+      if (userInfo) {
+        setCurrentRating(rating);
+        setCurrentComment(comment);
+        setDefaultCurrentRating(rating);
+        setDefaultCurrentComment(comment);
+        setReviews((reviews) => [
+          ...reviews.filter(
+            (review) => review.candidateId !== id || review.reviewer.email !== userInfo.email
+          ),
+          {
+            rating,
+            comment,
+            candidateDeciderInstanceUuid: uuid,
+            candidateId: id,
+            reviewer: userInfo,
+            uuid: ''
+          }
+        ]);
+      }
+    },
+    [
+      instance.uuid,
+      userInfo,
+      setCurrentRating,
+      setCurrentComment,
+      setDefaultCurrentRating,
+      setDefaultCurrentComment,
+      setReviews,
+      uuid
+    ]
+  );
 
-  const handleCandidateChange = (candidate: number) => {
-    if (candidate < 0 || candidate >= instance.candidates.length) {
-      return;
-    }
-    if (!isSaved) {
-      setNextCandidate(candidate);
-      setIsModalOpen(true);
-    } else {
-      setCurrentCandidate(candidate);
-      populateReviewForCandidate(candidate);
-    }
-  };
+  const handleCandidateChange = useCallback(
+    (candidate: number) => {
+      if (candidate < 0 || candidate >= instance.candidates.length) {
+        return;
+      }
+      if (!isSaved) {
+        setNextCandidate(candidate);
+        setIsModalOpen(true);
+      } else {
+        setCurrentCandidate(candidate);
+        populateReviewForCandidate(candidate);
+      }
+    },
+    [instance.candidates, isSaved, populateReviewForCandidate]
+  );
 
   const navigateToNextCandidate = (candidate: number) => {
     setCurrentCandidate(candidate);
@@ -143,6 +168,35 @@ const CandidateDecider: React.FC<CandidateDeciderProps> = ({ uuid }) => {
     setNextCandidate(null);
     setIsModalOpen(false);
   };
+
+  useKeyboardShortcut('ArrowRight', () => {
+    handleRatingAndCommentChange(currentCandidate, currentRating ?? 0, currentComment ?? '');
+    handleCandidateChange(currentCandidate + 1);
+  });
+  useKeyboardShortcut('ArrowLeft', () => {
+    handleRatingAndCommentChange(currentCandidate, currentRating ?? 0, currentComment ?? '');
+    handleCandidateChange(currentCandidate - 1);
+  });
+  useKeyboardShortcut(
+    'Enter',
+    () => {
+      handleRatingAndCommentChange(currentCandidate, currentRating ?? 0, currentComment ?? '');
+    },
+    { meta: true }
+  );
+  useEffect(() => {
+    ratings.forEach((rating) => {
+      document.addEventListener('keydown', (e) => {
+        if (e.key === rating.value.toString()) {
+          handleRatingAndCommentChange(
+            currentCandidate,
+            rating.value as Rating,
+            currentComment ?? ''
+          );
+        }
+      });
+    });
+  }, [currentCandidate, handleRatingAndCommentChange, currentRating, currentComment]);
 
   const hasAdminPermission = useHasAdminPermission();
 

--- a/frontend/src/hooks/useKeyboardShortcut.ts
+++ b/frontend/src/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+interface Modifiers {
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  meta?: boolean;
+}
+
+function useKeyboardShortcut(key: string, callback: () => void, modifiers: Modifiers = {}) {
+  useEffect(() => {
+    console.log('useKeyboardShortcut', key, callback, modifiers);
+    const handler = (event: KeyboardEvent) => {
+      const ctrlMatch = modifiers.ctrl ? event.ctrlKey || event.metaKey : true;
+      const shiftMatch = modifiers.shift ? event.shiftKey : true;
+      const altMatch = modifiers.alt ? event.altKey : true;
+      const metaMatch = modifiers.meta ? event.metaKey : true;
+
+      if (ctrlMatch && shiftMatch && altMatch && metaMatch && event.key === key) {
+        event.preventDefault();
+        callback();
+      }
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [key, callback, modifiers]);
+}
+
+export default useKeyboardShortcut;


### PR DESCRIPTION
### Summary <!-- Required -->

This PR implements keyboard shortcuts for Candidate Decider:
- [1-6] to set rating (0 for undecided)
- "cmd/ctrl+enter" to save
- left/right arrow to advance / previous candidate

Also adds the `useKeyboardShortcut` hook.

<!-- Optional: If adding/updating endpoints, update the backend api specification (openapi.yaml) -->

### Notion/Figma Link <!-- Optional -->

<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
