### PR TITLE
Add TEC Period Editing Capabilities to IDOL

### DIFF
--- a/backend/src/API/mailAPI.ts
+++ b/backend/src/API/mailAPI.ts
@@ -8,12 +8,8 @@ import { BadRequestError, PermissionError } from '../utils/errors';
 import { env } from '../firebase';
 import TeamEventAttendanceDao from '../dao/TeamEventAttendanceDao';
 import TeamEventsDao from '../dao/TeamEventsDao';
-import {
-  LEAD_ROLES,
-  TEC_DEADLINES,
-  REQUIRED_LEAD_TEC_CREDITS,
-  REQUIRED_MEMBER_TEC_CREDITS
-} from '../consts';
+import { LEAD_ROLES } from '../consts';
+import TecConfigDao from '../dao/TecConfigDao';
 
 const teamEventAttendanceDao = new TeamEventAttendanceDao();
 const IS_PROD = env === 'prod';
@@ -138,6 +134,9 @@ export const sendPeriodReminder = async (
   member: IdolMember
 ): Promise<AxiosResponse> => {
   const subject = `This Period's TEC Reminder`;
+  const tecConfig = await TecConfigDao.getTecConfig();
+  const tecDeadlines = tecConfig.periodEndDates.map((d) => new Date(d));
+  const { requiredMemberTecCredits, requiredLeadTecCredits } = tecConfig;
 
   interface Period {
     start: Date;
@@ -153,9 +152,9 @@ export const sendPeriodReminder = async (
   );
 
   const getTECPeriod = (submissionDate: Date) => {
-    const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
+    const currentPeriodIndex = tecDeadlines.findIndex((date) => submissionDate <= date);
     if (currentPeriodIndex === -1) {
-      return TEC_DEADLINES.length - 1;
+      return tecDeadlines.length - 1;
     }
     return currentPeriodIndex;
   };
@@ -189,8 +188,8 @@ export const sendPeriodReminder = async (
     const firstPeriodStart = today.getMonth() < 7 ? new Date(year, 0, 1) : new Date(year, 7, 1);
 
     const periodStart =
-      currentPeriodIndex === 0 ? firstPeriodStart : TEC_DEADLINES[currentPeriodIndex - 1];
-    const periodEnd = TEC_DEADLINES[currentPeriodIndex];
+      currentPeriodIndex === 0 ? firstPeriodStart : tecDeadlines[currentPeriodIndex - 1];
+    const periodEnd = tecDeadlines[currentPeriodIndex];
     const events = allEvents.filter((event) => {
       const eventDate = new Date(event.date);
       return eventDate > periodStart && eventDate <= periodEnd;
@@ -222,7 +221,7 @@ export const sendPeriodReminder = async (
   const { approvedCredits, pendingCredits } = calculateCurrentPeriodCredits(currentPeriod);
 
   const isLead = LEAD_ROLES.includes(member.role);
-  const requiredCreditsForPeriod = isLead ? REQUIRED_LEAD_TEC_CREDITS : REQUIRED_MEMBER_TEC_CREDITS;
+  const requiredCreditsForPeriod = isLead ? requiredLeadTecCredits : requiredMemberTecCredits;
   const remainingCredits = calculateCredits(approvedCredits, requiredCreditsForPeriod);
   const reminder =
     `This is a reminder to earn at least ${remainingCredits} team event ${

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -475,7 +475,7 @@ loginCheckedPut('/tec-config', async (req, user) => {
   if (!(await PermissionsManager.isAdmin(user))) {
     throw new PermissionError('Only IDOL admins can update TEC Config');
   }
-  return {config: await TecConfigDao.updateTecConfig(req.body)};
+  return { config: await TecConfigDao.updateTecConfig(req.body) };
 });
 loginCheckedPost('/send-period-reminder', async (req, user) => ({
   info: await notifyMemberPeriod(req, req.body, user)

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import admin from 'firebase-admin';
 import * as winston from 'winston';
 import * as expressWinston from 'express-winston';
+import TecConfigDao from './dao/TecConfigDao';
 import { app as adminApp, env } from './firebase';
 import PermissionsManager from './utils/permissionsManager';
 import {
@@ -127,7 +128,7 @@ import {
   removeAlumniFromLocation
 } from './API/cityCoordinatesAPI';
 
-import { HandlerError } from './utils/errors';
+import { HandlerError, PermissionError } from './utils/errors';
 
 // Constants and configurations
 const app = express();
@@ -466,6 +467,15 @@ loginCheckedPut('/team-event-attendance', async (req, user) => ({
 loginCheckedDelete('/team-event-attendance/:uuid', async (req, user) => {
   await deleteTeamEventAttendance(req.params.uuid, user);
   return {};
+});
+loginCheckedGet('/tec-config', async () => ({
+  config: await TecConfigDao.getTecConfig()
+}));
+loginCheckedPut('/tec-config', async (req, user) => {
+  if (!(await PermissionsManager.isAdmin(user))) {
+    throw new PermissionError('Only IDOL admins can update TEC Config');
+  }
+  return {config: await TecConfigDao.updateTecConfig(req.body)};
 });
 loginCheckedPost('/send-period-reminder', async (req, user) => ({
   info: await notifyMemberPeriod(req, req.body, user)

--- a/backend/src/consts.ts
+++ b/backend/src/consts.ts
@@ -9,13 +9,11 @@ export default COFFEE_CHAT_BINGO_BOARD;
 
 export const DISABLE_DELETE_ALL_COFFEE_CHATS = true;
 
-export const REQUIRED_MEMBER_TEC_CREDITS = 1;
-export const REQUIRED_LEAD_TEC_CREDITS = 2;
-export const TEC_DEADLINES = [
-  new Date('2026-02-22T23:59:59'),
-  new Date('2026-03-19T23:59:59'),
-  new Date('2026-05-04T23:59:59')
-];
+export const DEFAULT_TEC_CONFIG: TECConfig = {
+  periodEndDates: ['2026-02-22T23:59:59', '2026-03-19T23:59:59', '2026-05-04T23:59:59'],
+  requiredMemberTecCredits: 1,
+  requiredLeadTecCredits: 2
+};
 
 export const ALL_ROLES: Role[] = [
   'ops-lead',

--- a/backend/src/dao/TecConfigDao.ts
+++ b/backend/src/dao/TecConfigDao.ts
@@ -1,0 +1,46 @@
+import { tecConfigCollection } from '../firebase';
+import { DEFAULT_TEC_CONFIG } from '../consts';
+import { BadRequestError } from '../utils/errors';
+
+
+const TEC_CONFIG_DOC_ID = 'current';
+
+export default class TecConfigDao {
+  /** Returns the saved TEC config from Firestore document, or DEFAULT_TEC_CONFIG if invalid for some reason. */
+  static async getTecConfig(): Promise<TECConfig> {
+    const snap = await tecConfigCollection.doc(TEC_CONFIG_DOC_ID).get();
+    if (!snap.exists) {
+      return DEFAULT_TEC_CONFIG;
+    }
+    const data = snap.data();
+    if (!isValidTecConfig(data)) {
+      return DEFAULT_TEC_CONFIG;
+    }
+    return data;
+  }
+
+  static async updateTecConfig(config: TECConfig): Promise<TECConfig> {
+    if (!isValidTecConfig(config)) {
+      throw new BadRequestError("Invalid TEC config");
+    }
+
+    const normalizedConfig: TECConfig = {
+      periodEndDates: [...config.periodEndDates].sort(), // assures chronological order
+      requiredMemberTecCredits: config.requiredMemberTecCredits,
+      requiredLeadTecCredits: config.requiredLeadTecCredits
+    };
+
+    await tecConfigCollection.doc(TEC_CONFIG_DOC_ID).set(normalizedConfig);
+    return normalizedConfig;
+  }
+}
+
+function isValidTecConfig(data: TECConfig | undefined): data is TECConfig {
+  if (!data) return false;
+  return (
+    Array.isArray(data.periodEndDates) &&
+    data.periodEndDates.every((d) => typeof d === 'string') &&
+    typeof data.requiredMemberTecCredits === 'number' &&
+    typeof data.requiredLeadTecCredits === 'number'
+  );
+}

--- a/backend/src/dao/TecConfigDao.ts
+++ b/backend/src/dao/TecConfigDao.ts
@@ -2,7 +2,6 @@ import { tecConfigCollection } from '../firebase';
 import { DEFAULT_TEC_CONFIG } from '../consts';
 import { BadRequestError } from '../utils/errors';
 
-
 const TEC_CONFIG_DOC_ID = 'current';
 
 export default class TecConfigDao {
@@ -21,7 +20,7 @@ export default class TecConfigDao {
 
   static async updateTecConfig(config: TECConfig): Promise<TECConfig> {
     if (!isValidTecConfig(config)) {
-      throw new BadRequestError("Invalid TEC config");
+      throw new BadRequestError('Invalid TEC config');
     }
 
     const normalizedConfig: TECConfig = {

--- a/backend/src/dao/TecConfigDao.ts
+++ b/backend/src/dao/TecConfigDao.ts
@@ -1,30 +1,63 @@
 import { tecConfigCollection } from '../firebase';
 import { DEFAULT_TEC_CONFIG } from '../consts';
-import { BadRequestError } from '../utils/errors';
+import { BadRequestError, HandlerError } from '../utils/errors';
 
 const TEC_CONFIG_DOC_ID = 'current';
 
 export default class TecConfigDao {
-  /** Returns the saved TEC config from Firestore document, or DEFAULT_TEC_CONFIG if invalid for some reason. */
+  /**
+   * Returns the saved TEC config from the Firestore document.
+   *
+   * If the document does not exist, returns `DEFAULT_TEC_CONFIG`
+   * and logs a warning.
+   *
+   * If the document exists but is malformed, throws a 500 error.
+   */
   static async getTecConfig(): Promise<TECConfig> {
     const snap = await tecConfigCollection.doc(TEC_CONFIG_DOC_ID).get();
     if (!snap.exists) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[TecConfigDao] No TEC config document found at tec-config/${TEC_CONFIG_DOC_ID}; ` +
+          `falling back to DEFAULT_TEC_CONFIG. Seed the document via the admin panel.`
+      );
       return DEFAULT_TEC_CONFIG;
     }
     const data = snap.data();
     if (!isValidTecConfig(data)) {
-      return DEFAULT_TEC_CONFIG;
+      // eslint-disable-next-line no-console
+      console.error(
+        `[TecConfigDao] Malformed TEC config at tec-config/${TEC_CONFIG_DOC_ID}:`,
+        data
+      );
+      throw new HandlerError(
+        500,
+        `Stored TEC config at tec-config/${TEC_CONFIG_DOC_ID} is malformed. ` +
+          `An admin must re-save the config via the admin panel.`
+      );
     }
     return data;
   }
 
+  /**
+   * Validates and persists a TEC config to the Firestore document.
+   *
+   * Validation checks that `periodEndDates` is a
+   * non-empty array of parseable date strings and that both credit
+   * requirements are non-negative numbers. Period end dates are sorted
+   * chronologically.
+   *
+   * @param config The full TEC config to persist.
+   * @returns The normalized config that was written (dates sorted).
+   * @throws {BadRequestError} If `config` fails validation.
+   */
   static async updateTecConfig(config: TECConfig): Promise<TECConfig> {
     if (!isValidTecConfig(config)) {
       throw new BadRequestError('Invalid TEC config');
     }
 
     const normalizedConfig: TECConfig = {
-      periodEndDates: [...config.periodEndDates].sort(), // assures chronological order
+      periodEndDates: [...config.periodEndDates].sort(), // ensures chronological order
       requiredMemberTecCredits: config.requiredMemberTecCredits,
       requiredLeadTecCredits: config.requiredLeadTecCredits
     };
@@ -38,8 +71,11 @@ function isValidTecConfig(data: TECConfig | undefined): data is TECConfig {
   if (!data) return false;
   return (
     Array.isArray(data.periodEndDates) &&
-    data.periodEndDates.every((d) => typeof d === 'string') &&
+    data.periodEndDates.length > 0 &&
+    data.periodEndDates.every((d) => typeof d === 'string' && !Number.isNaN(Date.parse(d))) &&
     typeof data.requiredMemberTecCredits === 'number' &&
-    typeof data.requiredLeadTecCredits === 'number'
+    typeof data.requiredLeadTecCredits === 'number' &&
+    data.requiredMemberTecCredits >= 0 &&
+    data.requiredLeadTecCredits >= 0
   );
 }

--- a/backend/src/firebase.ts
+++ b/backend/src/firebase.ts
@@ -258,3 +258,14 @@ export const reimbursementRequestCollection: admin.firestore.CollectionReference
       return requestData;
     }
   });
+
+export const tecConfigCollection: admin.firestore.CollectionReference<TECConfig> = db
+  .collection('tec-config')
+  .withConverter({
+    fromFirestore(snapshot): TECConfig {
+      return snapshot.data() as TECConfig;
+    },
+    toFirestore(tecConfigData: TECConfig) {
+      return tecConfigData;
+    }
+  });

--- a/backend/src/openapi.yaml
+++ b/backend/src/openapi.yaml
@@ -698,6 +698,45 @@ paths:
                 type: object
         '403':
           description: "PermissionError: User does not have permission to delete a team event."
+  /tec-config:
+    get:
+      tags:
+      - "Team Event Credit"
+      summary: 'Returns the current TEC configuration (period end dates and required credits)'
+      responses:
+        '200':
+          description: "Successfully returns the TEC configuration"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  config:
+                    $ref: '#/components/schemas/TECConfig'
+    put:
+      tags:
+      - "Team Event Credit"
+      summary: 'Updates the TEC configuration. Admin-only.'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TECConfig'
+      responses:
+        '200':
+          description: "Successfully updates the TEC configuration"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  config:
+                    $ref: '#/components/schemas/TECConfig'
+        '400':
+          description: "BadRequestError: Invalid TEC config payload."
+        '403':
+          description: "PermissionError: Only IDOL admins can update TEC Config."
   /getEventProofImage:
     get:
       tags:
@@ -1138,6 +1177,27 @@ components:
         uuid:
           type: string
           format: uuid
+    TECConfig:
+      type: object
+      properties:
+        periodEndDates:
+          type: array
+          items:
+            type: string
+          description: "Sorted ISO-ish date strings marking the end of each TEC period."
+        requiredMemberTecCredits:
+          type: number
+          description: "Number of TEC credits required per period for members."
+        requiredLeadTecCredits:
+          type: number
+          description: "Number of TEC credits required per period for leads."
+      example:
+        periodEndDates:
+        - "2026-02-22T23:59:59"
+        - "2026-03-19T23:59:59"
+        - "2026-05-04T23:59:59"
+        requiredMemberTecCredits: 1
+        requiredLeadTecCredits: 2
     CandidateDeciderInfo:
       type: object
       properties:

--- a/backend/tests/TecConfigDao.test.ts
+++ b/backend/tests/TecConfigDao.test.ts
@@ -1,0 +1,132 @@
+/// <reference types="common-types" />
+import TecConfigDao from '../src/dao/TecConfigDao';
+import { tecConfigCollection } from '../src/firebase';
+import { DEFAULT_TEC_CONFIG } from '../src/consts';
+import { BadRequestError, HandlerError } from '../src/utils/errors';
+
+jest.setTimeout(20000);
+
+const DOC_ID = 'current';
+
+let originalDoc: FirebaseFirestore.DocumentData | undefined;
+
+beforeAll(async () => {
+  const snap = await tecConfigCollection.doc(DOC_ID).get();
+  originalDoc = snap.exists ? snap.data() : undefined;
+});
+
+afterAll(async () => {
+  if (originalDoc) {
+    await tecConfigCollection.doc(DOC_ID).set(originalDoc as TECConfig);
+  } else {
+    await tecConfigCollection.doc(DOC_ID).delete();
+  }
+});
+
+const validConfig: TECConfig = {
+  periodEndDates: ['2026-02-22T23:59:59', '2026-03-19T23:59:59'],
+  requiredMemberTecCredits: 1,
+  requiredLeadTecCredits: 2
+};
+
+describe('TecConfigDao.getTecConfig', () => {
+  test('returns the stored config when the doc exists and is valid', async () => {
+    await tecConfigCollection.doc(DOC_ID).set(validConfig);
+
+    const result = await TecConfigDao.getTecConfig();
+    expect(result).toEqual(validConfig);
+  });
+
+  test('returns DEFAULT_TEC_CONFIG when the doc does not exist', async () => {
+    await tecConfigCollection.doc(DOC_ID).delete();
+
+    const result = await TecConfigDao.getTecConfig();
+    expect(result).toEqual(DEFAULT_TEC_CONFIG);
+  });
+
+  test('throws when the stored doc is malformed', async () => {
+    await tecConfigCollection.doc(DOC_ID).set({
+      periodEndDates: ['2026-02-22T23:59:59'],
+      requiredMemberTecCredits: 'not a number'
+    } as unknown as TECConfig);
+
+    await expect(TecConfigDao.getTecConfig()).rejects.toThrow(HandlerError);
+  });
+});
+
+describe('TecConfigDao.updateTecConfig', () => {
+  test('writes the config and returns it (round-trips through Firestore)', async () => {
+    const returned = await TecConfigDao.updateTecConfig(validConfig);
+    expect(returned.requiredMemberTecCredits).toBe(validConfig.requiredMemberTecCredits);
+    expect(returned.requiredLeadTecCredits).toBe(validConfig.requiredLeadTecCredits);
+
+    const fetched = await TecConfigDao.getTecConfig();
+    expect(fetched).toEqual(returned);
+  });
+
+  test('sorts periodEndDates chronologically before persisting', async () => {
+    const unsorted: TECConfig = {
+      periodEndDates: ['2026-05-04T23:59:59', '2026-02-22T23:59:59', '2026-03-19T23:59:59'],
+      requiredMemberTecCredits: 1,
+      requiredLeadTecCredits: 2
+    };
+
+    const result = await TecConfigDao.updateTecConfig(unsorted);
+    expect(result.periodEndDates).toEqual([
+      '2026-02-22T23:59:59',
+      '2026-03-19T23:59:59',
+      '2026-05-04T23:59:59'
+    ]);
+  });
+
+  describe('validation', () => {
+    test('throws BadRequestError when periodEndDates is empty', async () => {
+      await expect(
+        TecConfigDao.updateTecConfig({
+          periodEndDates: [],
+          requiredMemberTecCredits: 1,
+          requiredLeadTecCredits: 2
+        })
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    test('throws BadRequestError when a periodEndDate is not parseable', async () => {
+      await expect(
+        TecConfigDao.updateTecConfig({
+          periodEndDates: ['not a date'],
+          requiredMemberTecCredits: 1,
+          requiredLeadTecCredits: 2
+        })
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    test('throws BadRequestError when periodEndDates contains a non-string', async () => {
+      await expect(
+        TecConfigDao.updateTecConfig({
+          periodEndDates: [123 as unknown as string],
+          requiredMemberTecCredits: 1,
+          requiredLeadTecCredits: 2
+        })
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    test('throws BadRequestError when a required credit field is missing', async () => {
+      const missing = {
+        periodEndDates: ['2026-02-22T23:59:59'],
+        requiredMemberTecCredits: 1
+      } as unknown as TECConfig;
+
+      await expect(TecConfigDao.updateTecConfig(missing)).rejects.toThrow(BadRequestError);
+    });
+
+    test('throws BadRequestError when required credits are negative', async () => {
+      await expect(
+        TecConfigDao.updateTecConfig({
+          periodEndDates: ['2026-02-22T23:59:59'],
+          requiredMemberTecCredits: -1,
+          requiredLeadTecCredits: 2
+        })
+      ).rejects.toThrow(BadRequestError);
+    });
+  });
+});

--- a/common-types/index.d.ts
+++ b/common-types/index.d.ts
@@ -657,3 +657,9 @@ interface ReimbursementRequest {
   isImmutable: boolean;
   resolvedAt: number | null;
 }
+
+interface TECConfig {
+  readonly periodEndDates: string[];
+  readonly requiredMemberTecCredits: number;
+  readonly requiredLeadTecCredits: number;
+}

--- a/frontend/src/API/TecConfigAPI.ts
+++ b/frontend/src/API/TecConfigAPI.ts
@@ -1,0 +1,17 @@
+import { backendURL } from '../environment';
+import APIWrapper from './APIWrapper';
+
+export default class TecConfigAPI {
+    static async getTecConfig(): Promise<TECConfig> {
+        const response = await APIWrapper.get(`${backendURL}/tec-config`);
+        return response.data.config;
+    }
+
+    static async updateTecConfig(config: TECConfig): Promise<TECConfig> {
+        const response = await APIWrapper.put(`${backendURL}/tec-config`, config);
+        if (!response.data?.config) {
+            throw new Error(response.data?.error ?? 'Failed to update TEC Periods');
+        }
+        return response.data.config;
+    }
+}

--- a/frontend/src/API/TecConfigAPI.ts
+++ b/frontend/src/API/TecConfigAPI.ts
@@ -2,16 +2,16 @@ import { backendURL } from '../environment';
 import APIWrapper from './APIWrapper';
 
 export default class TecConfigAPI {
-    static async getTecConfig(): Promise<TECConfig> {
-        const response = await APIWrapper.get(`${backendURL}/tec-config`);
-        return response.data.config;
-    }
+  static async getTecConfig(): Promise<TECConfig> {
+    const response = await APIWrapper.get(`${backendURL}/tec-config`);
+    return response.data.config;
+  }
 
-    static async updateTecConfig(config: TECConfig): Promise<TECConfig> {
-        const response = await APIWrapper.put(`${backendURL}/tec-config`, config);
-        if (!response.data?.config) {
-            throw new Error(response.data?.error ?? 'Failed to update TEC Periods');
-        }
-        return response.data.config;
+  static async updateTecConfig(config: TECConfig): Promise<TECConfig> {
+    const response = await APIWrapper.put(`${backendURL}/tec-config`, config);
+    if (!response.data?.config) {
+      throw new Error(response.data?.error ?? 'Failed to update TEC Periods');
     }
+    return response.data.config;
+  }
 }

--- a/frontend/src/API/TecConfigAPI.ts
+++ b/frontend/src/API/TecConfigAPI.ts
@@ -1,12 +1,36 @@
 import { backendURL } from '../environment';
 import APIWrapper from './APIWrapper';
 
+/**
+ * Frontend for the `/tec-config` backend endpoints.
+ *
+ * The TEC config (period end dates + credit requirements) lives in a single
+ * Firestore document and is read by anywhere in the app that needs to bucket
+ * team events into periods or compute required credits. Only
+ * IDOL admins on the backend can make edits.
+ */
 export default class TecConfigAPI {
+  /**
+   * Fetches the current TEC config from the backend.
+   *
+   * Any IDOL member can call this. Backend returns the stored config,
+   * or `DEFAULT_TEC_CONFIG` if no document has been created yet. A malformed
+   * stored doc throws a 500 error.
+   */
   static async getTecConfig(): Promise<TECConfig> {
     const response = await APIWrapper.get(`${backendURL}/tec-config`);
     return response.data.config;
   }
 
+  /**
+   * Writes a new TEC config to the backend, admin-only.
+   *
+   * Throws if the request fails or permission denied, validation error, etc. Callers
+   * should catch this via `Emitters.generalError`.
+   *
+   * @param config The full TEC config to persist.
+   * @returns The normalized config that was written (period end dates sorted).
+   */
   static async updateTecConfig(config: TECConfig): Promise<TECConfig> {
     const response = await APIWrapper.put(`${backendURL}/tec-config`, config);
     if (!response.data?.config) {

--- a/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEventDashboard.tsx
@@ -4,12 +4,8 @@ import { ExportToCsv, Options } from 'export-to-csv';
 import { ADVISOR_ROLES, LEAD_ROLES } from 'common-types/constants';
 import { useMembers } from '../../Common/FirestoreDataProvider';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
-import {
-  REQUIRED_LEAD_TEC_CREDITS,
-  REQUIRED_MEMBER_TEC_CREDITS,
-  REQUIRED_INITIATIVE_CREDITS,
-  INITIATIVE_EVENTS
-} from '../../../consts';
+import TecConfigAPI from '../../../API/TecConfigAPI';
+import { REQUIRED_INITIATIVE_CREDITS, INITIATIVE_EVENTS } from '../../../consts';
 import styles from './TeamEventDashboard.module.css';
 import NotifyMemberModal from '../../Modals/NotifyMemberModal';
 import { calculateCredits, getTECPeriod, getPeriods } from '../../../utils';
@@ -43,16 +39,22 @@ const getTotalCredits = (member: IdolMember, teamEvents: TeamEvent[]): number =>
 const getInitiativeCredits = (member: IdolMember, teamEvents: TeamEvent[]): number =>
   teamEvents.reduce((val, event) => val + calculateInitiativeCreditsForEvent(member, event), 0);
 
-const getRequiredCredits = (member: IdolMember): number =>
-  LEAD_ROLES.includes(member.role) ? REQUIRED_LEAD_TEC_CREDITS : REQUIRED_MEMBER_TEC_CREDITS;
-
-const getRemainingCredits = (member: IdolMember, currentPeriodCredits: number): number =>
-  calculateCredits(currentPeriodCredits, getRequiredCredits(member));
+const getRemainingCredits = (
+  member: IdolMember,
+  currentPeriodCredits: number,
+  requiredMemberTecCredits: number,
+  requiredLeadTecCredits: number
+): number =>
+  calculateCredits(
+    currentPeriodCredits,
+    LEAD_ROLES.includes(member.role) ? requiredLeadTecCredits : requiredMemberTecCredits
+  );
 
 const TeamEventDashboard: React.FC = () => {
   const [teamEvents, setTeamEvents] = useState<TeamEvent[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [displayPeriod, setDisplayPeriod] = useState<boolean>(false);
+  const [tecConfig, setTecConfig] = useState<TECConfig | null>(null);
 
   const allMembers = useMembers();
 
@@ -61,18 +63,32 @@ const TeamEventDashboard: React.FC = () => {
       setTeamEvents(events);
       setIsLoading(false);
     });
+    TecConfigAPI.getTecConfig().then(setTecConfig);
   }, []);
 
-  if (isLoading) return <Loader active>Fetching team event data...</Loader>;
+  if (isLoading || !tecConfig) return <Loader active>Fetching team event data...</Loader>;
 
-  const periods = getPeriods(teamEvents);
+  const tecDeadlines = tecConfig.periodEndDates.map((d) => new Date(d));
+  const { requiredMemberTecCredits, requiredLeadTecCredits } = tecConfig;
 
-  const currentPeriodIndex = getTECPeriod(new Date());
+  const getRequiredCredits = (member: IdolMember): number =>
+    LEAD_ROLES.includes(member.role) ? requiredLeadTecCredits : requiredMemberTecCredits;
+
+  const periods = getPeriods(teamEvents, tecDeadlines);
+
+  const currentPeriodIndex = getTECPeriod(new Date(), tecDeadlines);
 
   const membersNeedingNotification = allMembers.filter((member) => {
     if (ADVISOR_ROLES.includes(member.role)) return false;
     const currentPeriodCredits = getTotalCredits(member, periods[currentPeriodIndex].events);
-    return getRemainingCredits(member, currentPeriodCredits) > 0;
+    return (
+      getRemainingCredits(
+        member,
+        currentPeriodCredits,
+        requiredMemberTecCredits,
+        requiredLeadTecCredits
+      ) > 0
+    );
   });
 
   const handleExportToCsv = () => {
@@ -173,7 +189,12 @@ const TeamEventDashboard: React.FC = () => {
                     member,
                     periods[currentPeriodIndex].events
                   );
-                  const remainingCredits = getRemainingCredits(member, currentPeriodCredits);
+                  const remainingCredits = getRemainingCredits(
+                    member,
+                    currentPeriodCredits,
+                    requiredMemberTecCredits,
+                    requiredLeadTecCredits
+                  );
                   const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
                   return (
@@ -211,7 +232,12 @@ const TeamEventDashboard: React.FC = () => {
                     member,
                     periods[currentPeriodIndex].events
                   );
-                  const remainingCredits = getRemainingCredits(member, currentPeriodCredits);
+                  const remainingCredits = getRemainingCredits(
+                    member,
+                    currentPeriodCredits,
+                    requiredMemberTecCredits,
+                    requiredLeadTecCredits
+                  );
                   const isAdvisor = ADVISOR_ROLES.includes(member.role);
 
                   return (

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -10,7 +10,6 @@ import { INITIATIVE_EVENTS } from '../../../consts';
 import TecConfigAPI from '../../../API/TecConfigAPI';
 import TecConfigEditor from './TecConfigEditor';
 
-
 type TeamEventsDisplayProps = {
   isLoading: boolean;
   teamEvents: TeamEvent[];
@@ -110,7 +109,7 @@ const TeamEvents: React.FC = () => {
         <h1>Create a Team Event</h1>
         <TeamEventForm formType={'create'}></TeamEventForm>
       </div>
-      <div className={[styles.formWrapper,styles.wrapper].join(' ')}>
+      <div className={[styles.formWrapper, styles.wrapper].join(' ')}>
         <TecConfigEditor />
       </div>
       <div className={styles.wrapper}>

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -7,6 +7,9 @@ import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import { Emitters, getPeriods } from '../../../utils';
 import ClearTeamEventsModal from '../../Modals/ClearTeamEventsModal';
 import { INITIATIVE_EVENTS } from '../../../consts';
+import TecConfigAPI from '../../../API/TecConfigAPI';
+import TecConfigEditor from './TecConfigEditor';
+
 
 type TeamEventsDisplayProps = {
   isLoading: boolean;
@@ -61,11 +64,16 @@ const TeamEvents: React.FC = () => {
     { name: string; start: Date; deadline: Date; events: TeamEvent[] }[]
   >([]);
   const [isLoading, setLoading] = useState(true);
+  const [tecConfig, setTecConfig] = useState<TECConfig | null>(null);
 
   const fullReset = () => {
     setLoading(true);
     setGroupedTeamEvents([]);
   };
+
+  useEffect(() => {
+    TecConfigAPI.getTecConfig().then((config) => setTecConfig(config));
+  }, []);
 
   useEffect(() => {
     const cb = () => {
@@ -78,10 +86,11 @@ const TeamEvents: React.FC = () => {
   });
 
   useEffect(() => {
-    if (isLoading) {
+    if (isLoading && tecConfig) {
+      const tecDeadlines = tecConfig.periodEndDates.map((d) => new Date(d));
       TeamEventsAPI.getAllTeamEvents()
         .then((teamEvents) => {
-          const periods = getPeriods(teamEvents).reverse();
+          const periods = getPeriods(teamEvents, tecDeadlines).reverse();
           setGroupedTeamEvents(periods);
           setLoading(false);
         })
@@ -93,13 +102,16 @@ const TeamEvents: React.FC = () => {
           setLoading(false);
         });
     }
-  }, [isLoading]);
+  }, [isLoading, tecConfig]);
 
   return (
     <div>
       <div className={[styles.formWrapper, styles.wrapper].join(' ')}>
         <h1>Create a Team Event</h1>
         <TeamEventForm formType={'create'}></TeamEventForm>
+      </div>
+      <div className={[styles.formWrapper,styles.wrapper].join(' ')}>
+        <TecConfigEditor />
       </div>
       <div className={styles.wrapper}>
         <div>

--- a/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TeamEvents.tsx
@@ -110,7 +110,15 @@ const TeamEvents: React.FC = () => {
         <TeamEventForm formType={'create'}></TeamEventForm>
       </div>
       <div className={[styles.formWrapper, styles.wrapper].join(' ')}>
-        <TecConfigEditor />
+        {tecConfig && (
+          <TecConfigEditor
+            initialConfig={tecConfig}
+            onSaved={(saved) => {
+              setTecConfig(saved);
+              fullReset();
+            }}
+          />
+        )}
       </div>
       <div className={styles.wrapper}>
         <div>

--- a/frontend/src/components/Admin/TeamEvent/TecConfigEditor.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TecConfigEditor.tsx
@@ -4,114 +4,118 @@ import TecConfigAPI from '../../../API/TecConfigAPI';
 import { Emitters } from '../../../utils';
 
 const TecConfigEditor: React.FC = () => {
-    const [config, setConfig] = useState<TECConfig | null>(null);
-    const [isSaving, setIsSaving] = useState(false);
-    useEffect(() => {
-      TecConfigAPI.getTecConfig().then(setConfig);
-    }, []);
-    if (!config) return <Loader active inline>Loading TEC config…</Loader>;
-    const updatePeriod = (index: number, newValue: string) => {
-      const next = [...config.periodEndDates];
-      next[index] = newValue;
-      setConfig({ ...config, periodEndDates: next });
-    };
-    const addPeriod = () => {
-      setConfig({ ...config, periodEndDates: [...config.periodEndDates, ''] });
-    };
-    const removePeriod = (index: number) => {
-      setConfig({
-        ...config,
-        periodEndDates: config.periodEndDates.filter((_, i) => i !== index)
-      });
-    };
-    const handleSave = async () => {
-      if (config.periodEndDates.length === 0) {
-        Emitters.generalError.emit({
-          headerMsg: 'Invalid TEC config',
-          contentMsg: 'You must have at least one period.'
-        });
-        return;
-      }
-      if (config.periodEndDates.some((d) => Number.isNaN(new Date(d).getTime()))) {
-        Emitters.generalError.emit({
-          headerMsg: 'Invalid TEC config',
-          contentMsg: 'One or more period end dates are not valid dates.'
-        });
-        return;
-      }
-      if (config.requiredMemberTecCredits < 0 || config.requiredLeadTecCredits < 0) {
-        Emitters.generalError.emit({
-          headerMsg: 'Invalid TEC config',
-          contentMsg: 'Required credits must be zero or positive.'
-        });
-        return;
-      }
-      setIsSaving(true);
-      try {
-        const saved = await TecConfigAPI.updateTecConfig(config);
-        if (saved)setConfig(saved);
-        Emitters.generalSuccess.emit({
-          headerMsg: 'TEC config saved',
-          contentMsg: 'Period end dates and credit requirements have been updated.'
-        });
-      } catch (err) {
-        Emitters.generalError.emit({
-          headerMsg: 'Failed to save TEC config',
-          contentMsg: `${err}`
-        });
-      } finally {
-        setIsSaving(false);
-      }
-    };
+  const [config, setConfig] = useState<TECConfig | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  useEffect(() => {
+    TecConfigAPI.getTecConfig().then(setConfig);
+  }, []);
+  if (!config)
     return (
-      <Form>
-        <Header as="h1">Edit TEC Periods</Header>
-        <Header as="h4">Period End Dates</Header>
-        {config.periodEndDates.map((date, i) => (
-          <Form.Group key={i} inline>
-            <Form.Input
-              type="datetime-local"
-              step="1"
-              value={date}
-              onChange={(_, data) => updatePeriod(i, data.value)}
-            />
-            <Button
-              type="button"
-              icon
-              basic
-              color="black"
-              onClick={() => removePeriod(i)}
-            >
-              <Icon name="trash" />
-            </Button>
-          </Form.Group>
-        ))}
-        <Button type="button" onClick={addPeriod} size="small">
-          + Add period
-        </Button>
-        <Header as="h4">Required Credits</Header>
-        <Form.Input
-          label="Members"
-          type="number"
-          min={0}
-          value={config.requiredMemberTecCredits}
-          onChange={(_, data) =>
-            setConfig({ ...config, requiredMemberTecCredits: Number(data.value) })
-          }
-        />
-        <Form.Input
-          label="Leads"
-          type="number"
-          min={0}
-          value={config.requiredLeadTecCredits}
-          onChange={(_, data) =>
-            setConfig({ ...config, requiredLeadTecCredits: Number(data.value) })
-          }
-        />
-        <Button type="button" color="black"primary onClick={handleSave} loading={isSaving} disabled={isSaving}>
-          Save
-        </Button>
-      </Form>
+      <Loader active inline>
+        Loading TEC config…
+      </Loader>
     );
+  const updatePeriod = (index: number, newValue: string) => {
+    const next = [...config.periodEndDates];
+    next[index] = newValue;
+    setConfig({ ...config, periodEndDates: next });
   };
-  export default TecConfigEditor;
+  const addPeriod = () => {
+    setConfig({ ...config, periodEndDates: [...config.periodEndDates, ''] });
+  };
+  const removePeriod = (index: number) => {
+    setConfig({
+      ...config,
+      periodEndDates: config.periodEndDates.filter((_, i) => i !== index)
+    });
+  };
+  const handleSave = async () => {
+    if (config.periodEndDates.length === 0) {
+      Emitters.generalError.emit({
+        headerMsg: 'Invalid TEC config',
+        contentMsg: 'You must have at least one period.'
+      });
+      return;
+    }
+    if (config.periodEndDates.some((d) => Number.isNaN(new Date(d).getTime()))) {
+      Emitters.generalError.emit({
+        headerMsg: 'Invalid TEC config',
+        contentMsg: 'One or more period end dates are not valid dates.'
+      });
+      return;
+    }
+    if (config.requiredMemberTecCredits < 0 || config.requiredLeadTecCredits < 0) {
+      Emitters.generalError.emit({
+        headerMsg: 'Invalid TEC config',
+        contentMsg: 'Required credits must be zero or positive.'
+      });
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const saved = await TecConfigAPI.updateTecConfig(config);
+      if (saved) setConfig(saved);
+      Emitters.generalSuccess.emit({
+        headerMsg: 'TEC config saved',
+        contentMsg: 'Period end dates and credit requirements have been updated.'
+      });
+    } catch (err) {
+      Emitters.generalError.emit({
+        headerMsg: 'Failed to save TEC config',
+        contentMsg: `${err}`
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+  return (
+    <Form>
+      <Header as="h1">Edit TEC Periods</Header>
+      <Header as="h4">Period End Dates</Header>
+      {config.periodEndDates.map((date, i) => (
+        <Form.Group key={i} inline>
+          <Form.Input
+            type="datetime-local"
+            step="1"
+            value={date}
+            onChange={(_, data) => updatePeriod(i, data.value)}
+          />
+          <Button type="button" icon basic color="black" onClick={() => removePeriod(i)}>
+            <Icon name="trash" />
+          </Button>
+        </Form.Group>
+      ))}
+      <Button type="button" onClick={addPeriod} size="small">
+        + Add period
+      </Button>
+      <Header as="h4">Required Credits</Header>
+      <Form.Input
+        label="Members"
+        type="number"
+        min={0}
+        value={config.requiredMemberTecCredits}
+        onChange={(_, data) =>
+          setConfig({ ...config, requiredMemberTecCredits: Number(data.value) })
+        }
+      />
+      <Form.Input
+        label="Leads"
+        type="number"
+        min={0}
+        value={config.requiredLeadTecCredits}
+        onChange={(_, data) => setConfig({ ...config, requiredLeadTecCredits: Number(data.value) })}
+      />
+      <Button
+        type="button"
+        color="black"
+        primary
+        onClick={handleSave}
+        loading={isSaving}
+        disabled={isSaving}
+      >
+        Save
+      </Button>
+    </Form>
+  );
+};
+export default TecConfigEditor;

--- a/frontend/src/components/Admin/TeamEvent/TecConfigEditor.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TecConfigEditor.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { Form, Button, Loader, Header, Icon } from 'semantic-ui-react';
+import TecConfigAPI from '../../../API/TecConfigAPI';
+import { Emitters } from '../../../utils';
+
+const TecConfigEditor: React.FC = () => {
+    const [config, setConfig] = useState<TECConfig | null>(null);
+    const [isSaving, setIsSaving] = useState(false);
+    useEffect(() => {
+      TecConfigAPI.getTecConfig().then(setConfig);
+    }, []);
+    if (!config) return <Loader active inline>Loading TEC config…</Loader>;
+    const updatePeriod = (index: number, newValue: string) => {
+      const next = [...config.periodEndDates];
+      next[index] = newValue;
+      setConfig({ ...config, periodEndDates: next });
+    };
+    const addPeriod = () => {
+      setConfig({ ...config, periodEndDates: [...config.periodEndDates, ''] });
+    };
+    const removePeriod = (index: number) => {
+      setConfig({
+        ...config,
+        periodEndDates: config.periodEndDates.filter((_, i) => i !== index)
+      });
+    };
+    const handleSave = async () => {
+      if (config.periodEndDates.length === 0) {
+        Emitters.generalError.emit({
+          headerMsg: 'Invalid TEC config',
+          contentMsg: 'You must have at least one period.'
+        });
+        return;
+      }
+      if (config.periodEndDates.some((d) => Number.isNaN(new Date(d).getTime()))) {
+        Emitters.generalError.emit({
+          headerMsg: 'Invalid TEC config',
+          contentMsg: 'One or more period end dates are not valid dates.'
+        });
+        return;
+      }
+      if (config.requiredMemberTecCredits < 0 || config.requiredLeadTecCredits < 0) {
+        Emitters.generalError.emit({
+          headerMsg: 'Invalid TEC config',
+          contentMsg: 'Required credits must be zero or positive.'
+        });
+        return;
+      }
+      setIsSaving(true);
+      try {
+        const saved = await TecConfigAPI.updateTecConfig(config);
+        if (saved)setConfig(saved);
+        Emitters.generalSuccess.emit({
+          headerMsg: 'TEC config saved',
+          contentMsg: 'Period end dates and credit requirements have been updated.'
+        });
+      } catch (err) {
+        Emitters.generalError.emit({
+          headerMsg: 'Failed to save TEC config',
+          contentMsg: `${err}`
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    };
+    return (
+      <Form>
+        <Header as="h1">Edit TEC Periods</Header>
+        <Header as="h4">Period End Dates</Header>
+        {config.periodEndDates.map((date, i) => (
+          <Form.Group key={i} inline>
+            <Form.Input
+              type="datetime-local"
+              step="1"
+              value={date}
+              onChange={(_, data) => updatePeriod(i, data.value)}
+            />
+            <Button
+              type="button"
+              icon
+              basic
+              color="black"
+              onClick={() => removePeriod(i)}
+            >
+              <Icon name="trash" />
+            </Button>
+          </Form.Group>
+        ))}
+        <Button type="button" onClick={addPeriod} size="small">
+          + Add period
+        </Button>
+        <Header as="h4">Required Credits</Header>
+        <Form.Input
+          label="Members"
+          type="number"
+          min={0}
+          value={config.requiredMemberTecCredits}
+          onChange={(_, data) =>
+            setConfig({ ...config, requiredMemberTecCredits: Number(data.value) })
+          }
+        />
+        <Form.Input
+          label="Leads"
+          type="number"
+          min={0}
+          value={config.requiredLeadTecCredits}
+          onChange={(_, data) =>
+            setConfig({ ...config, requiredLeadTecCredits: Number(data.value) })
+          }
+        />
+        <Button type="button" color="black"primary onClick={handleSave} loading={isSaving} disabled={isSaving}>
+          Save
+        </Button>
+      </Form>
+    );
+  };
+  export default TecConfigEditor;

--- a/frontend/src/components/Admin/TeamEvent/TecConfigEditor.tsx
+++ b/frontend/src/components/Admin/TeamEvent/TecConfigEditor.tsx
@@ -1,20 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import { Form, Button, Loader, Header, Icon } from 'semantic-ui-react';
+import React, { useState } from 'react';
+import { Form, Button, Header, Icon } from 'semantic-ui-react';
 import TecConfigAPI from '../../../API/TecConfigAPI';
 import { Emitters } from '../../../utils';
 
-const TecConfigEditor: React.FC = () => {
-  const [config, setConfig] = useState<TECConfig | null>(null);
+type Props = {
+  initialConfig: TECConfig;
+  onSaved: (saved: TECConfig) => void;
+};
+
+const TecConfigEditor: React.FC<Props> = ({ initialConfig, onSaved }) => {
+  const [config, setConfig] = useState<TECConfig>(initialConfig);
   const [isSaving, setIsSaving] = useState(false);
-  useEffect(() => {
-    TecConfigAPI.getTecConfig().then(setConfig);
-  }, []);
-  if (!config)
-    return (
-      <Loader active inline>
-        Loading TEC config…
-      </Loader>
-    );
   const updatePeriod = (index: number, newValue: string) => {
     const next = [...config.periodEndDates];
     next[index] = newValue;
@@ -54,7 +50,10 @@ const TecConfigEditor: React.FC = () => {
     setIsSaving(true);
     try {
       const saved = await TecConfigAPI.updateTecConfig(config);
-      if (saved) setConfig(saved);
+      if (saved) {
+        setConfig(saved);
+        onSaved(saved);
+      }
       Emitters.generalSuccess.emit({
         headerMsg: 'TEC config saved',
         contentMsg: 'Period end dates and credit requirements have been updated.'

--- a/frontend/src/components/Alumni/Alumni.tsx
+++ b/frontend/src/components/Alumni/Alumni.tsx
@@ -9,7 +9,6 @@ import AlumniCard from './AlumniCard';
 import styles from './Alumni.module.css';
 import Button from '../Common/Button/Button';
 
-
 const AlumniMap = dynamic(() => import('./AlumniMap'), { ssr: false });
 
 type ViewMode = 'list' | 'map';
@@ -178,9 +177,6 @@ const Alumni: React.FC = () => {
     { key: 'design', text: 'Design', value: 'Design' },
     { key: 'lead', text: 'Lead', value: 'Lead' }
   ];
-
-
-  
 
   const companyOptions = useMemo(() => {
     // Dynamic filter based off of companies of existing alumni

--- a/frontend/src/components/Alumni/Alumni.tsx
+++ b/frontend/src/components/Alumni/Alumni.tsx
@@ -9,6 +9,7 @@ import AlumniCard from './AlumniCard';
 import styles from './Alumni.module.css';
 import Button from '../Common/Button/Button';
 
+
 const AlumniMap = dynamic(() => import('./AlumniMap'), { ssr: false });
 
 type ViewMode = 'list' | 'map';
@@ -177,6 +178,9 @@ const Alumni: React.FC = () => {
     { key: 'design', text: 'Design', value: 'Design' },
     { key: 'lead', text: 'Lead', value: 'Lead' }
   ];
+
+
+  
 
   const companyOptions = useMemo(() => {
     // Dynamic filter based off of companies of existing alumni

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -7,7 +7,7 @@ import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import TeamEventCreditDashboard from './TeamEventsCreditDashboard';
 import styles from './TeamEventCreditsForm.module.css';
 import ImagesAPI from '../../../API/ImagesAPI';
-import { INITIATIVE_EVENTS} from '../../../consts';
+import { INITIATIVE_EVENTS } from '../../../consts';
 import TecConfigAPI from '../../../API/TecConfigAPI';
 
 const TeamEventCreditForm: React.FC = () => {
@@ -37,7 +37,7 @@ const TeamEventCreditForm: React.FC = () => {
   if (!tecConfig) return <Loader active>Loading TEC Config...</Loader>;
 
   const tecDeadlines = tecConfig.periodEndDates.map((d) => new Date(d));
-  const { requiredMemberTecCredits, requiredLeadTecCredits } = tecConfig; 
+  const { requiredMemberTecCredits, requiredLeadTecCredits } = tecConfig;
 
   const approvedTECDates = approvedAttendance
     .map((attendance) => {

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventCreditsForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Form, Label, Dropdown } from 'semantic-ui-react';
+import { Form, Label, Dropdown, Loader } from 'semantic-ui-react';
 import { LEAD_ROLES, ADVISOR_ROLES } from 'common-types/constants';
 import { calculateCredits, Emitters, getNetIDFromEmail, getTECPeriod } from '../../../utils';
 import { useSelf } from '../../Common/FirestoreDataProvider';
@@ -7,12 +7,8 @@ import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import TeamEventCreditDashboard from './TeamEventsCreditDashboard';
 import styles from './TeamEventCreditsForm.module.css';
 import ImagesAPI from '../../../API/ImagesAPI';
-import {
-  INITIATIVE_EVENTS,
-  TEC_DEADLINES,
-  REQUIRED_LEAD_TEC_CREDITS,
-  REQUIRED_MEMBER_TEC_CREDITS
-} from '../../../consts';
+import { INITIATIVE_EVENTS} from '../../../consts';
+import TecConfigAPI from '../../../API/TecConfigAPI';
 
 const TeamEventCreditForm: React.FC = () => {
   // When the user is logged in, `useSelf` always return non-null data.
@@ -26,6 +22,7 @@ const TeamEventCreditForm: React.FC = () => {
   const [rejectedAttendance, setRejectedAttendance] = useState<TeamEventAttendance[]>([]);
   const [isAttendanceLoading, setIsAttendanceLoading] = useState<boolean>(true);
   const [images, setImages] = useState<string[]>(['']);
+  const [tecConfig, setTecConfig] = useState<TECConfig | null>(null);
 
   useEffect(() => {
     TeamEventsAPI.getAllTeamEventInfo().then((teamEvents) => setTeamEventInfoList(teamEvents));
@@ -35,7 +32,12 @@ const TeamEventCreditForm: React.FC = () => {
       setRejectedAttendance(attendance.filter((attendee) => attendee.status === 'rejected'));
       setIsAttendanceLoading(false);
     });
+    TecConfigAPI.getTecConfig().then(setTecConfig);
   }, []);
+  if (!tecConfig) return <Loader active>Loading TEC Config...</Loader>;
+
+  const tecDeadlines = tecConfig.periodEndDates.map((d) => new Date(d));
+  const { requiredMemberTecCredits, requiredLeadTecCredits } = tecConfig; 
 
   const approvedTECDates = approvedAttendance
     .map((attendance) => {
@@ -49,21 +51,21 @@ const TeamEventCreditForm: React.FC = () => {
     })
     .filter((entry): entry is { date: Date; credits: number } => entry !== null);
 
-  const tecCounts: number[] = Array.from({ length: TEC_DEADLINES.length }, () => 0);
+  const tecCounts: number[] = Array.from({ length: tecDeadlines.length }, () => 0);
   approvedTECDates.forEach(({ date, credits }) => {
-    const period = getTECPeriod(date);
+    const period = getTECPeriod(date, tecDeadlines);
     if (period < tecCounts.length) tecCounts[period] += credits;
   });
 
-  let requiredCredits = REQUIRED_MEMBER_TEC_CREDITS;
+  let requiredCredits = requiredMemberTecCredits;
   if (ADVISOR_ROLES.includes(userInfo.role)) {
     requiredCredits = 0;
   } else if (LEAD_ROLES.includes(userInfo.role)) {
-    requiredCredits = REQUIRED_LEAD_TEC_CREDITS;
+    requiredCredits = requiredLeadTecCredits;
   }
 
   const getCurrentCreditsNeeded = () => {
-    const currentPeriod = getTECPeriod(new Date());
+    const currentPeriod = getTECPeriod(new Date(), tecDeadlines);
     const currentCredits = tecCounts[currentPeriod] || 0;
 
     return calculateCredits(currentCredits, requiredCredits);
@@ -184,8 +186,8 @@ const TeamEventCreditForm: React.FC = () => {
           Earn team event credits for participating in DTI events! Fill out this form every time and
           attach a picture of yourself at the event to receive credit. The current month's TEC
           period ends on{' '}
-          {getTECPeriod(new Date()) < TEC_DEADLINES.length
-            ? TEC_DEADLINES[getTECPeriod(new Date())].toDateString()
+          {getTECPeriod(new Date(), tecDeadlines) < tecDeadlines.length
+            ? tecDeadlines[getTECPeriod(new Date(), tecDeadlines)].toDateString()
             : 'No upcoming period'}
           .
         </p>
@@ -326,6 +328,9 @@ const TeamEventCreditForm: React.FC = () => {
           setPendingAttendance={setPendingAttendance}
           requiredPeriodCredits={remainingCredits}
           tecCounts={tecCounts}
+          tecDeadlines={tecDeadlines}
+          requiredMemberTecCredits={requiredMemberTecCredits}
+          requiredLeadTecCredits={requiredLeadTecCredits}
         />
       </Form>
     </div>

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
@@ -6,10 +6,7 @@ import styles from './TeamEventCreditsForm.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import ImagesAPI from '../../../API/ImagesAPI';
 import { Emitters } from '../../../utils';
-import {
-  REQUIRED_INITIATIVE_CREDITS,
-  INITIATIVE_EVENTS,
-} from '../../../consts';
+import { REQUIRED_INITIATIVE_CREDITS, INITIATIVE_EVENTS } from '../../../consts';
 
 const TeamEventCreditDashboard = (props: {
   allTEC: TeamEventInfo[];

--- a/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
+++ b/frontend/src/components/Forms/TeamEventCreditsForm/TeamEventsCreditDashboard.tsx
@@ -6,13 +6,9 @@ import styles from './TeamEventCreditsForm.module.css';
 import { TeamEventsAPI } from '../../../API/TeamEventsAPI';
 import ImagesAPI from '../../../API/ImagesAPI';
 import { Emitters } from '../../../utils';
-
 import {
   REQUIRED_INITIATIVE_CREDITS,
-  REQUIRED_LEAD_TEC_CREDITS,
-  REQUIRED_MEMBER_TEC_CREDITS,
   INITIATIVE_EVENTS,
-  TEC_DEADLINES
 } from '../../../consts';
 
 const TeamEventCreditDashboard = (props: {
@@ -24,6 +20,9 @@ const TeamEventCreditDashboard = (props: {
   setPendingAttendance: Dispatch<SetStateAction<TeamEventAttendance[]>>;
   requiredPeriodCredits: number;
   tecCounts: number[];
+  tecDeadlines: Date[];
+  requiredMemberTecCredits: number;
+  requiredLeadTecCredits: number;
 }): JSX.Element => {
   const {
     allTEC,
@@ -33,7 +32,10 @@ const TeamEventCreditDashboard = (props: {
     isAttendanceLoading,
     setPendingAttendance,
     requiredPeriodCredits,
-    tecCounts
+    tecCounts,
+    tecDeadlines,
+    requiredMemberTecCredits,
+    requiredLeadTecCredits
   } = props;
   const [image, setImage] = useState('');
   const [open, setOpen] = useState(false);
@@ -91,14 +93,14 @@ const TeamEventCreditDashboard = (props: {
   let headerString;
   if (!LEAD_ROLES.includes(userRole))
     headerString = `Check your team event credit status for this semester here!  
-    Every DTI member must complete ${REQUIRED_MEMBER_TEC_CREDITS} team event credit per period${
+    Every DTI member must complete ${requiredMemberTecCredits} team event credit per period${
       INITIATIVE_EVENTS
         ? `, with ${REQUIRED_INITIATIVE_CREDITS} of them being initiative team event credits`
         : ''
     } 
     to fulfill this requirement.`;
   else
-    headerString = `Since you are a lead, you must complete ${REQUIRED_LEAD_TEC_CREDITS} total team event 
+    headerString = `Since you are a lead, you must complete ${requiredLeadTecCredits} total team event 
     credits per period${
       INITIATIVE_EVENTS
         ? `, with ${REQUIRED_INITIATIVE_CREDITS} of them being initiative team event credits`
@@ -213,7 +215,7 @@ const TeamEventCreditDashboard = (props: {
           <div className={styles.inline}>
             <label className={styles.bold}>Approved Credits per Period:</label>
             <ul>
-              {TEC_DEADLINES.map((deadline, index) => (
+              {tecDeadlines.map((deadline, index) => (
                 <li key={index}>
                   Period {index + 1} (Ends: {deadline.toDateString()}):
                   <span className={styles.dark_grey_color}> {tecCounts[index]}</span>

--- a/frontend/src/consts.ts
+++ b/frontend/src/consts.ts
@@ -1,11 +1,4 @@
 export const REQUIRED_INITIATIVE_CREDITS = 1;
-export const REQUIRED_MEMBER_TEC_CREDITS = 1;
-export const REQUIRED_LEAD_TEC_CREDITS = 2;
-export const TEC_DEADLINES = [
-  new Date('2026-02-22T23:59:59'),
-  new Date('2026-03-19T23:59:59'),
-  new Date('2026-05-04T23:59:59')
-];
 export const ALL_STATUS: Status[] = ['approved', 'pending', 'rejected'];
 export const INITIATIVE_EVENTS = false;
 export const ENABLE_COFFEE_CHAT = true;

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,4 +1,15 @@
-import { formatLink } from './utils';
+import { calculateCredits, formatLink, getPeriods, getTECPeriod } from './utils';
+
+const fakeEvent = (name: string, date: string): TeamEvent => ({
+  name,
+  date,
+  numCredits: '1',
+  hasHours: false,
+  uuid: name,
+  isInitiativeEvent: false,
+  maxCredits: '',
+  requests: []
+});
 
 describe('formatLink', () => {
   test('Formats LinkedIn links correctly', () => {
@@ -45,5 +56,104 @@ describe('formatLink', () => {
     expect(formatLink('Look at my awesome website https://en.wikipedia.org/wiki/Cat!!')).toEqual(
       'https://en.wikipedia.org/wiki/Cat'
     );
+  });
+});
+
+describe('getTECPeriod', () => {
+  const deadlines = [
+    new Date('2026-02-22T23:59:59'),
+    new Date('2026-03-19T23:59:59'),
+    new Date('2026-05-04T23:59:59')
+  ];
+
+  test('returns 0 for a date before the first deadline', () => {
+    expect(getTECPeriod(new Date('2026-02-10T12:00:00'), deadlines)).toBe(0);
+  });
+
+  test('returns the deadline index for a date that lands exactly on a deadline', () => {
+    expect(getTECPeriod(new Date('2026-02-22T23:59:59'), deadlines)).toBe(0);
+    expect(getTECPeriod(new Date('2026-03-19T23:59:59'), deadlines)).toBe(1);
+  });
+
+  test('returns the next deadline index for a date between two deadlines', () => {
+    expect(getTECPeriod(new Date('2026-03-10T12:00:00'), deadlines)).toBe(1);
+    expect(getTECPeriod(new Date('2026-04-15T12:00:00'), deadlines)).toBe(2);
+  });
+
+  test('returns the last index for a date after every deadline', () => {
+    expect(getTECPeriod(new Date('2026-12-31T12:00:00'), deadlines)).toBe(deadlines.length - 1);
+  });
+});
+
+describe('getPeriods', () => {
+  // `getPeriods` computes the first period's start from `new Date()` (Jan 1 or
+  // Aug 1 of the current year). Fix "today" so the test is deterministic
+  // regardless of when CI runs.
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-03-01T12:00:00'));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const deadlines = [
+    new Date('2026-02-22T23:59:59'),
+    new Date('2026-03-19T23:59:59'),
+    new Date('2026-05-04T23:59:59')
+  ];
+
+  test('returns one period per deadline with sequential names', () => {
+    const result = getPeriods([], deadlines);
+    expect(result).toHaveLength(deadlines.length);
+    expect(result.map((p) => p.name)).toEqual(['Period 1', 'Period 2', 'Period 3']);
+  });
+
+  test('buckets each event into the period whose deadline it falls within', () => {
+    const events = [
+      fakeEvent('inP1', '2026-02-10'),
+      fakeEvent('inP2', '2026-03-10'),
+      fakeEvent('inP3', '2026-04-01')
+    ];
+    const [p1, p2, p3] = getPeriods(events, deadlines);
+    expect(p1.events.map((e) => e.name)).toEqual(['inP1']);
+    expect(p2.events.map((e) => e.name)).toEqual(['inP2']);
+    expect(p3.events.map((e) => e.name)).toEqual(['inP3']);
+  });
+
+  test('sorts events within a period from latest to earliest', () => {
+    const events = [fakeEvent('earlier', '2026-04-01'), fakeEvent('later', '2026-04-15')];
+    const [, , p3] = getPeriods(events, deadlines);
+    expect(p3.events.map((e) => e.name)).toEqual(['later', 'earlier']);
+  });
+
+  test('excludes events that fall outside every period', () => {
+    const events = [
+      fakeEvent('beforeFirstStart', '2025-12-15'),
+      fakeEvent('afterLastDeadline', '2026-06-01')
+    ];
+    const periods = getPeriods(events, deadlines);
+    const allEventNames = periods.flatMap((p) => p.events.map((e) => e.name));
+    expect(allEventNames).toEqual([]);
+  });
+});
+
+describe('calculateCredits', () => {
+  test('returns 0 when the requirement is exactly met', () => {
+    expect(calculateCredits(1, 1)).toBe(0);
+    expect(calculateCredits(5, 5)).toBe(0);
+  });
+
+  test('returns 0 when the requirement is exceeded', () => {
+    expect(calculateCredits(3, 1)).toBe(0);
+  });
+
+  test('returns the remaining credits when the requirement is not met', () => {
+    expect(calculateCredits(0, 1)).toBe(1);
+    expect(calculateCredits(2, 5)).toBe(3);
+  });
+
+  test('defaults requiredCredits to 1 when omitted', () => {
+    expect(calculateCredits(0)).toBe(1);
+    expect(calculateCredits(1)).toBe(0);
   });
 });

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,7 +1,5 @@
 /* eslint-disable max-classes-per-file */
 
-import { TEC_DEADLINES } from './consts';
-
 export const getNetIDFromEmail = (email: string): string => email.split('@')[0];
 
 export const getRoleDescriptionFromRoleID = (role: Role): RoleDescription => {
@@ -244,10 +242,10 @@ export const getTimeString = (unixTime: number): string => {
  * @returns The index of the current TEC period in the `TEC_DEADLINES` array.
  *          If the submission date is after all deadlines, returns the last period index.
  */
-export const getTECPeriod = (submissionDate: Date) => {
-  const currentPeriodIndex = TEC_DEADLINES.findIndex((date) => submissionDate <= date);
+export const getTECPeriod = (submissionDate: Date, tecDeadlines: Date[]): number => {
+  const currentPeriodIndex = tecDeadlines.findIndex((date) => submissionDate <= date);
   if (currentPeriodIndex === -1) {
-    return TEC_DEADLINES.length - 1;
+    return tecDeadlines.length - 1;
   }
   return currentPeriodIndex;
 };
@@ -257,13 +255,13 @@ export const getTECPeriod = (submissionDate: Date) => {
  * @param teamEvents The array of team events that are being grouped into said periods within a given semester.
  * @returns An array of Period objects, TEC events grouped within their respective monthly periods, sorted by deadline from latest to earliest.
  */
-export const getPeriods = (teamEvents: TeamEvent[]): Period[] => {
+export const getPeriods = (teamEvents: TeamEvent[], tecDeadlines: Date[]): Period[] => {
   const today = new Date();
   const year = today.getFullYear();
   const firstPeriodStart = today.getMonth() < 7 ? new Date(year, 0, 1) : new Date(year, 7, 1);
 
-  return TEC_DEADLINES.map((deadline, i) => {
-    const periodStart = i === 0 ? firstPeriodStart : TEC_DEADLINES[i - 1];
+  return tecDeadlines.map((deadline, i) => {
+    const periodStart = i === 0 ? firstPeriodStart : tecDeadlines[i - 1];
     const events = teamEvents
       .filter((event) => {
         const eventDate = new Date(event.date);

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -239,7 +239,9 @@ export const getTimeString = (unixTime: number): string => {
 /**
  * Determines the TEC period index for a given submission date.
  * @param submissionDate The date for which the TEC period is being determined.
- * @returns The index of the current TEC period in the `TEC_DEADLINES` array.
+ * @param tecDeadlines The ordered list of TEC period end dates from the
+ *                     `TECConfig` Firestore document (take a look at `TecConfigAPI.getTecConfig`).
+ * @returns The index of the matching TEC period in `tecDeadlines`.
  *          If the submission date is after all deadlines, returns the last period index.
  */
 export const getTECPeriod = (submissionDate: Date, tecDeadlines: Date[]): number => {
@@ -253,6 +255,8 @@ export const getTECPeriod = (submissionDate: Date, tecDeadlines: Date[]): number
 /**
  * Gets the periods for all TECs for a team event by date.
  * @param teamEvents The array of team events that are being grouped into said periods within a given semester.
+ * @param tecDeadlines The ordered list of TEC period end dates from the
+ *                     `TECConfig` Firestore document (take a look at `TecConfigAPI.getTecConfig`).
  * @returns An array of Period objects, TEC events grouped within their respective monthly periods, sorted by deadline from latest to earliest.
  */
 export const getPeriods = (teamEvents: TeamEvent[], tecDeadlines: Date[]): Period[] => {
@@ -275,7 +279,9 @@ export const getPeriods = (teamEvents: TeamEvent[], tecDeadlines: Date[]): Perio
 /**
  * Calculates the number of credits needed for the current period only where each period is independent.
  * @param currentCredits The number of credits approved in the current period.
- * @param requiredCredits The number of credits required for this period (1 for members, 2 for leads).
+ * @param requiredCredits The number of credits required for this period. Should pass
+ *                        `requiredMemberTecCredits` or `requiredLeadTecCredits` from the `TECConfig`
+ *                        Firestore document (see `TecConfigAPI.getTecConfig`) depending on the member's role.
  * @returns The number of additional credits needed to meet the requirement.
  *          Returns 0 if the requirement is already met.
  */


### PR DESCRIPTION
### Summary <!-- Required -->

This PR moves TEC period deadlines and lead/member credit requirements out of hardcoded consts.ts files and into a Firestore document, so they can be edited in directly on IDOL without changing the code. On the frontend, a small panel (available only to admins) was added to edit, delete, and save (update) TEC Periods.

**Backend**
- Added a TECConfig type to common-types/index.d.ts to store array of strings periodEndDates, and integers requiredMemberTecCredits and requiredLeadTecCredits
- Added a tec-config Firestore collection (see Database Schema Change below for what that means for Firebase) to backend/src/firebase.ts. Config is a document with id "current"
- Created backend/src/dao/TecConfigDao.ts to return a clean TecConfig object (includes fallback DEFAULT_TEC_CONFIG if the doc is invalid)
- Added two endpoints in api.ts (backend): GET /tec-config and PUT /tec-config (which calls TecConfigDao.updateTecConfig
- API/mailAPI.ts now has the period reminder fetching the config from the firebase instead of just reading the constants
- Removed constants TEC_DEADLINES, REQUIRED_MEMBER_TEC_CREDITS, and REQUIRED_LEAD_TEC_CREDITS from backend/src/consts.ts, since they are no longer of use.

**Frontend**
- Added the file frontend/src/API/TecConfigAPI.ts with notable functions getTecConfig() and updateTecConfig(config)
- Frontend utils.ts functions getTECPeriod and getPeriod no longer take TEC_DEADLINES as a parameter (no longer a constant) 
- Current components now fetch the config on mount
- Added admin editing capabilities (styling is not great, let me know how to improve, the "Save" button is brutally blue)
- Removed TEC_DEADLINES, REQUIRED_MEMBER_TEC_CREDITS, and REQUIRED_LEAD_TEC_CREDITS from frontend/src/consts.ts, since they are no longer of use.

### Test Plan <!-- Required -->

1. Navigate to Admin
2. Go to Edit Team Events
3. Fiddle around with the calendar & period end dates, change the required Lead & Member TEC Credits
4. Click Save -> Done -> the same editing component should still be visible
5. To check if this updated on Firestore, navigate to cornelldti-idol-dev in Firebase and check collection "tec-config" -> document "current" -> see whether the field values have changed
<img width="1099" height="583" alt="Screenshot 2026-04-23 at 11 07 59 PM" src="https://github.com/user-attachments/assets/d07bd021-8e8a-4ce0-8c8b-8c90f0f8c624" />
<img width="1408" height="702" alt="Screenshot 2026-04-23 at 11 10 15 PM" src="https://github.com/user-attachments/assets/d3afed93-c4f0-457a-ada7-cea110491777" />


### Notes 

Have never worked with yaml files before, so those are AI generated. 
Used some AI for the styling of the TecConfigEditor component, didn't really know how to import the calendar either, I tried to stay moderately consistent with the styling, but let me know specifically what to change!
_Currently missing updated backend tests & updated documentation_

### Database Schema Change 

Currently, in the cornelldti-idol-dev database, I've added a new collection called "tec config" which stores the previously hard-coded array of period end dates. The collection stores one singular document, called "current," with 3 fields: an array of period end dates, and the numbers of required member tec credits per period and lead tec credits per period (1 and 2 respectively). 