### PR TITLE
commented out ratings display

### DIFF
--- a/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
+++ b/frontend/src/components/Candidate-Decider/LocalProgressPanel.tsx
@@ -1,7 +1,7 @@
 import { LEAD_ROLES } from 'common-types/constants';
 import styles from './ProgressPanel.module.css';
 import { useSelf } from '../Common/FirestoreDataProvider';
-import RatingsDisplay from './RatingsDisplay';
+// import RatingsDisplay from './RatingsDisplay';
 import { ratingToString } from './ratings-utils';
 import ProgressBar from '../Common/ProgressBar/ProgressBar';
 


### PR DESCRIPTION
### Summary 
 Hide Global Ratings display in Candidate Decider
  - Commented out RatingsDisplay component showing global ratings in LocalProgressPanel

### Test Plan 
  - Verify that the "Candidate X Global Ratings" section no longer appears for lead users in the
  Candidate Decider 
  - Verify that "All Votes" and "All Comments" sections still display correctly for leads
  
Note: The RatingsDisplay component is commented out rather than deleted for easy restoration if needed, aka a temporary change.
