### PR TITLE
Leads can be the member in interview scheduler

### DIFF
--- a/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
+++ b/frontend/src/components/Interview-Scheduler/SchedulingSidePanel.tsx
@@ -50,12 +50,10 @@ const SchedulingSidePanel: React.FC<{
 
   const memberOptions = [
     { text: 'Vacant' },
-    ...members
-      .filter((mem) => !LEAD_ROLES.includes(mem.role))
-      .map((mem) => ({
-        text: `${mem.firstName} ${mem.lastName}`,
-        value: mem.email
-      }))
+    ...members.map((mem) => ({
+      text: `${mem.firstName} ${mem.lastName}`,
+      value: mem.email
+    }))
   ];
 
   const applicantOptions = [

--- a/frontend/src/components/Interview-Scheduler/SlotHooks.tsx
+++ b/frontend/src/components/Interview-Scheduler/SlotHooks.tsx
@@ -28,6 +28,7 @@ export const useInterviewSlotStatus = (slot: InterviewSlot): SlotStatus => {
 
   if (isLead) {
     if (slot.lead === null) return 'vacant';
+    if (slot.members.some((mem) => mem && mem.email === userEmail)) return 'possessed';
     return slot.lead !== null && slot.lead.email === userEmail ? 'possessed' : 'occupied';
   }
   if (isMember) {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards implementing feature Foo

- [x] implemented small changes so leads can choose the member slot in interview scheduler
- [x] i tested it trust
