### PR TITLE
apis + frontview mock up

### DIFF
--- a/backend/src/API/reimbursementAPI.ts
+++ b/backend/src/API/reimbursementAPI.ts
@@ -1,0 +1,246 @@
+import { v4 as uuidv4 } from 'uuid';
+import ReimbursementRequestDao from '../dao/ReimbursementRequestDao';
+import ReimbursementTeamDao from '../dao/ReimbursementTeamDao';
+import PermissionsManager from '../utils/permissionsManager';
+import { BadRequestError, NotFoundError, PermissionError } from '../utils/errors';
+
+const requestDao = new ReimbursementRequestDao();
+const teamDao = new ReimbursementTeamDao();
+
+//teams
+
+export const getAllReimbursementTeams = async (user: IdolMember): Promise<ReimbursementTeam[]> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to view reimbursement teams.`
+    );
+  }
+  return teamDao.getAllTeams();
+};
+
+export const getReimbursementTeam = async (
+  teamId: string,
+  user: IdolMember
+): Promise<ReimbursementTeam> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to view reimbursement team ${teamId}.`
+    );
+  }
+  const team = await teamDao.getTeam(teamId);
+  if (!team) throw new NotFoundError(`Reimbursement team with ID ${teamId} not found.`);
+  return team;
+};
+
+export const createReimbursementTeam = async (
+  team: ReimbursementTeam,
+  user: IdolMember
+): Promise<ReimbursementTeam> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to create a reimbursement team.`
+    );
+  }
+  if (!team.teamId || !team.teamName) {
+    throw new BadRequestError('teamId and teamName are required.');
+  }
+  const existing = await teamDao.getTeam(team.teamId);
+  if (existing) throw new BadRequestError(`Team with ID ${team.teamId} already exists.`);
+
+  const newTeam: ReimbursementTeam = {
+    ...team,
+    totalSpent: team.totalSpent ?? 0,
+    assignedAdmins: team.assignedAdmins ?? []
+  };
+  return teamDao.createTeam(newTeam);
+};
+
+export const updateReimbursementTeam = async (
+  team: ReimbursementTeam,
+  user: IdolMember
+): Promise<ReimbursementTeam> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to update a reimbursement team.`
+    );
+  }
+  const existing = await teamDao.getTeam(team.teamId);
+  if (!existing) throw new NotFoundError(`Reimbursement team with ID ${team.teamId} not found.`);
+  return teamDao.updateTeam(team);
+};
+
+export const deleteReimbursementTeam = async (teamId: string, user: IdolMember): Promise<void> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to delete a reimbursement team.`
+    );
+  }
+  const existing = await teamDao.getTeam(teamId);
+  if (!existing) throw new NotFoundError(`Reimbursement team with ID ${teamId} not found.`);
+  await teamDao.deleteTeam(teamId);
+};
+
+export const resetReimbursementTeamBudget = async (
+  teamId: string,
+  newBudget: number | undefined,
+  user: IdolMember
+): Promise<ReimbursementTeam> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to reset a team's budget.`
+    );
+  }
+  return teamDao.resetTeamBudget(teamId, newBudget);
+};
+
+//requests
+
+export const getAllReimbursementRequests = async (
+  user: IdolMember
+): Promise<ReimbursementRequest[]> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to view all reimbursement requests.`
+    );
+  }
+  return requestDao.getAllRequests();
+};
+
+export const getMyReimbursementRequests = async (
+  user: IdolMember
+): Promise<ReimbursementRequest[]> => requestDao.getRequestsByRequester(user.email);
+
+export const getReimbursementRequest = async (
+  requestId: string,
+  user: IdolMember
+): Promise<ReimbursementRequest> => {
+  const request = await requestDao.getRequest(requestId);
+  if (!request) throw new NotFoundError(`Reimbursement request with ID ${requestId} not found.`);
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  if (!isLeadOrAdmin && request.requesterId !== user.email) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to view request ${requestId}.`
+    );
+  }
+  return request;
+};
+
+export const createReimbursementRequest = async (
+  request: Partial<ReimbursementRequest>,
+  user: IdolMember
+): Promise<ReimbursementRequest> => {
+  if (!request.teamId) throw new BadRequestError('teamId is required.');
+  if (request.amount == null || request.amount <= 0) {
+    throw new BadRequestError('amount must be a positive number.');
+  }
+  const team = await teamDao.getTeam(request.teamId);
+  if (!team) throw new NotFoundError(`Reimbursement team with ID ${request.teamId} not found.`);
+
+  const now = Date.now();
+  const newRequest: ReimbursementRequest = {
+    requestId: request.requestId ?? uuidv4(),
+    requesterId: user.email,
+    requesterPhoneNumber: request.requesterPhoneNumber ?? '',
+    requesterAddress: request.requesterAddress ?? '',
+    teamId: request.teamId,
+    amount: request.amount,
+    reason: request.reason ?? '',
+    attendees: request.attendees ?? [],
+    dateOfPurchase: request.dateOfPurchase ?? now,
+    dateSubmitted: now,
+    status: 'pending',
+    receiptUrl: request.receiptUrl ?? '',
+    messages: [],
+    statusLog: [{ status: 'pending', changedBy: user.email, changedAt: now, note: 'Submitted' }],
+    isImmutable: false,
+    resolvedAt: null
+  };
+  return requestDao.createRequest(newRequest);
+};
+
+export const updateReimbursementRequest = async (
+  request: ReimbursementRequest,
+  user: IdolMember
+): Promise<ReimbursementRequest> => {
+  const existing = await requestDao.getRequest(request.requestId);
+  if (!existing) {
+    throw new NotFoundError(`Reimbursement request with ID ${request.requestId} not found.`);
+  }
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  if (!isLeadOrAdmin && existing.requesterId !== user.email) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to edit request ${request.requestId}.`
+    );
+  }
+  if (existing.isImmutable) {
+    throw new BadRequestError('Cannot update an immutable reimbursement request.');
+  }
+  const merged: ReimbursementRequest = {
+    ...request,
+    requesterId: existing.requesterId,
+    dateSubmitted: existing.dateSubmitted,
+    status: existing.status,
+    statusLog: existing.statusLog,
+    messages: existing.messages,
+    resolvedAt: existing.resolvedAt
+  };
+  return requestDao.updateRequest(merged);
+};
+
+export const deleteReimbursementRequest = async (
+  requestId: string,
+  user: IdolMember
+): Promise<void> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to delete a reimbursement request.`
+    );
+  }
+  const existing = await requestDao.getRequest(requestId);
+  if (!existing) throw new NotFoundError(`Reimbursement request with ID ${requestId} not found.`);
+  await requestDao.deleteRequest(requestId);
+};
+
+export const updateReimbursementRequestStatus = async (
+  requestId: string,
+  newStatus: ReimbursementRequestStatus,
+  note: string,
+  user: IdolMember
+): Promise<ReimbursementRequest> => {
+  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to change request status.`
+    );
+  }
+  const existing = await requestDao.getRequest(requestId);
+  if (!existing) throw new NotFoundError(`Reimbursement request with ID ${requestId} not found.`);
+
+  const updated = await requestDao.updateStatus(requestId, newStatus, user.email, note);
+
+  if (newStatus === 'settled' && existing.status !== 'settled') {
+    await teamDao.updateTotalSpent(updated.teamId, updated.amount);
+  }
+  return updated;
+};
+
+export const addReimbursementRequestMessage = async (
+  requestId: string,
+  content: string,
+  user: IdolMember
+): Promise<ReimbursementRequest> => {
+  if (!content || !content.trim()) throw new BadRequestError('Message content is required.');
+  const existing = await requestDao.getRequest(requestId);
+  if (!existing) throw new NotFoundError(`Reimbursement request with ID ${requestId} not found.`);
+
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  if (!isLeadOrAdmin && existing.requesterId !== user.email) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to message on request ${requestId}.`
+    );
+  }
+  return requestDao.addMessage(requestId, {
+    authorId: user.email,
+    content,
+    sentAt: Date.now()
+  });
+};

