### PR TITLE
fix widths of candidate decider columns

### DIFF
--- a/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
+++ b/frontend/src/components/Candidate-Decider/CandidateDecider.module.css
@@ -10,11 +10,11 @@
 }
 
 .leftColumn {
-  width: fit-content;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   height: 100%;
+  width: 40%;
   border: 1px solid var(--border-default);
   border-radius: 6px;
 }
@@ -66,7 +66,7 @@
 .responsesContainer {
   display: flex;
   flex-direction: column;
-  width: 100%;
+  width: 60%;
   flex: 1;
   border: 1px solid #666;
   background: var(--bg-default);


### PR DESCRIPTION
### Summary <!-- Required -->
Fix the widths of the candidate decider to a 40:60 split. Previously, long comments would dominate the screen width, preventing clients from seeing the right column.

### Test Plan <!-- Required -->
| Before    | <img width="1467" height="478" alt="Screenshot 2025-10-17 at 1 24 30 PM" src="https://github.com/user-attachments/assets/56c660a2-5482-40c4-a8d7-b4b856b326eb" /> |
| -------- | ------- |
| After | <img width="1475" height="514" alt="image" src="https://github.com/user-attachments/assets/fe211f56-0efb-4eda-9ac9-276e046648b8" />    |