--- a/backend/src/API/reimbursementAPI.ts
+++ b/backend/src/API/reimbursementAPI.ts
@@ -7,7 +7,7 @@ import { BadRequestError, NotFoundError, PermissionError } from '../utils/errors
 const requestDao = new ReimbursementRequestDao();
 const teamDao = new ReimbursementTeamDao();
 
-//teams
+// teams
 
 export const getAllReimbursementTeams = async (user: IdolMember): Promise<ReimbursementTeam[]> => {
   if (!(await PermissionsManager.isLeadOrAdmin(user))) {
@@ -93,7 +93,7 @@ export const resetReimbursementTeamBudget = async (
   return teamDao.resetTeamBudget(teamId, newBudget);
 };
 
-//requests
+// requests
 
 export const getAllReimbursementRequests = async (
   user: IdolMember

--- a/backend/src/API/reimbursementAPI.ts
+++ b/backend/src/API/reimbursementAPI.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import ReimbursementRequestDao from '../dao/ReimbursementRequestDao';
 import ReimbursementTeamDao from '../dao/ReimbursementTeamDao';
 import PermissionsManager from '../utils/permissionsManager';
+import { hasReimbursementRequesterPermissions } from '../utils/reimbursementPermissions';
 import { BadRequestError, NotFoundError, PermissionError } from '../utils/errors';
 
 const requestDao = new ReimbursementRequestDao();
@@ -129,6 +130,11 @@ export const createReimbursementRequest = async (
   request: Partial<ReimbursementRequest>,
   user: IdolMember
 ): Promise<ReimbursementRequest> => {
+  if (!hasReimbursementRequesterPermissions(user.role)) {
+    throw new PermissionError(
+      `User with email ${user.email} does not have permissions to create a reimbursement request.`
+    );
+  }
   if (!request.teamId) throw new BadRequestError('teamId is required.');
   if (request.amount == null || request.amount <= 0) {
     throw new BadRequestError('amount must be a positive number.');
@@ -207,13 +213,17 @@ export const updateReimbursementRequestStatus = async (
   note: string,
   user: IdolMember
 ): Promise<ReimbursementRequest> => {
-  if (!(await PermissionsManager.isLeadOrAdmin(user))) {
+  const existing = await requestDao.getRequest(requestId);
+  if (!existing) throw new NotFoundError(`Reimbursement request with ID ${requestId} not found.`);
+
+  const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
+  const isRequesterSettling =
+    existing.requesterId === user.email && newStatus === 'settled';
+  if (!isLeadOrAdmin && !isRequesterSettling) {
     throw new PermissionError(
       `User with email ${user.email} does not have permissions to change request status.`
     );
   }
-  const existing = await requestDao.getRequest(requestId);
-  if (!existing) throw new NotFoundError(`Reimbursement request with ID ${requestId} not found.`);
 
   const updated = await requestDao.updateStatus(requestId, newStatus, user.email, note);
 

--- a/backend/src/API/reimbursementAPI.ts
+++ b/backend/src/API/reimbursementAPI.ts
@@ -217,8 +217,7 @@ export const updateReimbursementRequestStatus = async (
   if (!existing) throw new NotFoundError(`Reimbursement request with ID ${requestId} not found.`);
 
   const isLeadOrAdmin = await PermissionsManager.isLeadOrAdmin(user);
-  const isRequesterSettling =
-    existing.requesterId === user.email && newStatus === 'settled';
+  const isRequesterSettling = existing.requesterId === user.email && newStatus === 'settled';
   if (!isLeadOrAdmin && !isRequesterSettling) {
     throw new PermissionError(
       `User with email ${user.email} does not have permissions to change request status.`

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -157,8 +157,8 @@ export const enforceSession = true;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd
-  ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
-  : [/http:\/\/localhost:3000/];
+    ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
+    : [/http:\/\/localhost:3000/];
 
 // Middleware
 app.use(

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -126,6 +126,22 @@ import {
   addAlumniToLocation,
   removeAlumniFromLocation
 } from './API/cityCoordinatesAPI';
+import {
+  getAllReimbursementTeams,
+  getReimbursementTeam,
+  createReimbursementTeam,
+  updateReimbursementTeam,
+  deleteReimbursementTeam,
+  resetReimbursementTeamBudget,
+  getAllReimbursementRequests,
+  getMyReimbursementRequests,
+  getReimbursementRequest,
+  createReimbursementRequest,
+  updateReimbursementRequest,
+  deleteReimbursementRequest,
+  updateReimbursementRequestStatus,
+  addReimbursementRequestMessage
+} from './API/reimbursementAPI';
 
 import { HandlerError } from './utils/errors';
 
@@ -141,8 +157,8 @@ export const enforceSession = true;
 const allowedOrigins = allowAllOrigins
   ? [/.*/]
   : isProd
-    ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
-    : [/http:\/\/localhost:3000/];
+  ? [/https:\/\/idol\.cornelldti\.org/, /.*--cornelldti-idol\.netlify\.app/]
+  : [/http:\/\/localhost:3000/];
 
 // Middleware
 app.use(
@@ -705,6 +721,71 @@ loginCheckedDelete(
     )
   })
 );
+
+// Reimbursement Teams
+loginCheckedGet('/reimbursement-team', async (_, user) => ({
+  teams: await getAllReimbursementTeams(user)
+}));
+
+loginCheckedGet('/reimbursement-team/:teamId', async (req, user) => ({
+  team: await getReimbursementTeam(req.params.teamId, user)
+}));
+
+loginCheckedPost('/reimbursement-team', async (req, user) => ({
+  team: await createReimbursementTeam(req.body, user)
+}));
+
+loginCheckedPut('/reimbursement-team', async (req, user) => ({
+  team: await updateReimbursementTeam(req.body, user)
+}));
+
+loginCheckedDelete('/reimbursement-team/:teamId', async (req, user) => {
+  await deleteReimbursementTeam(req.params.teamId, user);
+  return {};
+});
+
+loginCheckedPatch('/reimbursement-team/:teamId/reset-budget', async (req, user) => ({
+  team: await resetReimbursementTeamBudget(req.params.teamId, req.body.newBudget, user)
+}));
+
+// Reimbursement Requests
+loginCheckedGet('/reimbursement-request', async (_, user) => ({
+  requests: await getAllReimbursementRequests(user)
+}));
+
+loginCheckedGet('/reimbursement-request/me', async (_, user) => ({
+  requests: await getMyReimbursementRequests(user)
+}));
+
+loginCheckedGet('/reimbursement-request/:requestId', async (req, user) => ({
+  request: await getReimbursementRequest(req.params.requestId, user)
+}));
+
+loginCheckedPost('/reimbursement-request', async (req, user) => ({
+  request: await createReimbursementRequest(req.body, user)
+}));
+
+loginCheckedPut('/reimbursement-request', async (req, user) => ({
+  request: await updateReimbursementRequest(req.body, user)
+}));
+
+loginCheckedDelete('/reimbursement-request/:requestId', async (req, user) => {
+  await deleteReimbursementRequest(req.params.requestId, user);
+  return {};
+});
+
+loginCheckedPatch('/reimbursement-request/:requestId/status', async (req, user) => ({
+  request: await updateReimbursementRequestStatus(
+    req.params.requestId,
+    req.body.status,
+    req.body.note ?? '',
+    user
+  )
+}));
+
+loginCheckedPost('/reimbursement-request/:requestId/message', async (req, user) => ({
+  request: await addReimbursementRequestMessage(req.params.requestId, req.body.content, user)
+}));
 
 app.use('/.netlify/functions/api', router);
 

--- a/backend/src/utils/reimbursementPermissions.ts
+++ b/backend/src/utils/reimbursementPermissions.ts
@@ -21,15 +21,17 @@ export function hasReimbursementAdminPermissions(role: Role): boolean {
  * @returns true if the user has requester permissions
  */
 export function hasReimbursementRequesterPermissions(role: Role): boolean {
-  const leadRoles: Role[] = [
+  const requesterRoles: Role[] = [
     'ops-lead',
     'product-lead',
     'dev-lead',
     'design-lead',
-    'business-lead'
+    'business-lead',
+    'tpm',
+    'pm'
   ];
 
-  return leadRoles.includes(role);
+  return requesterRoles.includes(role);
 }
 
 /**

--- a/frontend/src/components/Forms/ReimbursementDashboard/BudgetOverview.tsx
+++ b/frontend/src/components/Forms/ReimbursementDashboard/BudgetOverview.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styles from './ReimbursementDashboard.module.css';
+
+type Props = {
+  team: ReimbursementTeam;
+};
+
+const formatDollars = (amount: number): string => `$${amount.toLocaleString()}`;
+
+const BudgetOverview: React.FC<Props> = ({ team }) => {
+  const remaining = Math.max(team.budget - team.totalSpent, 0);
+  const pct = team.budget > 0 ? Math.min((team.totalSpent / team.budget) * 100, 100) : 0;
+
+  return (
+    <section className={styles.card}>
+      <h3 className={styles.cardTitle}>Budget Overview</h3>
+      <div className={styles.budgetRow}>
+        <div>
+          <div className={styles.budgetSpent}>{formatDollars(team.totalSpent)}</div>
+          <div className={styles.budgetSpentLabel}>out of {formatDollars(team.budget)} total</div>
+        </div>
+        <div className={styles.budgetRemainingWrap}>
+          <div className={styles.budgetRemaining}>{formatDollars(remaining)}</div>
+          <div className={styles.budgetRemainingLabel}>remaining</div>
+        </div>
+      </div>
+      <div className={styles.progressTrack}>
+        <div className={styles.progressFill} style={{ width: `${pct}%` }} />
+      </div>
+      <div className={styles.progressLabels}>
+        <span>$0</span>
+        <span>{formatDollars(team.budget)}</span>
+      </div>
+    </section>
+  );
+};
+
+export default BudgetOverview;

--- a/frontend/src/components/Forms/ReimbursementDashboard/ReimbursementDashboard.module.css
+++ b/frontend/src/components/Forms/ReimbursementDashboard/ReimbursementDashboard.module.css
@@ -1,0 +1,194 @@
+.page {
+  width: 90%;
+  max-width: 1400px;
+  margin: 2rem auto 4rem;
+  padding: 0 1rem;
+}
+
+.pageHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.pageTitle {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.submitButton {
+  background-color: #1a1a1a !important;
+  color: #fff !important;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media only screen and (max-width: 900px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+}
+
+.cardTitle {
+  font-size: 1.125rem;
+  font-weight: 700;
+  margin: 0 0 1rem 0;
+}
+
+.budgetRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 0.75rem;
+}
+
+.budgetSpent {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.budgetSpentLabel {
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.budgetRemainingWrap {
+  text-align: right;
+}
+
+.budgetRemaining {
+  color: #16a34a;
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.budgetRemainingLabel {
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.progressTrack {
+  width: 100%;
+  height: 6px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+  margin-top: 0.75rem;
+}
+
+.progressFill {
+  height: 100%;
+  background: #111827;
+  border-radius: 999px;
+}
+
+.progressLabels {
+  display: flex;
+  justify-content: space-between;
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.tableHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead th {
+  background: #f3f4f6;
+  color: #6b7280;
+  font-weight: 500;
+  font-size: 0.875rem;
+  text-align: left;
+  padding: 0.75rem 1rem;
+}
+
+.table tbody td {
+  padding: 1rem;
+  border-top: 1px solid #f3f4f6;
+  font-size: 0.9375rem;
+  color: #374151;
+}
+
+.amountCell {
+  font-weight: 600;
+  color: #111827;
+}
+
+.actionCol {
+  text-align: right;
+}
+
+.viewLink {
+  background: none;
+  border: none;
+  font-weight: 600;
+  color: #111827;
+  cursor: pointer;
+  padding: 0;
+}
+
+.viewLink:hover {
+  text-decoration: underline;
+}
+
+.statusPill {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.status_approved {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.status_pending {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status_needs_changes {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status_in_progress_with_cornell {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.status_settled {
+  background: #e5e7eb;
+  color: #374151;
+}

--- a/frontend/src/components/Forms/ReimbursementDashboard/ReimbursementDashboard.module.css
+++ b/frontend/src/components/Forms/ReimbursementDashboard/ReimbursementDashboard.module.css
@@ -75,7 +75,7 @@
 }
 
 .budgetRemaining {
-  color: #16a34a;
+  color: #15803d;
   font-size: 1.75rem;
   font-weight: 700;
   line-height: 1;

--- a/frontend/src/components/Forms/ReimbursementDashboard/ReimbursementDashboard.tsx
+++ b/frontend/src/components/Forms/ReimbursementDashboard/ReimbursementDashboard.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { Button } from 'semantic-ui-react';
+import BudgetOverview from './BudgetOverview';
+import RequestsTable from './RequestsTable';
+import SubmitRequestModal from './SubmitRequestModal';
+import { mockReimbursementRequests, mockReimbursementTeam } from './mockData';
+import styles from './ReimbursementDashboard.module.css';
+
+const ReimbursementDashboard: React.FC = () => {
+  const team = mockReimbursementTeam;
+  const requests = mockReimbursementRequests;
+  const [submitOpen, setSubmitOpen] = useState(false);
+
+  const handleView = (_requestId: string) => {
+    // Detail view comes later.
+  };
+
+  const handleViewAll = () => {
+    // "View all" page comes later.
+  };
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.pageHeader}>
+        <h1 className={styles.pageTitle}>Requestor Dashboard</h1>
+        <Button primary className={styles.submitButton} onClick={() => setSubmitOpen(true)}>
+          Submit new request
+        </Button>
+      </header>
+
+      <div className={styles.grid}>
+        <BudgetOverview team={team} />
+        <RequestsTable requests={requests} onView={handleView} onViewAll={handleViewAll} />
+      </div>
+
+      <SubmitRequestModal open={submitOpen} onClose={() => setSubmitOpen(false)} />
+    </div>
+  );
+};
+
+export default ReimbursementDashboard;

--- a/frontend/src/components/Forms/ReimbursementDashboard/RequestsTable.tsx
+++ b/frontend/src/components/Forms/ReimbursementDashboard/RequestsTable.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Button } from 'semantic-ui-react';
+import styles from './ReimbursementDashboard.module.css';
+
+type Props = {
+  requests: ReimbursementRequest[];
+  onView: (requestId: string) => void;
+  onViewAll: () => void;
+};
+
+const formatDate = (timestamp: number): string => {
+  const d = new Date(timestamp);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+const STATUS_LABEL: Record<ReimbursementRequestStatus, string> = {
+  pending: 'Pending',
+  needs_changes: 'Needs Change',
+  approved: 'Submitted',
+  in_progress_with_cornell: 'In Progress',
+  settled: 'Settled'
+};
+
+const StatusPill: React.FC<{ status: ReimbursementRequestStatus }> = ({ status }) => (
+  <span className={`${styles.statusPill} ${styles[`status_${status}`]}`}>
+    {STATUS_LABEL[status]}
+  </span>
+);
+
+const RequestsTable: React.FC<Props> = ({ requests, onView, onViewAll }) => (
+  <section className={styles.card}>
+    <div className={styles.tableHeader}>
+      <h3 className={styles.cardTitle}>My Requests</h3>
+      <Button basic onClick={onViewAll}>
+        View all
+      </Button>
+    </div>
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Date Submitted</th>
+          <th>Date of Purchase</th>
+          <th>Amount</th>
+          <th>Status</th>
+          <th className={styles.actionCol}>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        {requests.map((r) => (
+          <tr key={r.requestId}>
+            <td>{formatDate(r.dateSubmitted)}</td>
+            <td>{formatDate(r.dateOfPurchase)}</td>
+            <td className={styles.amountCell}>${r.amount}</td>
+            <td>
+              <StatusPill status={r.status} />
+            </td>
+            <td className={styles.actionCol}>
+              <button type="button" className={styles.viewLink} onClick={() => onView(r.requestId)}>
+                View
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </section>
+);
+
+export default RequestsTable;

--- a/frontend/src/components/Forms/ReimbursementDashboard/SubmitRequestModal.module.css
+++ b/frontend/src/components/Forms/ReimbursementDashboard/SubmitRequestModal.module.css
@@ -1,0 +1,314 @@
+.modal {
+  border-radius: 0.75rem !important;
+  overflow: hidden;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 500px;
+}
+
+@media only screen and (max-width: 768px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sidebar {
+  background: #f9fafb;
+  padding: 2rem 1.5rem;
+  border-right: 1px solid #e5e7eb;
+}
+
+.sidebarTitle {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 2rem 0;
+}
+
+.stepsNav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stepItem {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  color: #374151;
+  font-size: 0.9375rem;
+  cursor: default;
+}
+
+.stepActive {
+  background: #dbeafe;
+  color: #1e40af;
+  font-weight: 600;
+}
+
+.content {
+  position: relative;
+  padding: 2rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.closeButton {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+  color: #6b7280;
+  padding: 0.5rem;
+}
+
+.closeButton:hover {
+  color: #111827;
+}
+
+.stepBody {
+  flex: 1;
+}
+
+.stepTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 1.5rem 0;
+}
+
+.formGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.fieldFull {
+  grid-column: 1 / -1;
+}
+
+.label {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  font-size: 0.9375rem;
+  font-family: inherit;
+}
+
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.textarea {
+  min-height: 100px;
+  background: #f9fafb;
+  resize: vertical;
+}
+
+.assignLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.vendorRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.vendorChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: #374151;
+}
+
+.vendorChipActive {
+  background: #e5e7eb;
+  border-color: #9ca3af;
+  color: #111827;
+}
+
+.addVendorButton {
+  padding: 0.375rem 0.75rem;
+  background: transparent;
+  border: 1px dashed #9ca3af;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+  cursor: pointer;
+}
+
+.newVendorInputWrap {
+  display: inline-flex;
+}
+
+.newVendorInput {
+  padding: 0.375rem 0.625rem;
+  border: 1px solid #3b82f6;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  outline: none;
+}
+
+.dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  border: 2px dashed #d1d5db;
+  border-radius: 0.5rem;
+  background: #f9fafb;
+  color: #6b7280;
+  cursor: pointer;
+  font-size: 0.9375rem;
+}
+
+.dropzone:hover {
+  border-color: #9ca3af;
+  background: #f3f4f6;
+}
+
+.fileInput {
+  display: none;
+}
+
+.dropzoneHint {
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  color: #9ca3af;
+}
+
+.uploadedList {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.uploadedVendorLabel {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+.fileRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  background: #fff;
+}
+
+.fileName {
+  flex: 1;
+  font-size: 0.875rem;
+  color: #374151;
+}
+
+.trashButton {
+  background: none;
+  border: none;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.trashButton:hover {
+  color: #dc2626;
+}
+
+.reviewSection {
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  background: #f9fafb;
+}
+
+.reviewSectionTitle {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #6b7280;
+  letter-spacing: 0.025em;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.reviewRow {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.375rem 0;
+  font-size: 0.9375rem;
+  color: #111827;
+}
+
+.reviewKey {
+  color: #6b7280;
+}
+
+.reviewEmpty {
+  font-size: 0.875rem;
+  color: #9ca3af;
+  font-style: italic;
+}
+
+.demoNote {
+  font-size: 0.8125rem;
+  color: #92400e;
+  background: #fef3c7;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.375rem;
+  margin-top: 1rem;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #f3f4f6;
+}
+
+.footerSpacer {
+  flex: 1;
+}

--- a/frontend/src/components/Forms/ReimbursementDashboard/SubmitRequestModal.tsx
+++ b/frontend/src/components/Forms/ReimbursementDashboard/SubmitRequestModal.tsx
@@ -1,0 +1,342 @@
+import React, { useState } from 'react';
+import { Modal, Button, Icon } from 'semantic-ui-react';
+import styles from './SubmitRequestModal.module.css';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+type Step = 'basic' | 'receipt' | 'review';
+
+const STEPS: { key: Step; label: string; icon: 'user circle' | 'upload' | 'paper plane' }[] = [
+  { key: 'basic', label: 'Basic information', icon: 'user circle' },
+  { key: 'receipt', label: 'Receipt upload', icon: 'upload' },
+  { key: 'review', label: 'Review and submit', icon: 'paper plane' }
+];
+
+const SubmitRequestModal: React.FC<Props> = ({ open, onClose }) => {
+  const [step, setStep] = useState<Step>('basic');
+
+  // Basic info fields (visualization only — never submitted anywhere).
+  const [name, setName] = useState('');
+  const [netID, setNetID] = useState('');
+  const [phone, setPhone] = useState('');
+  const [address, setAddress] = useState('');
+  const [attendees, setAttendees] = useState('');
+
+  // Receipt upload (visualization only — files exist in local state, never uploaded).
+  const [vendors, setVendors] = useState<string[]>(['Uncategorized']);
+  const [activeVendor, setActiveVendor] = useState<string>('Uncategorized');
+  const [newVendorInput, setNewVendorInput] = useState('');
+  const [showNewVendorField, setShowNewVendorField] = useState(false);
+  const [receipts, setReceipts] = useState<{ vendor: string; fileName: string }[]>([]);
+
+  const reset = () => {
+    setStep('basic');
+    setName('');
+    setNetID('');
+    setPhone('');
+    setAddress('');
+    setAttendees('');
+    setVendors(['Uncategorized']);
+    setActiveVendor('Uncategorized');
+    setNewVendorInput('');
+    setShowNewVendorField(false);
+    setReceipts([]);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const goNext = () => {
+    if (step === 'basic') setStep('receipt');
+    else if (step === 'receipt') setStep('review');
+  };
+
+  const goBack = () => {
+    if (step === 'review') setStep('receipt');
+    else if (step === 'receipt') setStep('basic');
+  };
+
+  const addVendor = () => {
+    const trimmed = newVendorInput.trim();
+    if (trimmed && !vendors.includes(trimmed)) {
+      setVendors([...vendors, trimmed]);
+      setActiveVendor(trimmed);
+    }
+    setNewVendorInput('');
+    setShowNewVendorField(false);
+  };
+
+  const removeVendor = (vendor: string) => {
+    if (vendor === 'Uncategorized') return;
+    setVendors(vendors.filter((v) => v !== vendor));
+    setReceipts(receipts.filter((r) => r.vendor !== vendor));
+    if (activeVendor === vendor) setActiveVendor('Uncategorized');
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setReceipts([...receipts, { vendor: activeVendor, fileName: file.name }]);
+    e.target.value = '';
+  };
+
+  const removeReceipt = (index: number) => {
+    setReceipts(receipts.filter((_, i) => i !== index));
+  };
+
+  const receiptsByVendor = vendors
+    .map((v) => ({
+      vendor: v,
+      files: receipts.filter((r) => r.vendor === v)
+    }))
+    .filter((g) => g.files.length > 0);
+
+  return (
+    <Modal open={open} onClose={handleClose} size="large" className={styles.modal}>
+      <div className={styles.layout}>
+        <aside className={styles.sidebar}>
+          <h2 className={styles.sidebarTitle}>Submit new request</h2>
+          <nav className={styles.stepsNav}>
+            {STEPS.map((s) => (
+              <div
+                key={s.key}
+                className={`${styles.stepItem} ${step === s.key ? styles.stepActive : ''}`}
+              >
+                <Icon name={s.icon} />
+                <span>{s.label}</span>
+              </div>
+            ))}
+          </nav>
+        </aside>
+
+        <div className={styles.content}>
+          <button type="button" className={styles.closeButton} onClick={handleClose}>
+            <Icon name="close" />
+          </button>
+
+          {step === 'basic' && (
+            <div className={styles.stepBody}>
+              <h3 className={styles.stepTitle}>Basic information</h3>
+              <div className={styles.formGrid}>
+                <label className={styles.field}>
+                  <span className={styles.label}>Name</span>
+                  <input
+                    className={styles.input}
+                    placeholder="John Doe"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                  />
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.label}>NetID</span>
+                  <input
+                    className={styles.input}
+                    placeholder="jd227"
+                    value={netID}
+                    onChange={(e) => setNetID(e.target.value)}
+                  />
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.label}>Phone Number</span>
+                  <input
+                    className={styles.input}
+                    placeholder="1234567891"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                  />
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.label}>Address</span>
+                  <input
+                    className={styles.input}
+                    placeholder="1234 Doe Ave"
+                    value={address}
+                    onChange={(e) => setAddress(e.target.value)}
+                  />
+                </label>
+              </div>
+              <label className={`${styles.field} ${styles.fieldFull}`}>
+                <span className={styles.label}>
+                  If this reimbursement is for a social, who were the attendees?
+                </span>
+                <textarea
+                  className={styles.textarea}
+                  placeholder="List them out here..."
+                  value={attendees}
+                  onChange={(e) => setAttendees(e.target.value)}
+                />
+              </label>
+            </div>
+          )}
+
+          {step === 'receipt' && (
+            <div className={styles.stepBody}>
+              <h3 className={styles.stepTitle}>Receipt upload</h3>
+              <div className={styles.assignLabel}>ASSIGN TO VENDOR</div>
+              <div className={styles.vendorRow}>
+                {vendors.map((v) => (
+                  <button
+                    key={v}
+                    type="button"
+                    className={`${styles.vendorChip} ${
+                      activeVendor === v ? styles.vendorChipActive : ''
+                    }`}
+                    onClick={() => setActiveVendor(v)}
+                  >
+                    <span>{v}</span>
+                    {v !== 'Uncategorized' && (
+                      <Icon
+                        name="close"
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation();
+                          removeVendor(v);
+                        }}
+                      />
+                    )}
+                  </button>
+                ))}
+                {showNewVendorField ? (
+                  <div className={styles.newVendorInputWrap}>
+                    <input
+                      className={styles.newVendorInput}
+                      autoFocus
+                      placeholder="Vendor name"
+                      value={newVendorInput}
+                      onChange={(e) => setNewVendorInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') addVendor();
+                        if (e.key === 'Escape') {
+                          setShowNewVendorField(false);
+                          setNewVendorInput('');
+                        }
+                      }}
+                      onBlur={addVendor}
+                    />
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className={styles.addVendorButton}
+                    onClick={() => setShowNewVendorField(true)}
+                  >
+                    + New vendor
+                  </button>
+                )}
+              </div>
+
+              <label className={styles.dropzone}>
+                <Icon name="upload" />
+                <span>Upload receipt(s)</span>
+                <input
+                  type="file"
+                  accept="application/pdf"
+                  className={styles.fileInput}
+                  onChange={handleFileSelect}
+                />
+              </label>
+              <div className={styles.dropzoneHint}>Files must be in pdf format.</div>
+
+              {receiptsByVendor.length > 0 && (
+                <div className={styles.uploadedList}>
+                  {receiptsByVendor.map((g) => (
+                    <div key={g.vendor} className={styles.uploadedGroup}>
+                      <div className={styles.uploadedVendorLabel}>{g.vendor}</div>
+                      {g.files.map((file) => {
+                        const idx = receipts.findIndex(
+                          (r) => r.vendor === file.vendor && r.fileName === file.fileName
+                        );
+                        return (
+                          <div key={`${file.vendor}-${file.fileName}`} className={styles.fileRow}>
+                            <Icon name="file outline" />
+                            <span className={styles.fileName}>{file.fileName}</span>
+                            <button
+                              type="button"
+                              className={styles.trashButton}
+                              onClick={() => removeReceipt(idx)}
+                            >
+                              <Icon name="trash" />
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {step === 'review' && (
+            <div className={styles.stepBody}>
+              <h3 className={styles.stepTitle}>Review and submit</h3>
+              <div className={styles.reviewSection}>
+                <div className={styles.reviewSectionTitle}>Basic information</div>
+                <div className={styles.reviewRow}>
+                  <span className={styles.reviewKey}>Name</span>
+                  <span>{name || '—'}</span>
+                </div>
+                <div className={styles.reviewRow}>
+                  <span className={styles.reviewKey}>NetID</span>
+                  <span>{netID || '—'}</span>
+                </div>
+                <div className={styles.reviewRow}>
+                  <span className={styles.reviewKey}>Phone</span>
+                  <span>{phone || '—'}</span>
+                </div>
+                <div className={styles.reviewRow}>
+                  <span className={styles.reviewKey}>Address</span>
+                  <span>{address || '—'}</span>
+                </div>
+                <div className={styles.reviewRow}>
+                  <span className={styles.reviewKey}>Attendees</span>
+                  <span>{attendees || '—'}</span>
+                </div>
+              </div>
+              <div className={styles.reviewSection}>
+                <div className={styles.reviewSectionTitle}>Receipts</div>
+                {receipts.length === 0 ? (
+                  <div className={styles.reviewEmpty}>No receipts uploaded.</div>
+                ) : (
+                  receipts.map((r, i) => (
+                    <div key={`${r.vendor}-${r.fileName}-${i}`} className={styles.reviewRow}>
+                      <span className={styles.reviewKey}>{r.vendor}</span>
+                      <span>{r.fileName}</span>
+                    </div>
+                  ))
+                )}
+              </div>
+              <div className={styles.demoNote}>
+                This is a visualization only — submitting will not save anything.
+              </div>
+            </div>
+          )}
+
+          <div className={styles.footer}>
+            {step !== 'basic' && (
+              <Button basic onClick={goBack}>
+                Back
+              </Button>
+            )}
+            <div className={styles.footerSpacer} />
+            {step !== 'review' ? (
+              <Button primary onClick={goNext}>
+                Next
+              </Button>
+            ) : (
+              <Button primary onClick={handleClose}>
+                Submit
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default SubmitRequestModal;

--- a/frontend/src/components/Forms/ReimbursementDashboard/SubmitRequestModal.tsx
+++ b/frontend/src/components/Forms/ReimbursementDashboard/SubmitRequestModal.tsx
@@ -30,7 +30,7 @@ const SubmitRequestModal: React.FC<Props> = ({ open, onClose }) => {
   const [activeVendor, setActiveVendor] = useState<string>('Uncategorized');
   const [newVendorInput, setNewVendorInput] = useState('');
   const [showNewVendorField, setShowNewVendorField] = useState(false);
-  const [receipts, setReceipts] = useState<{ vendor: string; fileName: string }[]>([]);
+  const [receipts, setReceipts] = useState<{ id: string; vendor: string; fileName: string }[]>([]);
 
   const reset = () => {
     setStep('basic');
@@ -81,12 +81,16 @@ const SubmitRequestModal: React.FC<Props> = ({ open, onClose }) => {
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setReceipts([...receipts, { vendor: activeVendor, fileName: file.name }]);
+    const id =
+      typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random()}`;
+    setReceipts([...receipts, { id, vendor: activeVendor, fileName: file.name }]);
     e.target.value = '';
   };
 
-  const removeReceipt = (index: number) => {
-    setReceipts(receipts.filter((_, i) => i !== index));
+  const removeReceipt = (id: string) => {
+    setReceipts(receipts.filter((r) => r.id !== id));
   };
 
   const receiptsByVendor = vendors
@@ -246,24 +250,19 @@ const SubmitRequestModal: React.FC<Props> = ({ open, onClose }) => {
                   {receiptsByVendor.map((g) => (
                     <div key={g.vendor} className={styles.uploadedGroup}>
                       <div className={styles.uploadedVendorLabel}>{g.vendor}</div>
-                      {g.files.map((file) => {
-                        const idx = receipts.findIndex(
-                          (r) => r.vendor === file.vendor && r.fileName === file.fileName
-                        );
-                        return (
-                          <div key={`${file.vendor}-${file.fileName}`} className={styles.fileRow}>
-                            <Icon name="file outline" />
-                            <span className={styles.fileName}>{file.fileName}</span>
-                            <button
-                              type="button"
-                              className={styles.trashButton}
-                              onClick={() => removeReceipt(idx)}
-                            >
-                              <Icon name="trash" />
-                            </button>
-                          </div>
-                        );
-                      })}
+                      {g.files.map((file) => (
+                        <div key={file.id} className={styles.fileRow}>
+                          <Icon name="file outline" />
+                          <span className={styles.fileName}>{file.fileName}</span>
+                          <button
+                            type="button"
+                            className={styles.trashButton}
+                            onClick={() => removeReceipt(file.id)}
+                          >
+                            <Icon name="trash" />
+                          </button>
+                        </div>
+                      ))}
                     </div>
                   ))}
                 </div>
@@ -302,8 +301,8 @@ const SubmitRequestModal: React.FC<Props> = ({ open, onClose }) => {
                 {receipts.length === 0 ? (
                   <div className={styles.reviewEmpty}>No receipts uploaded.</div>
                 ) : (
-                  receipts.map((r, i) => (
-                    <div key={`${r.vendor}-${r.fileName}-${i}`} className={styles.reviewRow}>
+                  receipts.map((r) => (
+                    <div key={r.id} className={styles.reviewRow}>
                       <span className={styles.reviewKey}>{r.vendor}</span>
                       <span>{r.fileName}</span>
                     </div>

--- a/frontend/src/components/Forms/ReimbursementDashboard/mockData.ts
+++ b/frontend/src/components/Forms/ReimbursementDashboard/mockData.ts
@@ -1,0 +1,102 @@
+// Mock data used until the reimbursement APIs are wired up to the real Firestore.
+// Types come from common-types/index.d.ts (ambient), so changes to those types
+// will surface as compile errors here.
+
+export const MOCK_USER_EMAIL = 'jdoe@cornell.edu';
+
+export const mockReimbursementTeam: ReimbursementTeam = {
+  teamId: 'design',
+  teamName: 'Design',
+  budget: 500,
+  totalSpent: 100,
+  assignedAdmins: ['lead@cornell.edu']
+};
+
+const dateOfPurchase = new Date('2026-02-25').getTime();
+const dateSubmitted = new Date('2026-02-27').getTime();
+
+export const mockReimbursementRequests: ReimbursementRequest[] = [
+  {
+    requestId: 'req-001',
+    requesterId: MOCK_USER_EMAIL,
+    requesterPhoneNumber: '1234567891',
+    requesterAddress: '1234 Doe Ave',
+    teamId: 'design',
+    amount: 50,
+    reason: 'Team social snacks',
+    attendees: ['Alice', 'Bob', 'Charlie'],
+    dateOfPurchase,
+    dateSubmitted,
+    status: 'approved',
+    receiptUrl: '',
+    messages: [],
+    statusLog: [
+      {
+        status: 'pending',
+        changedBy: MOCK_USER_EMAIL,
+        changedAt: dateSubmitted,
+        note: 'Submitted'
+      },
+      { status: 'approved', changedBy: 'lead@cornell.edu', changedAt: dateSubmitted, note: '' }
+    ],
+    isImmutable: false,
+    resolvedAt: null
+  },
+  {
+    requestId: 'req-002',
+    requesterId: MOCK_USER_EMAIL,
+    requesterPhoneNumber: '1234567891',
+    requesterAddress: '1234 Doe Ave',
+    teamId: 'design',
+    amount: 50,
+    reason: 'Figma plugin license',
+    attendees: [],
+    dateOfPurchase,
+    dateSubmitted,
+    status: 'pending',
+    receiptUrl: '',
+    messages: [],
+    statusLog: [
+      { status: 'pending', changedBy: MOCK_USER_EMAIL, changedAt: dateSubmitted, note: 'Submitted' }
+    ],
+    isImmutable: false,
+    resolvedAt: null
+  },
+  {
+    requestId: 'req-003',
+    requesterId: MOCK_USER_EMAIL,
+    requesterPhoneNumber: '1234567891',
+    requesterAddress: '1234 Doe Ave',
+    teamId: 'design',
+    amount: 120,
+    reason: 'Workshop supplies',
+    attendees: [],
+    dateOfPurchase,
+    dateSubmitted,
+    status: 'needs_changes',
+    receiptUrl: '',
+    messages: [
+      {
+        authorId: 'lead@cornell.edu',
+        content: 'Please attach an itemized receipt.',
+        sentAt: dateSubmitted
+      }
+    ],
+    statusLog: [
+      {
+        status: 'pending',
+        changedBy: MOCK_USER_EMAIL,
+        changedAt: dateSubmitted,
+        note: 'Submitted'
+      },
+      {
+        status: 'needs_changes',
+        changedBy: 'lead@cornell.edu',
+        changedAt: dateSubmitted,
+        note: 'Itemized receipt missing'
+      }
+    ],
+    isImmutable: false,
+    resolvedAt: null
+  }
+];

--- a/frontend/src/pages/forms/index.tsx
+++ b/frontend/src/pages/forms/index.tsx
@@ -38,6 +38,11 @@ const navCardItems: readonly NavigationCardItem[] = [
     description: 'Submit your coffee chats.',
     link: '/forms/coffeeChats',
     adminOnly: !ENABLE_COFFEE_CHAT
+  },
+  {
+    header: 'Reimbursement',
+    description: 'View your team budget and submit reimbursement requests.',
+    link: '/forms/reimbursement'
   }
 ];
 

--- a/frontend/src/pages/forms/reimbursement.tsx
+++ b/frontend/src/pages/forms/reimbursement.tsx
@@ -1,0 +1,3 @@
+import ReimbursementDashboard from '../../components/Forms/ReimbursementDashboard/ReimbursementDashboard';
+
+export default ReimbursementDashboard;


### PR DESCRIPTION
### Summary <!-- Required -->
This pull request adds the backend reimbursement APIs and the requestor side dashboard UI (with a visualization only submit modal). 

**Backend**                                                                                                                     
  - Added `reimbursementAPI.ts` wrapping the existing `ReimbursementRequestDao` and `ReimbursementTeamDao` with permission checks via `PermissionsManager.isLeadOrAdmin`                                                                                   
  - Wired routes in `api.ts`                                                                                                                                                                                                          
  - `updateStatus` rolls request `amount` into the team's `totalSpent` on transition to `settled`

**Frontend**                                                                                                                  
  - Added Requestor Dashboard at `/forms/reimbursement` with Budget Overview card and My Requests table                       
  - Added "Reimbursement" entry to the forms navigation index                                                                 
  - Added Submit Request modal (UI-only, does not submit anything)
                                                                                                                                  
  **Mock data**                                                                                                                   
  - Added `mockData.ts` with a typed `ReimbursementTeam` ($100 spent / $500 total) and three `ReimbursementRequest`s matching the Figma mockup.


### Notion/Figma Link <!-- Optional -->

[<!-- If the changes have associated Notion pages/Figma design(s), please include the links here.-->]
https://www.figma.com/design/ApnK2bbEIQqpRAyBAv7LDR/IDOL-Ashley-Working-File?node-id=932-2390&t=mWbXlvMiYFo8hK6T-0


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Testing was made via looking at the tab on IDOL, and making sure matches figma design.

<img width="1122" height="493" alt="image" src="https://github.com/user-attachments/assets/a017a509-3442-4375-9ed4-cf6fca16f54d" />
<img width="955" height="398" alt="image" src="https://github.com/user-attachments/assets/aa27cfaa-ffd4-404e-b552-4b844d618646" />
<img width="1083" height="533" alt="image" src="https://github.com/user-attachments/assets/80ee6768-9c88-4403-81ec-bea813745fd4" />


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

The submit modal is intentionally visualization-only for this PR, no upload to storage or API call. Firestore is currently empty for reimbursement collections. The backend endpoints work but will return empty lists until data exists.    

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->

- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)
